### PR TITLE
Enable to record more artifact versions into build logs.

### DIFF
--- a/compiler-project/analyzer/src/main/java/com/asakusafw/lang/compiler/analyzer/Info.java
+++ b/compiler-project/analyzer/src/main/java/com/asakusafw/lang/compiler/analyzer/Info.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.compiler.analyzer;
+
+import com.asakusafw.lang.compiler.api.ExtensionInfo;
+
+/**
+ * Information of this extension module.
+ * @since 0.3.1
+ */
+public class Info implements ExtensionInfo {
+
+    @Override
+    public String getName() {
+        return "core.analyzer";
+    }
+}

--- a/compiler-project/analyzer/src/main/resources/META-INF/services/com.asakusafw.lang.compiler.api.ExtensionInfo
+++ b/compiler-project/analyzer/src/main/resources/META-INF/services/com.asakusafw.lang.compiler.api.ExtensionInfo
@@ -1,0 +1,1 @@
+com.asakusafw.lang.compiler.analyzer.Info

--- a/compiler-project/api/src/main/java/com/asakusafw/lang/compiler/api/ExtensionInfo.java
+++ b/compiler-project/api/src/main/java/com/asakusafw/lang/compiler/api/ExtensionInfo.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.compiler.api;
+
+/**
+ * A marker for compiler extensions.
+ * Compiler extension modules should implement this interface, and put it into service registry.
+ * @since 0.3.1
+ */
+public interface ExtensionInfo {
+
+    /**
+     * Returns the extension name.
+     * @return the extension name
+     */
+    String getName();
+}

--- a/compiler-project/core/src/main/java/com/asakusafw/lang/compiler/core/participant/BuildLogParticipant.java
+++ b/compiler-project/core/src/main/java/com/asakusafw/lang/compiler/core/participant/BuildLogParticipant.java
@@ -24,12 +24,14 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.Map;
+import java.util.ServiceLoader;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.asakusafw.lang.compiler.api.ExtensionInfo;
 import com.asakusafw.lang.compiler.api.reference.BatchReference;
 import com.asakusafw.lang.compiler.common.Location;
 import com.asakusafw.lang.compiler.core.BatchCompiler;
@@ -98,6 +100,13 @@ public class BuildLogParticipant extends AbstractCompilerParticipant {
         editor.put("compiler.jobflowProcessor", info(tools.getJobflowProcessor())); //$NON-NLS-1$
         editor.put("compiler.batchProcessor", info(tools.getBatchProcessor())); //$NON-NLS-1$
         editor.put("compiler.participant", info(tools.getParticipant())); //$NON-NLS-1$
+
+        for (ExtensionInfo extension : ServiceLoader.load(ExtensionInfo.class, context.getProject().getClassLoader())) {
+            String name = extension.getName();
+            String info = DiagnosticUtil.getArtifactInfo(extension.getClass());
+            LOG.debug("compiler extension: {}={}", name, info);
+            editor.put(String.format("compiler.extension.%s", name), info);
+        }
     }
 
     private String info(Object object) {

--- a/compiler-project/test-adapter/src/main/java/com/asakusafw/lang/compiler/testdriver/adapter/Info.java
+++ b/compiler-project/test-adapter/src/main/java/com/asakusafw/lang/compiler/testdriver/adapter/Info.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.compiler.testdriver.adapter;
+
+import com.asakusafw.lang.compiler.api.ExtensionInfo;
+
+/**
+ * Information of this extension module.
+ * @since 0.3.1
+ */
+public class Info implements ExtensionInfo {
+
+    @Override
+    public String getName() {
+        return "testdriver.adapter";
+    }
+}

--- a/compiler-project/test-adapter/src/main/resources/META-INF/services/com.asakusafw.lang.compiler.api.ExtensionInfo
+++ b/compiler-project/test-adapter/src/main/resources/META-INF/services/com.asakusafw.lang.compiler.api.ExtensionInfo
@@ -1,0 +1,1 @@
+com.asakusafw.lang.compiler.testdriver.adapter.Info


### PR DESCRIPTION
## Summary

This commit enables to record more artifact versions into the compiler's build logs.

## Background, Problem or Goal of the patch

The compiler's build log only includes information about terminal extensions, and indirect modules cannot appear on it (e.g. `asakusafw-dag`).

## Design of the fix, or a new feature

This commit introduces `com.asakusafw.lang.compiler.api.ExtensionInfo`. Once register implementations into `META-INF/services`, then the compiler will collect and put them onto build logs.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 
