### PR TITLE
Fix checking if hive libraries are available.

### DIFF
--- a/compiler-project/extension-hive/src/main/java/com/asakusafw/lang/compiler/extension/hive/HiveSchemaAggregatorProcessor.java
+++ b/compiler-project/extension-hive/src/main/java/com/asakusafw/lang/compiler/extension/hive/HiveSchemaAggregatorProcessor.java
@@ -54,7 +54,9 @@ public class HiveSchemaAggregatorProcessor implements BatchProcessor {
 
     @Override
     public void process(Context context, BatchReference source) throws IOException {
-        Util.checkDependencies(context.getClassLoader());
+        if (Util.isAvailable(context.getClassLoader()) == false) {
+            return;
+        }
         LOG.debug("aggregating hive schema information: {}", source.getBatchId());
         List<InputInfo> inputs = new ArrayList<>();
         List<OutputInfo> outputs = new ArrayList<>();

--- a/compiler-project/extension-hive/src/main/java/com/asakusafw/lang/compiler/extension/hive/HiveSchemaCollectorProcessor.java
+++ b/compiler-project/extension-hive/src/main/java/com/asakusafw/lang/compiler/extension/hive/HiveSchemaCollectorProcessor.java
@@ -62,7 +62,9 @@ public class HiveSchemaCollectorProcessor implements JobflowProcessor {
     @Override
     public void process(Context context, Jobflow source) throws IOException {
         ClassLoader loader = context.getClassLoader();
-        Util.checkDependencies(loader);
+        if (Util.isAvailable(loader) == false) {
+            return;
+        }
         LOG.debug("collecting Hive inputs: {}", source.getFlowId());
         List<InputInfo> inputs = collectInputs(loader, source.getOperatorGraph().getInputs().values());
         List<OutputInfo> outputs = collectOutputs(loader, source.getOperatorGraph().getOutputs().values());

--- a/compiler-project/extension-hive/src/main/java/com/asakusafw/lang/compiler/extension/hive/Util.java
+++ b/compiler-project/extension-hive/src/main/java/com/asakusafw/lang/compiler/extension/hive/Util.java
@@ -39,14 +39,16 @@ final class Util {
         return;
     }
 
-    static void checkDependencies(ClassLoader loader) {
+    static boolean isAvailable(ClassLoader loader) {
         LOG.debug("checking if hive dependencies are available");
         try {
             REQUIRED_CLASS.resolve(loader);
             LOG.debug("hive dependencies are available: {}", REQUIRED_CLASS);
+            return true;
         } catch (ClassNotFoundException e) {
             // if dependencies are not available, then the application cannot contain hive related features
             LOG.debug("hive dependencies are not available: {}", REQUIRED_CLASS, e);
+            return false;
         }
     }
 


### PR DESCRIPTION
## Summary

This commit fixes library checking routine in #60.

## Background, Problem or Goal of the patch

#60 includes hive libraries checking mechanism is available but it does not work.

## Design of the fix, or a new feature

Fixed to continue collecting Hive schema info only if the related classes are available.

## Related Issue, Pull Request or Code

* #60

## Wanted reviewer

N/A.