### PR TITLE
Revise error message on Direct I/O input missing.

### DIFF
--- a/bridge-project/runtime-hadoop/src/main/java/com/asakusafw/bridge/hadoop/directio/DirectFileInputFormat.java
+++ b/bridge-project/runtime-hadoop/src/main/java/com/asakusafw/bridge/hadoop/directio/DirectFileInputFormat.java
@@ -123,17 +123,15 @@ public class DirectFileInputFormat extends InputFormat<NullWritable, Object> {
         if (fragments.isEmpty()) {
             if (info.optional) {
                 LOG.info(MessageFormat.format(
-                        "skipped optional input (datasource={0}, basePath=\"{1}\", resourcePattern=\"{2}\", type={3})",
+                        "skipped optional input (datasource={0}, path=\"{1}\", type={2})",
                         repository.getRelatedId(info.basePath),
-                        componentPath,
-                        info.resourcePattern.toString(),
+                        ds.path(componentPath, info.resourcePattern),
                         info.definition.getDataClass().getName()));
             } else {
                 throw new IOException(MessageFormat.format(
-                        "input not found (datasource={0}, basePath=\"{1}\", resourcePattern=\"{2}\", type={3})",
+                        "input not found (datasource={0}, path=\"{1}\", type={2})",
                         repository.getRelatedId(info.basePath),
-                        componentPath,
-                        info.resourcePattern.toString(),
+                        ds.path(componentPath, info.resourcePattern),
                         info.definition.getDataClass().getName()));
             }
         }


### PR DESCRIPTION
## Summary

This PR revises error messages when Direct I/O input does not exist.

## Background, Problem or Goal of the patch

This feature is an implementation of asakusafw/asakusafw#632 for platforms which use the compiler features in this repository.

## Design of the fix, or a new feature

Please see asakusafw/asakusafw#632.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw#632

## Wanted reviewer

N/A.