### PR TITLE
Expand `${asakusafw.groupId}`.

### DIFF
--- a/bridge-project/runtime-adapter/pom.xml
+++ b/bridge-project/runtime-adapter/pom.xml
@@ -18,7 +18,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>

--- a/bridge-project/runtime-directio/pom.xml
+++ b/bridge-project/runtime-directio/pom.xml
@@ -18,13 +18,13 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}.sandbox</groupId>
+      <groupId>com.asakusafw.sandbox</groupId>
       <artifactId>asakusa-directio-runtime-ext</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>

--- a/bridge-project/runtime-hadoop/pom.xml
+++ b/bridge-project/runtime-hadoop/pom.xml
@@ -18,7 +18,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>

--- a/bridge-project/runtime/pom.xml
+++ b/bridge-project/runtime/pom.xml
@@ -13,7 +13,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>

--- a/compiler-project/analyzer/pom.xml
+++ b/compiler-project/analyzer/pom.xml
@@ -23,19 +23,19 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>simple-graph</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-dsl-vocabulary</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>

--- a/compiler-project/api-testing/pom.xml
+++ b/compiler-project/api-testing/pom.xml
@@ -18,13 +18,13 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-dsl-vocabulary</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>

--- a/compiler-project/cli/pom.xml
+++ b/compiler-project/cli/pom.xml
@@ -48,13 +48,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-dsl-vocabulary</artifactId>
       <version>${asakusafw.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime</artifactId>
       <version>${asakusafw.version}</version>
       <scope>test</scope>

--- a/compiler-project/core/pom.xml
+++ b/compiler-project/core/pom.xml
@@ -43,19 +43,19 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>simple-graph</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-dsl-vocabulary</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>

--- a/compiler-project/extension-cleanup/pom.xml
+++ b/compiler-project/extension-cleanup/pom.xml
@@ -23,13 +23,13 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>java-dom</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>

--- a/compiler-project/extension-directio/pom.xml
+++ b/compiler-project/extension-directio/pom.xml
@@ -33,19 +33,19 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-directio-vocabulary</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>java-dom</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
@@ -100,7 +100,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime-inprocess</artifactId>
       <version>${asakusafw.version}</version>
       <scope>test</scope>

--- a/compiler-project/extension-externalio/pom.xml
+++ b/compiler-project/extension-externalio/pom.xml
@@ -18,7 +18,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-dsl-vocabulary</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>

--- a/compiler-project/extension-hive/pom.xml
+++ b/compiler-project/extension-hive/pom.xml
@@ -31,25 +31,25 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-hive-info</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>simple-graph</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-directio-vocabulary</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
@@ -78,7 +78,7 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>java-dom</artifactId>
       <version>${asakusafw.version}</version>
       <scope>test</scope>

--- a/compiler-project/extension-test-moderator/pom.xml
+++ b/compiler-project/extension-test-moderator/pom.xml
@@ -38,25 +38,25 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-dsl-vocabulary</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-test-moderator</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>java-dom</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
@@ -105,7 +105,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime-inprocess</artifactId>
       <version>${asakusafw.version}</version>
       <scope>test</scope>

--- a/compiler-project/extension-trace/pom.xml
+++ b/compiler-project/extension-trace/pom.xml
@@ -18,25 +18,25 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-dsl-vocabulary</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>java-dom</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-test-trace-model</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>

--- a/compiler-project/extension-windgate/pom.xml
+++ b/compiler-project/extension-windgate/pom.xml
@@ -18,7 +18,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-windgate-vocabulary</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>

--- a/compiler-project/extension-yaess/pom.xml
+++ b/compiler-project/extension-yaess/pom.xml
@@ -23,7 +23,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-yaess-core</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>

--- a/compiler-project/internalio/pom.xml
+++ b/compiler-project/internalio/pom.xml
@@ -13,7 +13,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-dsl-vocabulary</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>

--- a/compiler-project/mapreduce-testing/pom.xml
+++ b/compiler-project/mapreduce-testing/pom.xml
@@ -23,13 +23,13 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime-inprocess</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>

--- a/compiler-project/mapreduce/pom.xml
+++ b/compiler-project/mapreduce/pom.xml
@@ -18,13 +18,13 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>java-dom</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
@@ -67,7 +67,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime-inprocess</artifactId>
       <version>${asakusafw.version}</version>
       <scope>test</scope>

--- a/compiler-project/operator-project/builtin/pom.xml
+++ b/compiler-project/operator-project/builtin/pom.xml
@@ -45,19 +45,19 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-dsl-vocabulary</artifactId>
       <version>${asakusafw.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime</artifactId>
       <version>${asakusafw.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>jsr199-testing</artifactId>
       <version>${asakusafw.version}</version>
       <scope>test</scope>

--- a/compiler-project/operator-project/core/pom.xml
+++ b/compiler-project/operator-project/core/pom.xml
@@ -34,12 +34,12 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>jsr269-bridge</artifactId>
       <version>${asakusafw.version}</version>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>javadoc-parser</artifactId>
       <version>${asakusafw.version}</version>
     </dependency>
@@ -64,19 +64,19 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-dsl-vocabulary</artifactId>
       <version>${asakusafw.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime</artifactId>
       <version>${asakusafw.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>jsr199-testing</artifactId>
       <version>${asakusafw.version}</version>
       <scope>test</scope>

--- a/compiler-project/operator-project/dmdl/pom.xml
+++ b/compiler-project/operator-project/dmdl/pom.xml
@@ -45,19 +45,19 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-dsl-vocabulary</artifactId>
       <version>${asakusafw.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime</artifactId>
       <version>${asakusafw.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>jsr199-testing</artifactId>
       <version>${asakusafw.version}</version>
       <scope>test</scope>

--- a/compiler-project/operator-project/vocabulary/pom.xml
+++ b/compiler-project/operator-project/vocabulary/pom.xml
@@ -13,7 +13,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-dsl-vocabulary</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>

--- a/compiler-project/optimizer/pom.xml
+++ b/compiler-project/optimizer/pom.xml
@@ -18,7 +18,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>simple-graph</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>

--- a/compiler-project/plan/pom.xml
+++ b/compiler-project/plan/pom.xml
@@ -18,7 +18,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>simple-graph</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>

--- a/compiler-project/test-adapter/pom.xml
+++ b/compiler-project/test-adapter/pom.xml
@@ -28,25 +28,25 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-test-compiler</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-dsl-vocabulary</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-test-trace-model</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
@@ -78,13 +78,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>simple-graph</artifactId>
       <version>${asakusafw.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>java-dom</artifactId>
       <version>${asakusafw.version}</version>
       <scope>test</scope>

--- a/compiler-project/tester/pom.xml
+++ b/compiler-project/tester/pom.xml
@@ -18,19 +18,19 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>simple-graph</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-dsl-vocabulary</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${asakusafw.groupId}</groupId>
+      <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime</artifactId>
       <version>${asakusafw.version}</version>
       <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,6 @@
     <plugin.javadoc.version>2.10.1</plugin.javadoc.version>
 
     <!-- artifact versions -->
-    <asakusafw.groupId>com.asakusafw</asakusafw.groupId>
     <asakusafw.version>0.8.1-SNAPSHOT</asakusafw.version>
     <hadoop.version>2.7.2</hadoop.version>
     <commons-cli.version>1.2</commons-cli.version>
@@ -329,7 +328,7 @@ encoding/<project>=UTF-8
           <version>2.8</version>
           <dependencies>
             <dependency>
-              <groupId>${asakusafw.groupId}</groupId>
+              <groupId>com.asakusafw</groupId>
               <artifactId>build-tools</artifactId>
               <version>${asakusafw.version}</version>
             </dependency>
@@ -385,7 +384,7 @@ encoding/<project>=UTF-8
           <version>3.0.0</version>
           <dependencies>
             <dependency>
-              <groupId>${asakusafw.groupId}</groupId>
+              <groupId>com.asakusafw</groupId>
               <artifactId>build-tools</artifactId>
               <version>${asakusafw.version}</version>
             </dependency>
@@ -409,7 +408,7 @@ encoding/<project>=UTF-8
               <version>${checkstyle.version}</version>
             </dependency>
             <dependency>
-              <groupId>${asakusafw.groupId}</groupId>
+              <groupId>com.asakusafw</groupId>
               <artifactId>build-tools</artifactId>
               <version>${asakusafw.version}</version>
             </dependency>


### PR DESCRIPTION
## Summary

This commit expands `${asakusafw.groupId}` into `com.asakusafw` in each `pom.xml`.

## Background, Problem or Goal of the patch

It may decrease readability of `pom.xml`, and the group ID will not have never been substituted with another one. 

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 