### PR TITLE
Enable generator constraints for external outputs.

### DIFF
--- a/compiler-project/analyzer/src/main/java/com/asakusafw/lang/compiler/analyzer/FlowGraphAnalyzer.java
+++ b/compiler-project/analyzer/src/main/java/com/asakusafw/lang/compiler/analyzer/FlowGraphAnalyzer.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -225,7 +226,12 @@ public final class FlowGraphAnalyzer {
             context.registerExternalOutput(description.getName(), info);
             source = context.findOutputSource(description.getName());
         }
-        return convert(description, source, ExternalOutput.builder(description.getName(), info));
+        Set<OperatorConstraint> constraints = EnumSet.noneOf(OperatorConstraint.class);
+        if (info != null && info.isGenerator()) {
+            constraints.add(OperatorConstraint.GENERATOR);
+        }
+        return convert(description, source, ExternalOutput.builder(description.getName(), info)
+                .constraint(constraints));
     }
 
     private Operator convert(Context context, FlowPartDescription description) {

--- a/compiler-project/api/src/main/java/com/asakusafw/lang/compiler/api/reference/ExternalOutputReference.java
+++ b/compiler-project/api/src/main/java/com/asakusafw/lang/compiler/api/reference/ExternalOutputReference.java
@@ -75,6 +75,11 @@ public class ExternalOutputReference extends BasicAttributeContainer
     }
 
     @Override
+    public boolean isGenerator() {
+        return info.isGenerator();
+    }
+
+    @Override
     public Set<String> getParameterNames() {
         return info.getParameterNames();
     }

--- a/compiler-project/extension-directio/src/main/java/com/asakusafw/lang/compiler/extension/directio/DirectFileIoPortProcessor.java
+++ b/compiler-project/extension-directio/src/main/java/com/asakusafw/lang/compiler/extension/directio/DirectFileIoPortProcessor.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -156,6 +157,17 @@ public class DirectFileIoPortProcessor
         assertPresent(validate, description.getDeletePatterns(), "getDeletePatterns"); //$NON-NLS-1$
         validate.raiseException();
         return new DirectFileOutputModel(description);
+    }
+
+    @Override
+    protected Set<OutputAttribute> analyzeOutputAttributes(
+            AnalyzeContext context, String name, DirectFileOutputDescription description) {
+        // Direct I/O file output must be GENERATOR only if it declares delete-patterns
+        if (description.getDeletePatterns().isEmpty()) {
+            return Collections.emptySet();
+        } else {
+            return EnumSet.of(OutputAttribute.GENERATOR);
+        }
     }
 
     @Override

--- a/compiler-project/extension-externalio/src/main/java/com/asakusafw/lang/compiler/extension/externalio/AbstractExternalPortProcessor.java
+++ b/compiler-project/extension-externalio/src/main/java/com/asakusafw/lang/compiler/extension/externalio/AbstractExternalPortProcessor.java
@@ -16,6 +16,7 @@
 package com.asakusafw.lang.compiler.extension.externalio;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -36,7 +37,7 @@ import com.asakusafw.vocabulary.external.ImporterDescription;
  * @param <TInput> the importer description type
  * @param <TOutput> the exporter description type
  * @since 0.1.0
- * @version 0.3.0
+ * @version 0.3.1
  */
 public abstract class AbstractExternalPortProcessor<
             TInput extends ImporterDescription,
@@ -63,7 +64,7 @@ public abstract class AbstractExternalPortProcessor<
 
     /**
      * Returns the properties of the target importer description.
-     * @param context  the current context
+     * @param context the current context
      * @param name the input name
      * @param description the target description
      * @return the extracted properties, or {@code null} if the input does not have any additional properties
@@ -73,7 +74,7 @@ public abstract class AbstractExternalPortProcessor<
 
     /**
      * Returns the properties of the target exporter description.
-     * @param context  the current context
+     * @param context the current context
      * @param name the input name
      * @param description the target description
      * @return the extracted properties, or {@code null} if the output does not have any additional properties
@@ -82,26 +83,52 @@ public abstract class AbstractExternalPortProcessor<
             AnalyzeContext context, String name, TOutput description);
 
     /**
+     * Returns the extra attributes of the target importer description.
+     * @param context the current context
+     * @param name the input name
+     * @param description the target description
+     * @return the extracted attributes, or {@code null} if the input does not have any attributes
+     * @since 0.3.1
+     */
+    protected Set<InputAttribute> analyzeInputAttributes(AnalyzeContext context, String name, TInput description) {
+        return Collections.emptySet();
+    }
+
+    /**
+     * Returns the extra attributes of the target exporter description.
+     * @param context the current context
+     * @param name the input name
+     * @param description the target description
+     * @return the extracted attributes, or {@code null} if the output does not have any attributes
+     * @since 0.3.1
+     */
+    protected Set<OutputAttribute> analyzeOutputAttributes(AnalyzeContext context, String name, TOutput description) {
+        return Collections.emptySet();
+    }
+
+    /**
      * Returns the parameter names of the target importer description.
-     * @param context  the current context
+     * @param context the current context
      * @param name the input name
      * @param description the target description
      * @return the parameter names
      * @since 0.3.0
      */
