### PR TITLE
Add OptimizerToolkit to implement planner dependent operations.

### DIFF
--- a/compiler-project/optimizer/src/main/java/com/asakusafw/lang/compiler/optimizer/OptimizerContext.java
+++ b/compiler-project/optimizer/src/main/java/com/asakusafw/lang/compiler/optimizer/OptimizerContext.java
@@ -26,6 +26,8 @@ import com.asakusafw.lang.compiler.model.description.ClassDescription;
 
 /**
  * Context for optimizers.
+ * @since 0.1.0
+ * @version 0.3.1
  */
 public interface OptimizerContext extends ExtensionContainer {
 
@@ -58,6 +60,13 @@ public interface OptimizerContext extends ExtensionContainer {
      * @return the data model loader
      */
     DataModelLoader getDataModelLoader();
+
+    /**
+     * Returns the optimizer toolkit.
+     * @return the optimizer toolkit
+     * @since 0.3.1
+     */
+    OptimizerToolkit getToolkit();
 
     /**
      * Adds a new Java class file and returns its output stream.

--- a/compiler-project/optimizer/src/main/java/com/asakusafw/lang/compiler/optimizer/OptimizerToolkit.java
+++ b/compiler-project/optimizer/src/main/java/com/asakusafw/lang/compiler/optimizer/OptimizerToolkit.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.compiler.optimizer;
+
+import com.asakusafw.lang.compiler.model.graph.OperatorGraph;
+import com.asakusafw.lang.compiler.model.graph.OperatorInput;
+import com.asakusafw.lang.compiler.model.graph.OperatorOutput;
+
+/**
+ * Toolkit for optimizers.
+ * @since 0.3.1
+ */
+public interface OptimizerToolkit {
+
+    /**
+     * Repairs the target operator graph if its invariants are broken.
+     * @param graph the target operator graph
+     */
+    void repair(OperatorGraph graph);
+
+    /**
+     * Returns whether or not the target input has one or more effective upstream ports.
+     * @param port the target input
+     * @return {@code true} if the target input has one or more effective upstream ports, otherwise {@code false}
+     */
+    boolean hasEffectiveOpposites(OperatorInput port);
+
+    /**
+     * Returns whether or not the target output has one or more effective downstream ports.
+     * @param port the target input
+     * @return {@code true} if the target output has one or more effective downstream ports, otherwise {@code false}
+     */
+    boolean hasEffectiveOpposites(OperatorOutput port);
+}

--- a/compiler-project/optimizer/src/main/java/com/asakusafw/lang/compiler/optimizer/adapter/ForwardingOptimizerContext.java
+++ b/compiler-project/optimizer/src/main/java/com/asakusafw/lang/compiler/optimizer/adapter/ForwardingOptimizerContext.java
@@ -23,9 +23,12 @@ import com.asakusafw.lang.compiler.api.DataModelLoader;
 import com.asakusafw.lang.compiler.common.Location;
 import com.asakusafw.lang.compiler.model.description.ClassDescription;
 import com.asakusafw.lang.compiler.optimizer.OptimizerContext;
+import com.asakusafw.lang.compiler.optimizer.OptimizerToolkit;
 
 /**
  * Forwarding {@link OptimizerContext}.
+ * @since 0.1.0
+ * @version 0.3.1
  */
 public abstract class ForwardingOptimizerContext implements OptimizerContext {
 
@@ -62,6 +65,11 @@ public abstract class ForwardingOptimizerContext implements OptimizerContext {
     @Override
     public DataModelLoader getDataModelLoader() {
         return delegate.getDataModelLoader();
+    }
+
+    @Override
+    public OptimizerToolkit getToolkit() {
+        return delegate.getToolkit();
     }
 
     @Override

--- a/compiler-project/optimizer/src/main/java/com/asakusafw/lang/compiler/optimizer/adapter/OptimizerContextAdapter.java
+++ b/compiler-project/optimizer/src/main/java/com/asakusafw/lang/compiler/optimizer/adapter/OptimizerContextAdapter.java
@@ -25,13 +25,19 @@ import com.asakusafw.lang.compiler.api.JobflowProcessor.Context;
 import com.asakusafw.lang.compiler.common.Location;
 import com.asakusafw.lang.compiler.model.description.ClassDescription;
 import com.asakusafw.lang.compiler.optimizer.OptimizerContext;
+import com.asakusafw.lang.compiler.optimizer.OptimizerToolkit;
+import com.asakusafw.lang.compiler.optimizer.basic.BasicOptimizerToolkit;
 
 /**
  * Adapter for {@link OptimizerContext}.
+ * @since 0.1.0
+ * @version 0.3.1
  */
 public class OptimizerContextAdapter implements OptimizerContext {
 
     private final JobflowProcessor.Context delegate;
+
+    private final OptimizerToolkit toolkit;
 
     private final String flowId;
 
@@ -41,8 +47,20 @@ public class OptimizerContextAdapter implements OptimizerContext {
      * @param flowId the compiling flow ID
      */
     public OptimizerContextAdapter(Context delegate, String flowId) {
+        this(delegate, flowId, null);
+    }
+
+    /**
+     * Creates a new instance.
+     * @param delegate the delegation target
+     * @param flowId the compiling flow ID
+     * @param toolkit the optimizer toolkit (nullable)
+     * @since 0.3.1
+     */
+    public OptimizerContextAdapter(Context delegate, String flowId, OptimizerToolkit toolkit) {
         this.delegate = delegate;
         this.flowId = flowId;
+        this.toolkit = toolkit == null ? new BasicOptimizerToolkit() : toolkit;
     }
 
     @Override
@@ -68,6 +86,11 @@ public class OptimizerContextAdapter implements OptimizerContext {
     @Override
     public DataModelLoader getDataModelLoader() {
         return delegate.getDataModelLoader();
+    }
+
+    @Override
+    public OptimizerToolkit getToolkit() {
+        return toolkit;
     }
 
     @Override

--- a/compiler-project/optimizer/src/main/java/com/asakusafw/lang/compiler/optimizer/basic/BasicOptimizerToolkit.java
+++ b/compiler-project/optimizer/src/main/java/com/asakusafw/lang/compiler/optimizer/basic/BasicOptimizerToolkit.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.compiler.optimizer.basic;
+
+import com.asakusafw.lang.compiler.model.graph.OperatorGraph;
+import com.asakusafw.lang.compiler.model.graph.OperatorInput;
+import com.asakusafw.lang.compiler.model.graph.OperatorOutput;
+import com.asakusafw.lang.compiler.optimizer.OptimizerToolkit;
+
+/**
+ * A basic implementation of {@link OptimizerToolkit}.
+ * @since 0.3.1
+ */
+public class BasicOptimizerToolkit implements OptimizerToolkit {
+
+    @Override
+    public void repair(OperatorGraph graph) {
+        graph.rebuild();
+    }
+
+    @Override
+    public boolean hasEffectiveOpposites(OperatorInput port) {
+        return port.hasOpposites();
+    }
+
+    @Override
+    public boolean hasEffectiveOpposites(OperatorOutput port) {
+        return port.hasOpposites();
+    }
+}

--- a/compiler-project/optimizer/src/test/java/com/asakusafw/lang/compiler/optimizer/testing/MockOptimizerContext.java
+++ b/compiler-project/optimizer/src/test/java/com/asakusafw/lang/compiler/optimizer/testing/MockOptimizerContext.java
@@ -26,6 +26,8 @@ import com.asakusafw.lang.compiler.common.Location;
 import com.asakusafw.lang.compiler.common.ResourceContainer;
 import com.asakusafw.lang.compiler.model.description.ClassDescription;
 import com.asakusafw.lang.compiler.optimizer.OptimizerContext;
+import com.asakusafw.lang.compiler.optimizer.OptimizerToolkit;
+import com.asakusafw.lang.compiler.optimizer.basic.BasicOptimizerToolkit;
 
 /**
  * Mock implementation of {@link com.asakusafw.lang.compiler.api.JobflowProcessor.Context}.
@@ -43,6 +45,8 @@ public class MockOptimizerContext extends BasicExtensionContainer implements Opt
     private final ClassLoader classLoader;
 
     private final DataModelLoader dataModels;
+
+    private final OptimizerToolkit toolkit = new BasicOptimizerToolkit();
 
     private final ResourceContainer resources;
 
@@ -111,6 +115,11 @@ public class MockOptimizerContext extends BasicExtensionContainer implements Opt
     @Override
     public DataModelLoader getDataModelLoader() {
         return dataModels;
+    }
+
+    @Override
+    public OptimizerToolkit getToolkit() {
+        return toolkit;
     }
 
     @Override


### PR DESCRIPTION
## Summary

This commit includes `OptimizerToolkit` interface for optimization mechanism, to implement planner dependent operations.

## Background, Problem or Goal of the patch

It seems that #54 does not work well. It requires that input ports does not have any upstream ports, but the current planner puts some marker operators into all empty ports to later planning operations.

## Design of the fix, or a new feature

We introduce `OptimizerToolkit` interface. It provides common interface of some optimization operation over differences on each runtime platform and planning mechanism. Note that, this patch will not fix the problem, and implementations of `OptimizerToolkit` are required for each platform.

## Related Issue, Pull Request or Code

#54

## Wanted reviewer

@akirakw 