### PR TITLE
Remove unused findbugs exclusion file.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -392,7 +392,6 @@ encoding/<project>=UTF-8
           <configuration>
             <xmlOutput>true</xmlOutput>
             <findbugsXmlOutput>true</findbugsXmlOutput>
-            <excludeFilterFile>com/asakusafw/fb_exclude.xml</excludeFilterFile>
             <sourceEncoding>UTF-8</sourceEncoding>
             <outputEncoding>UTF-8</outputEncoding>
           </configuration>


### PR DESCRIPTION
## Summary

This commit removes unused findbugs exclusion file in pom.xml.

## Background, Problem or Goal of the patch

It seems that the findbugs exclusion file defined in `asakusafw/build-tools` does not have any effects for this project.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 