-    protected abstract Set<String> analyzeInputParameterNames(
-            AnalyzeContext context, String name, TInput description);
+    protected Set<String> analyzeInputParameterNames(AnalyzeContext context, String name, TInput description) {
+        return Collections.emptySet();
+    }
 
     /**
      * Returns the parameter names of the target exporter description.
-     * @param context  the current context
-     * @param name the input name
+     * @param context the current context
+     * @param name the output name
      * @param description the target description
      * @return the parameter names
      * @since 0.3.0
      */
-    protected abstract Set<String> analyzeOutputParameterNames(
-            AnalyzeContext context, String name, TOutput description);
+    protected Set<String> analyzeOutputParameterNames(AnalyzeContext context, String name, TOutput description) {
+        return Collections.emptySet();
+    }
 
     /**
      * Returns input paths, which will be used in main phase, of the target external input.
@@ -160,11 +187,13 @@ public abstract class AbstractExternalPortProcessor<
         }
         TOutput desc = type.cast(description);
         ValueDescription properties = analyzeOutputProperties(context, name, desc);
+        Set<OutputAttribute> attributes = analyzeOutputAttributes(context, name, desc);
         Set<String> parameters = analyzeOutputParameterNames(context, name, desc);
         return new ExternalOutputInfo.Basic(
                 Descriptions.classOf(desc.getClass()),
                 getModuleName(),
                 Descriptions.classOf(desc.getModelType()),
+                attributes.contains(OutputAttribute.GENERATOR),
                 parameters,
                 properties);
     }
@@ -223,5 +252,26 @@ public abstract class AbstractExternalPortProcessor<
         default:
             return ExternalInputInfo.DataSize.UNKNOWN;
         }
+    }
+
+    /**
+     * Attributes of external inputs.
+     * @since 0.3.1
+     */
+    public enum InputAttribute {
+
+        // no special members
+    }
+
+    /**
+     * Attributes of external outputs.
+     * @since 0.3.1
+     */
+    public enum OutputAttribute {
+
+        /**
+         * The output has generator constraint.
+         */
+        GENERATOR,
     }
 }

--- a/compiler-project/extension-windgate/src/main/java/com/asakusafw/lang/compiler/extension/windgate/WindGatePortProcessor.java
+++ b/compiler-project/extension-windgate/src/main/java/com/asakusafw/lang/compiler/extension/windgate/WindGatePortProcessor.java
@@ -21,6 +21,7 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -127,6 +128,13 @@ public class WindGatePortProcessor
                     name,
                     e.getMessage()));
         }
+    }
+
+    @Override
+    protected Set<OutputAttribute> analyzeOutputAttributes(
+            AnalyzeContext context, String name, WindGateExporterDescription description) {
+        // WindGate outputs must be GENERATOR for truncating target outputs
+        return EnumSet.of(OutputAttribute.GENERATOR);
     }
 
     @Override

--- a/compiler-project/extension-windgate/src/main/java/com/asakusafw/lang/compiler/extension/windgate/WindGatePortProcessor.java
+++ b/compiler-project/extension-windgate/src/main/java/com/asakusafw/lang/compiler/extension/windgate/WindGatePortProcessor.java
@@ -322,9 +322,16 @@ public class WindGatePortProcessor
                     "failed to resolve data model type: {0}",
                     reference.getDataModelClass()), e);
         }
