### PR TITLE
Introduce `DirectFileIoModels` to use compiler model directly.

### DIFF
--- a/compiler-project/extension-directio/src/main/java/com/asakusafw/lang/compiler/extension/directio/DirectFileIoConstants.java
+++ b/compiler-project/extension-directio/src/main/java/com/asakusafw/lang/compiler/extension/directio/DirectFileIoConstants.java
@@ -22,8 +22,16 @@ import com.asakusafw.runtime.stage.output.BridgeOutputFormat;
 
 /**
  * Constants for Direct file I/Os.
+ * @since 0.1.0
+ * @version 0.3.1
  */
 public final class DirectFileIoConstants {
+
+    /**
+     * The module name of Direct file I/O.
+     * @since 0.3.1
+     */
+    public static final String MODULE_NAME = "directio"; //$NON-NLS-1$
 
     /**
      * Hadoop input format class for direct file inputs.

--- a/compiler-project/extension-directio/src/main/java/com/asakusafw/lang/compiler/extension/directio/DirectFileIoModels.java
+++ b/compiler-project/extension-directio/src/main/java/com/asakusafw/lang/compiler/extension/directio/DirectFileIoModels.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.compiler.extension.directio;
+
+import java.text.MessageFormat;
+
+import com.asakusafw.lang.compiler.model.info.ExternalInputInfo;
+import com.asakusafw.lang.compiler.model.info.ExternalOutputInfo;
+import com.asakusafw.lang.compiler.model.info.ExternalPortInfo;
+
+/**
+ * Utilities for Direct file I/O models.
+ * @since 0.3.1
+ */
+public final class DirectFileIoModels {
+
+    private DirectFileIoModels() {
+        return;
+    }
+
+    /**
+     * Returns whether or not the target external port represents a direct file input.
+     * @param info the target external port info
+     * @return {@code true} if the target external port represents a direct, otherwise {@code false}
+     */
+    public static boolean isSupported(ExternalInputInfo info) {
+        return isSupported0(info);
+    }
+
+    /**
+     * Returns whether or not the target external port represents a direct file output.
+     * @param info the target external port info
+     * @return {@code true} if the target external port represents a direct, otherwise {@code false}
+     */
+    public static boolean isSupported(ExternalOutputInfo info) {
+        return isSupported0(info);
+    }
+
+    /**
+     * Resolves an external port of direct file input and returns a model object which represents its operation.
+     * @param info the target external port
+     * @return the operation model
+     * @throws IllegalArgumentException if the target port does not represent a valid direct file input
+     * @see #isSupported(ExternalInputInfo)
+     */
+    public static DirectFileInputModel resolve(ExternalInputInfo info) {
+        return resolve0(DirectFileInputModel.class, info);
+    }
+
+    /**
+     * Resolves an external port of direct file output and returns a model object which represents its operation.
+     * @param info the target external port
+     * @return the operation model
+     * @throws IllegalArgumentException if the target port does not represent a valid direct file output
+     * @see #isSupported(ExternalOutputInfo)
+     */
+    public static DirectFileOutputModel resolve(ExternalOutputInfo info) {
+        return resolve0(DirectFileOutputModel.class, info);
+    }
+
+    private static boolean isSupported0(ExternalPortInfo info) {
+        return info.getModuleName().equals(DirectFileIoConstants.MODULE_NAME);
+    }
+
+    private static <T> T resolve0(Class<T> type, ExternalPortInfo info) {
+        if (isSupported0(info) == false) {
+            throw new IllegalArgumentException(MessageFormat.format(
+                    "unsupported direct file I/O info: {0}",
+                    info));
+        }
+        try {
+            Object contents = info.getContents().resolve(type.getClassLoader());
+            if (type.isInstance(contents) == false) {
+                throw new IllegalArgumentException(MessageFormat.format(
+                        "unsupported direct file I/O info: {0}",
+                        info));
+            }
+            return type.cast(contents);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalArgumentException(MessageFormat.format(
+                    "unsupported direct file I/O info: {0}",
+                    info), e);
+        }
+    }
+}

--- a/compiler-project/extension-directio/src/main/java/com/asakusafw/lang/compiler/extension/directio/DirectFileIoPortProcessor.java
+++ b/compiler-project/extension-directio/src/main/java/com/asakusafw/lang/compiler/extension/directio/DirectFileIoPortProcessor.java
@@ -77,11 +77,6 @@ public class DirectFileIoPortProcessor
 
     static final Logger LOG = LoggerFactory.getLogger(DirectFileIoPortProcessor.class);
 
-    /**
-     * The module name of Direct file I/O.
-     */
-    public static final String MODULE_NAME = "directio"; //$NON-NLS-1$
-
     static final TaskReference.Phase PHASE_INPUT = TaskReference.Phase.PROLOGUE;
 
     static final TaskReference.Phase PHASE_OUTPUT = TaskReference.Phase.EPILOGUE;
@@ -108,7 +103,7 @@ public class DirectFileIoPortProcessor
 
     @Override
     protected String getModuleName() {
-        return MODULE_NAME;
+        return DirectFileIoConstants.MODULE_NAME;
     }
 
     @Override

--- a/compiler-project/extension-hive/src/main/java/com/asakusafw/lang/compiler/extension/hive/HiveSchemaCollectorProcessor.java
+++ b/compiler-project/extension-hive/src/main/java/com/asakusafw/lang/compiler/extension/hive/HiveSchemaCollectorProcessor.java
@@ -31,7 +31,7 @@ import com.asakusafw.directio.hive.info.TableInfo;
 import com.asakusafw.lang.compiler.api.JobflowProcessor;
 import com.asakusafw.lang.compiler.common.Location;
 import com.asakusafw.lang.compiler.extension.directio.DirectFileInputModel;
-import com.asakusafw.lang.compiler.extension.directio.DirectFileIoPortProcessor;
+import com.asakusafw.lang.compiler.extension.directio.DirectFileIoModels;
 import com.asakusafw.lang.compiler.extension.directio.DirectFileOutputModel;
 import com.asakusafw.lang.compiler.model.graph.ExternalInput;
 import com.asakusafw.lang.compiler.model.graph.ExternalOutput;
@@ -108,17 +108,12 @@ public class HiveSchemaCollectorProcessor implements JobflowProcessor {
             return null;
         }
         ExternalInputInfo info = port.getInfo();
-        if (info.getModuleName().equals(DirectFileIoPortProcessor.MODULE_NAME) == false) {
+        if (DirectFileIoModels.isSupported(info) == false) {
             LOG.trace("not direct I/O: {}", info);
             return null;
         }
         try {
-            Object contents = info.getContents().resolve(classLoader);
-            if ((contents instanceof DirectFileInputModel) == false) {
-                LOG.trace("not direct file I/O: {}", info);
-                return null;
-            }
-            DirectFileInputModel model = (DirectFileInputModel) contents;
+            DirectFileInputModel model = DirectFileIoModels.resolve(info);
             Object format = model.getFormatClass()
                     .resolve(classLoader)
                     .newInstance();
@@ -129,7 +124,7 @@ public class HiveSchemaCollectorProcessor implements JobflowProcessor {
             return new InputInfo(
                     new LocationInfo(model.getBasePath(), model.getResourcePattern()),
                     ((TableInfo.Provider) format).getSchema());
-        } catch (ReflectiveOperationException e) {
+        } catch (IllegalArgumentException | ReflectiveOperationException e) {
             LOG.debug("failed to resolve external port model: {}", info, e);
             return null;
         }
@@ -141,17 +136,12 @@ public class HiveSchemaCollectorProcessor implements JobflowProcessor {
             return null;
         }
         ExternalOutputInfo info = port.getInfo();
-        if (info.getModuleName().equals(DirectFileIoPortProcessor.MODULE_NAME) == false) {
+        if (DirectFileIoModels.isSupported(info) == false) {
             LOG.trace("not direct I/O: {}", info);
             return null;
         }
         try {
-            Object contents = info.getContents().resolve(classLoader);
-            if ((contents instanceof DirectFileOutputModel) == false) {
-                LOG.trace("not direct file I/O: {}", info);
-                return null;
-            }
-            DirectFileOutputModel model = (DirectFileOutputModel) contents;
+            DirectFileOutputModel model = DirectFileIoModels.resolve(info);
             Object format = model.getFormatClass()
                     .resolve(classLoader)
                     .newInstance();


### PR DESCRIPTION
## Summary

This PR introduces `DirectFileIoModels` to use internal compiler models directly. 

## Background, Problem or Goal of the patch

Some features directly use internal compiler models of Direct file I/O via too low level compiler API. This PR will introduce a better abstraction for them.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@ueshin