### PR TITLE
Put batch arguments into Direct I/O input splits.

### DIFF
--- a/bridge-project/runtime-hadoop/src/main/java/com/asakusafw/bridge/hadoop/directio/DirectFileInputFormat.java
+++ b/bridge-project/runtime-hadoop/src/main/java/com/asakusafw/bridge/hadoop/directio/DirectFileInputFormat.java
@@ -92,14 +92,18 @@ public class DirectFileInputFormat extends InputFormat<NullWritable, Object> {
 
     @Override
     public List<InputSplit> getSplits(JobContext context) throws IOException, InterruptedException {
+        Configuration conf = Compatibility.getConfiguration(context);
+        StageInfo stage = getStageInfo(conf);
         DirectFileInputInfo<?> info = extractInfo(context);
         DirectDataSourceRepository repository = getDataSourceRepository(context);
         String containerPath = repository.getContainerPath(info.basePath);
         List<DirectInputFragment> fragments = findFragments(info, repository);
         List<InputSplit> results = new ArrayList<>();
         for (DirectInputFragment fragment : fragments) {
-            DirectFileInputSplit split = new DirectFileInputSplit(containerPath, info.definition, fragment);
-            ReflectionUtils.setConf(split, Compatibility.getConfiguration(context));
+            DirectFileInputSplit split = new DirectFileInputSplit(
+                    containerPath, info.definition, fragment,
+                    stage.getBatchArguments());
+            ReflectionUtils.setConf(split, conf);
             results.add(split);
         }
         if (results.isEmpty()) {

--- a/compiler-project/mapreduce-testing/src/main/java/com/asakusafw/lang/compiler/mapreduce/testing/mock/MockData.java
+++ b/compiler-project/mapreduce-testing/src/main/java/com/asakusafw/lang/compiler/mapreduce/testing/mock/MockData.java
@@ -33,6 +33,8 @@ import com.asakusafw.runtime.value.StringOption;
 
 /**
  * Mock data model class.
+ * @since 0.1.0
+ * @version 0.1.1
  */
 public class MockData implements DataModel<MockData>, Writable {
 
@@ -45,15 +47,27 @@ public class MockData implements DataModel<MockData>, Writable {
     private final DateTimeOption datetimeValue = new DateTimeOption();
 
     /**
-     * Puts values as {@link #getStringValueOption() string_value} .
+     * Puts values as {@link #getStringValueOption() string_value}.
      * @param output the target output
      * @param values the values to set
      * @throws IOException if failed
      */
     public static void put(ModelOutput<MockData> output, String... values) throws IOException {
+        put(output, 0, values);
+    }
+
+    /**
+     * Puts values as {@link #getStringValueOption() string_value}.
+     * @param output the target output
+     * @param offset starting ID number
+     * @param values the values to set
+     * @throws IOException if failed
+     * @since 0.1.1
+     */
+    public static void put(ModelOutput<MockData> output, int offset, String... values) throws IOException {
         Map<Integer, String> map = new LinkedHashMap<>();
         for (String s : values) {
-            map.put(map.size(), s);
+            map.put(offset + map.size(), s);
         }
         put(output, map);
     }


### PR DESCRIPTION
This will fix Direct I/O input filter on Spark.