-        DriverScript source = new DriverScript(
-                Constants.HADOOP_FILE_RESOURCE_NAME,
-                Collections.singletonMap(FileProcess.FILE.key(), locations));
+        DriverScript source;
+        if (locations.isEmpty()) {
+            source = new DriverScript(
+                    Constants.VOID_RESOURCE_NAME,
+                    Collections.<String, String>emptyMap());
+        } else {
+            source = new DriverScript(
+                    Constants.HADOOP_FILE_RESOURCE_NAME,
+                    Collections.singletonMap(FileProcess.FILE.key(), locations));
+        }
         DriverScript drain = model.getDriverScript();
         return createProcessScript(reference.getName(), dataModelType, source, drain);
     }

--- a/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/graph/ExternalOutput.java
+++ b/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/graph/ExternalOutput.java
@@ -17,7 +17,9 @@ package com.asakusafw.lang.compiler.model.graph;
 
 import java.text.MessageFormat;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 import com.asakusafw.lang.compiler.model.description.TypeDescription;
 import com.asakusafw.lang.compiler.model.info.ExternalOutputInfo;
@@ -104,12 +106,9 @@ public final class ExternalOutput extends ExternalPort {
      * @return the created instance
      */
     public static ExternalOutput newInstance(String name, ExternalOutputInfo info, OperatorOutput... upstreams) {
-        boolean generator = info != null && info.isGenerator();
         return builder(name, info)
                 .input(PORT_NAME, info.getDataModelClass(), upstreams)
-                .constraint(generator
-                        ? Collections.singleton(OperatorConstraint.GENERATOR)
-                        : Collections.<OperatorConstraint>emptySet())
+                .constraint(getConstraints(info))
                 .build();
     }
 
@@ -128,7 +127,19 @@ public final class ExternalOutput extends ExternalPort {
             OperatorOutput... upstreams) {
         return builder(name, info)
                 .input(PORT_NAME, upstream, upstreams)
+                .constraint(getConstraints(info))
                 .build();
+    }
+
+    private static Set<OperatorConstraint> getConstraints(ExternalOutputInfo info) {
+        if (info == null) {
+            return Collections.emptySet();
+        }
+        Set<OperatorConstraint> results = EnumSet.noneOf(OperatorConstraint.class);
+        if (info.isGenerator()) {
+            results.add(OperatorConstraint.GENERATOR);
+        }
+        return results;
     }
 
     /**

--- a/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/graph/ExternalOutput.java
+++ b/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/graph/ExternalOutput.java
@@ -16,6 +16,7 @@
 package com.asakusafw.lang.compiler.model.graph;
 
 import java.text.MessageFormat;
+import java.util.Collections;
 import java.util.List;
 
 import com.asakusafw.lang.compiler.model.description.TypeDescription;
@@ -24,7 +25,7 @@ import com.asakusafw.lang.compiler.model.info.ExternalOutputInfo;
 /**
  * Represents an external/flow output operator.
  * @since 0.1.0
- * @version 0.3.0
+ * @version 0.3.1
  */
 public final class ExternalOutput extends ExternalPort {
 
@@ -103,8 +104,12 @@ public final class ExternalOutput extends ExternalPort {
      * @return the created instance
      */
     public static ExternalOutput newInstance(String name, ExternalOutputInfo info, OperatorOutput... upstreams) {
+        boolean generator = info != null && info.isGenerator();
         return builder(name, info)
                 .input(PORT_NAME, info.getDataModelClass(), upstreams)
+                .constraint(generator
+                        ? Collections.singleton(OperatorConstraint.GENERATOR)
+                        : Collections.<OperatorConstraint>emptySet())
                 .build();
     }
 


### PR DESCRIPTION
## Summary

This commit introduces the "generator constraint" for  external outputs.
It constraint prevents dead-flow elision optimization even if the operator does not have any upstream sources.

## Background, Problem or Goal of the patch

When external outputs have no upstream sources, they will be removed by dead-flow elision optimization. But some of external outputs may work even if they don't have any upstream sources (e.g. truncate tables, remove files, ...). It optimizations may change equivalence of operator graph semantics.

## Design of the fix, or a new feature

`ExternalPortIoProcessor` now can tell whether the target external output should have the generator constraint or not. And the subsequent execution planning engines will suppress the dead-flow elision optimization if it is a generator.

## Related Issue, Pull Request or Code

* #54
* asakusafw/asakusafw#628

## Wanted reviewer

N/A.
