### PR TITLE
Add files generated by IntelliJ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@
 /.classpath
 /.settings
 /bin
-
+/.idea
+*.iml
+*~


### PR DESCRIPTION
While I was reviewing and trying to hack the code with IntelliJ, `.iml` files and `.idea` directory generated by IntelliJ bothered me a lot when I'm trying to run some git commands. This pull request makes git ignore all such generated files.
