### PR TITLE
Add optimizations for join with empty inputs.

### DIFF
--- a/compiler-project/analyzer/src/main/java/com/asakusafw/lang/compiler/analyzer/builtin/BuiltInOperatorRewriter.java
+++ b/compiler-project/analyzer/src/main/java/com/asakusafw/lang/compiler/analyzer/builtin/BuiltInOperatorRewriter.java
@@ -27,6 +27,7 @@ public class BuiltInOperatorRewriter implements OperatorRewriter {
     private static final OperatorRewriter DELEGATE = CompositeOperatorRewriter.builder()
             .add(new LoggingOperatorRemover())
             .add(new CheckpointOperatorRemover())
+            .add(new EmptyMasterJoinRemover())
             .build();
 
     @Override

--- a/compiler-project/analyzer/src/main/java/com/asakusafw/lang/compiler/analyzer/builtin/EmptyMasterJoinRemover.java
+++ b/compiler-project/analyzer/src/main/java/com/asakusafw/lang/compiler/analyzer/builtin/EmptyMasterJoinRemover.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.compiler.analyzer.builtin;
+
+import java.util.Collection;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.lang.compiler.analyzer.util.MasterJoinOperatorUtil;
+import com.asakusafw.lang.compiler.model.graph.Operator;
+import com.asakusafw.lang.compiler.model.graph.OperatorGraph;
+import com.asakusafw.lang.compiler.model.graph.OperatorInput;
+import com.asakusafw.lang.compiler.model.graph.OperatorOutput;
+import com.asakusafw.lang.compiler.model.graph.Operators;
+import com.asakusafw.lang.compiler.optimizer.OperatorRewriter;
+
+/**
+ * Removes empty {@code master-join} like operators.
+ * @since 0.3.1
+ */
+public class EmptyMasterJoinRemover implements OperatorRewriter {
+
+    static final Logger LOG = LoggerFactory.getLogger(EmptyMasterJoinRemover.class);
+
+    /**
+     * The compiler option key of whether this removes master-join like operators with empty master port.
+     */
+    public static final String KEY_REMOVE_EMPTY_MASTER = "operator.masterjoin.remove.empty.master";
+
+    /**
+     * The compiler option key of whether this removes master-join like operators with empty transaction port.
+     */
+    public static final String KEY_REMOVE_EMPTY_TRANACTION = "operator.masterjoin.remove.empty.transaction";
+
+    static final boolean DEFAULT_REMOVE_EMPTY_MASTER = false;
+
+    static final boolean DEFAULT_REMOVE_EMPTY_TRANSACTION = false;
+
+    @Override
+    public void perform(Context context, OperatorGraph graph) {
+        if (context.getOptions().get(KEY_REMOVE_EMPTY_MASTER, DEFAULT_REMOVE_EMPTY_MASTER)) {
+            LOG.debug("applying empty join remover: flow={}, port=master", context.getFlowId());
+            for (Operator operator : graph.getOperators()) {
+                if (MasterJoinOperatorUtil.isSupported(operator)) {
+                    boolean removed = removeEmptyJoinMaster(operator);
+                    if (removed) {
+                        graph.remove(operator);
+                    }
+                }
+            }
+        }
+        if (context.getOptions().get(KEY_REMOVE_EMPTY_TRANACTION, DEFAULT_REMOVE_EMPTY_TRANSACTION)) {
+            LOG.debug("applying empty join remover: flow={}, port=transaction", context.getFlowId());
+            for (Operator operator : graph.getOperators()) {
+                boolean removed = removeEmptyJoinTransaction(operator);
+                if (removed) {
+                    graph.remove(operator);
+                }
+            }
+        }
+    }
+
+    private boolean removeEmptyJoinMaster(Operator operator) {
+        if (MasterJoinOperatorUtil.isSupported(operator) == false) {
+            return false;
+        }
+        if (MasterJoinOperatorUtil.getMasterInput(operator).hasOpposites()) {
+            return false;
+        }
+        if (MasterJoinOperatorUtil.hasSelection(operator)) {
+            return false;
+        }
+        OperatorOutput destination = MasterJoinOperatorUtil.getNotJoinedOutput(operator);
+        if (destination == null) {
+            return false;
+        }
+        LOG.debug("removing empty join: {}", operator);
+        OperatorInput transaction = MasterJoinOperatorUtil.getTransactionInput(operator);
+        Collection<OperatorOutput> upstreams = transaction.getOpposites();
+        Collection<OperatorInput> downstreams = destination.getOpposites();
+        operator.disconnectAll();
+        Operators.connectAll(upstreams, downstreams);
+        return true;
+    }
+
+    private boolean removeEmptyJoinTransaction(Operator operator) {
+        if (MasterJoinOperatorUtil.isSupported(operator) == false) {
+            return false;
+        }
+        if (MasterJoinOperatorUtil.getTransactionInput(operator).hasOpposites()) {
+            return false;
+        }
+        LOG.debug("removing empty join: {}", operator);
+        operator.disconnectAll();
+        return true;
+    }
+}

--- a/compiler-project/analyzer/src/test/java/com/asakusafw/lang/compiler/analyzer/builtin/EmptyMasterJoinRemoverTest.java
+++ b/compiler-project/analyzer/src/test/java/com/asakusafw/lang/compiler/analyzer/builtin/EmptyMasterJoinRemoverTest.java
@@ -1,0 +1,255 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.compiler.analyzer.builtin;
+
+import static com.asakusafw.lang.compiler.model.description.Descriptions.*;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.asakusafw.lang.compiler.model.graph.OperatorGraph;
+import com.asakusafw.lang.compiler.model.testing.MockOperators;
+import com.asakusafw.lang.compiler.model.testing.OperatorExtractor;
+import com.asakusafw.lang.compiler.optimizer.OperatorRewriter;
+import com.asakusafw.lang.compiler.optimizer.OptimizerContext;
+import com.asakusafw.vocabulary.operator.MasterBranch;
+import com.asakusafw.vocabulary.operator.MasterJoinUpdate;
+import com.asakusafw.vocabulary.operator.MasterSelection;
+
+/**
+ * Test for {@link EmptyMasterJoinRemover}.
+ */
+public class EmptyMasterJoinRemoverTest extends BuiltInOptimizerTestRoot {
+
+    private final OperatorRewriter optimizer = new EmptyMasterJoinRemover();
+
+    /**
+     * connected.
+     */
+    @Test
+    public void connected() {
+        OperatorGraph graph = join().toGraph();
+        apply(context(), optimizer, graph);
+        assertThat(graph, hasOperator("join"));
+    }
+
+    /**
+     * w/ empty master.
+     */
+    @Test
+    public void empty_master() {
+        MockOperators mock = join();
+        mock.getInput("join.master").disconnectAll();
+        OperatorGraph graph = mock.toGraph();
+        apply(context(), optimizer, graph);
+        assertThat(graph, not(hasOperator("join")));
+
+        mock.assertConnected("transaction", "missed");
+        assertThat(mock.getInput("joined").hasOpposites(), is(false));
+    }
+
+    /**
+     * w/ empty tx.
+     */
+    @Test
+    public void empty_tx() {
+        MockOperators mock = join();
+        mock.getInput("join.transaction").disconnectAll();
+        OperatorGraph graph = mock.toGraph();
+        apply(context(), optimizer, graph);
+        assertThat(graph, not(hasOperator("join")));
+
+        assertThat(mock.getInput("joined").hasOpposites(), is(false));
+        assertThat(mock.getInput("missed").hasOpposites(), is(false));
+    }
+
+    /**
+     * w/ empty both.
+     */
+    @Test
+    public void empty_both() {
+        MockOperators mock = join();
+        mock.getInput("join.master").disconnectAll();
+        mock.getInput("join.transaction").disconnectAll();
+        OperatorGraph graph = mock.toGraph();
+        apply(context(), optimizer, graph);
+        assertThat(graph, not(hasOperator("join")));
+
+        assertThat(mock.getInput("joined").hasOpposites(), is(false));
+        assertThat(mock.getInput("missed").hasOpposites(), is(false));
+    }
+
+    /**
+     * w/ empty master for branch.
+     */
+    @Test
+    public void branch_empty_master() {
+        MockOperators mock = branch();
+        mock.getInput("join.master").disconnectAll();
+        OperatorGraph graph = mock.toGraph();
+        apply(context(), optimizer, graph);
+        assertThat(graph, hasOperator("branch"));
+    }
+
+    /**
+     * w/ empty tx for branch.
+     */
+    @Test
+    public void branch_empty_tx() {
+        MockOperators mock = branch();
+        mock.getInput("join.transaction").disconnectAll();
+        OperatorGraph graph = mock.toGraph();
+        apply(context(), optimizer, graph);
+        assertThat(graph, not(hasOperator("branch")));
+
+        assertThat(mock.getInput("joined").hasOpposites(), is(false));
+        assertThat(mock.getInput("missed").hasOpposites(), is(false));
+    }
+
+    /**
+     * w/ empty both for branch.
+     */
+    @Test
+    public void branch_empty_both() {
+        MockOperators mock = branch();
+        mock.getInput("join.master").disconnectAll();
+        mock.getInput("join.transaction").disconnectAll();
+        OperatorGraph graph = mock.toGraph();
+        apply(context(), optimizer, graph);
+        assertThat(graph, not(hasOperator("branch")));
+
+        assertThat(mock.getInput("joined").hasOpposites(), is(false));
+        assertThat(mock.getInput("missed").hasOpposites(), is(false));
+    }
+
+    /**
+     * w/ empty master for selection.
+     */
+    @Test
+    public void selection_empty_master() {
+        MockOperators mock = selection();
+        mock.getInput("join.master").disconnectAll();
+        OperatorGraph graph = mock.toGraph();
+        apply(context(), optimizer, graph);
+        assertThat(graph, hasOperator("selection"));
+    }
+
+    /**
+     * w/ empty tx for selection.
+     */
+    @Test
+    public void selection_empty_tx() {
+        MockOperators mock = selection();
+        mock.getInput("join.transaction").disconnectAll();
+        OperatorGraph graph = mock.toGraph();
+        apply(context(), optimizer, graph);
+        assertThat(graph, not(hasOperator("selection")));
+
+        assertThat(mock.getInput("joined").hasOpposites(), is(false));
+        assertThat(mock.getInput("missed").hasOpposites(), is(false));
+    }
+
+    /**
+     * w/ empty both for selection.
+     */
+    @Test
+    public void selection_empty_both() {
+        MockOperators mock = selection();
+        mock.getInput("join.master").disconnectAll();
+        mock.getInput("join.transaction").disconnectAll();
+        OperatorGraph graph = mock.toGraph();
+        apply(context(), optimizer, graph);
+        assertThat(graph, not(hasOperator("selection")));
+
+        assertThat(mock.getInput("joined").hasOpposites(), is(false));
+        assertThat(mock.getInput("missed").hasOpposites(), is(false));
+    }
+
+    private OptimizerContext context() {
+        return context(new String[] {
+                EmptyMasterJoinRemover.KEY_REMOVE_EMPTY_MASTER, "true",
+                EmptyMasterJoinRemover.KEY_REMOVE_EMPTY_TRANACTION, "true",
+        });
+    }
+
+    private MockOperators join() {
+        return new MockOperators()
+                .marker("master")
+                .marker("transaction")
+                .bless("join", OperatorExtractor.extract(MasterJoinUpdate.class, Ops.class, "join")
+                        .input("master", typeOf(String.class))
+                        .input("transaction", typeOf(String.class))
+                        .output("updated", typeOf(String.class))
+                        .output("missed", typeOf(String.class)))
+                .marker("joined")
+                .marker("missed")
+                .connect("master", "join.master")
+                .connect("transaction", "join.transaction")
+                .connect("join.updated", "joined")
+                .connect("join.missed", "missed");
+    }
+
+    private MockOperators branch() {
+        return new MockOperators()
+                .marker("master")
+                .marker("transaction")
+                .bless("join", OperatorExtractor.extract(MasterBranch.class, Ops.class, "branch")
+                        .input("master", typeOf(String.class))
+                        .input("transaction", typeOf(String.class))
+                        .output("updated", typeOf(String.class))
+                        .output("missed", typeOf(String.class)))
+                .marker("joined")
+                .marker("missed")
+                .connect("master", "join.master")
+                .connect("transaction", "join.transaction")
+                .connect("join.updated", "joined")
+                .connect("join.missed", "missed");
+    }
+
+    private MockOperators selection() {
+        return new MockOperators()
+                .marker("master")
+                .marker("transaction")
+                .bless("join", OperatorExtractor.extract(MasterJoinUpdate.class, Ops.class, "selection")
+                        .input("master", typeOf(String.class))
+                        .input("transaction", typeOf(String.class))
+                        .output("updated", typeOf(String.class))
+                        .output("missed", typeOf(String.class)))
+                .marker("joined")
+                .marker("missed")
+                .connect("master", "join.master")
+                .connect("transaction", "join.transaction")
+                .connect("join.updated", "joined")
+                .connect("join.missed", "missed");
+    }
+
+    @SuppressWarnings("javadoc")
+    public abstract static class Ops {
+
+        @MasterJoinUpdate
+        public abstract void join();
+
+        @MasterBranch
+        public abstract void branch();
+
+        @MasterJoinUpdate(selection = "selector")
+        public abstract void selection();
+
+        @MasterSelection
+        public abstract void selector();
+    }
+}


### PR DESCRIPTION
* `operator.masterjoin.remove.empty.master`
  * remove master-join like operator if master input is empty
  * default: `false` (experimental feature)
* `operator.masterjoin.remove.empty.transaction`
  * remove master-join like operator if transaction input is empty
  * default: `false` (experimantal feature)