### PR TITLE
Fix code style for Java8.

### DIFF
--- a/bridge-project/runtime-hadoop/src/test/java/com/asakusafw/bridge/hadoop/ModelInputRecordReaderTest.java
+++ b/bridge-project/runtime-hadoop/src/test/java/com/asakusafw/bridge/hadoop/ModelInputRecordReaderTest.java
@@ -130,7 +130,7 @@ public class ModelInputRecordReaderTest {
 
         @Override
         public List<InputSplit> getSplits(JobContext context) throws IOException, InterruptedException {
-            return Collections.<InputSplit>singletonList(new InputSplit() {
+            return Collections.singletonList(new InputSplit() {
                 @Override
                 public long getLength() throws IOException, InterruptedException {
                     return 0;

--- a/bridge-project/runtime/src/main/java/com/asakusafw/bridge/api/ReportAdapter.java
+++ b/bridge-project/runtime/src/main/java/com/asakusafw/bridge/api/ReportAdapter.java
@@ -106,12 +106,7 @@ final class ReportAdapter implements Closeable {
      * @throws IllegalStateException if resource session has not been started yet
      */
     public static Delegate delegate() {
-        Delegate cached = CACHE.find();
-        if (cached != null) {
-            return cached;
-        }
-        ReportAdapter self = ResourceBroker.get(ReportAdapter.class, SUPPLIER);
-        return CACHE.put(self.delegate);
+        return CACHE.get(() -> ResourceBroker.get(ReportAdapter.class, SUPPLIER).delegate);
     }
 
     @Override

--- a/bridge-project/runtime/src/test/java/com/asakusafw/bridge/api/MapConfiguration.java
+++ b/bridge-project/runtime/src/test/java/com/asakusafw/bridge/api/MapConfiguration.java
@@ -34,7 +34,7 @@ public class MapConfiguration implements ResourceConfiguration {
      * Creates a new empty instance.
      */
     public MapConfiguration() {
-        this(Collections.<String, String>emptyMap(), MapConfiguration.class.getClassLoader());
+        this(Collections.emptyMap(), MapConfiguration.class.getClassLoader());
     }
 
     /**

--- a/compiler-project/analyzer/src/main/java/com/asakusafw/lang/compiler/analyzer/FlowGraphAnalyzer.java
+++ b/compiler-project/analyzer/src/main/java/com/asakusafw/lang/compiler/analyzer/FlowGraphAnalyzer.java
@@ -117,7 +117,7 @@ public final class FlowGraphAnalyzer {
     private static final Map<Class<?>, Collection<Class<? extends Annotation>>> OPERATOR_ANNOTATION_ALIASES;
     static {
         Map<Class<?>, Collection<Class<? extends Annotation>>> map = new HashMap<>();
-        map.put(CoGroup.class, Arrays.<Class<? extends Annotation>>asList(GroupSort.class));
+        map.put(CoGroup.class, Arrays.asList(GroupSort.class));
         OPERATOR_ANNOTATION_ALIASES = map;
     }
 

--- a/compiler-project/analyzer/src/test/java/com/asakusafw/lang/compiler/analyzer/MockFlowGraph.java
+++ b/compiler-project/analyzer/src/test/java/com/asakusafw/lang/compiler/analyzer/MockFlowGraph.java
@@ -43,7 +43,6 @@ import com.asakusafw.vocabulary.flow.graph.FlowElementPortDescription;
 import com.asakusafw.vocabulary.flow.graph.FlowGraph;
 import com.asakusafw.vocabulary.flow.graph.FlowIn;
 import com.asakusafw.vocabulary.flow.graph.FlowOut;
-import com.asakusafw.vocabulary.flow.graph.FlowResourceDescription;
 import com.asakusafw.vocabulary.flow.graph.InputDescription;
 import com.asakusafw.vocabulary.flow.graph.OperatorDescription;
 import com.asakusafw.vocabulary.flow.graph.OutputDescription;
@@ -127,7 +126,7 @@ public class MockFlowGraph {
      * @return this
      */
     public MockFlowGraph operator(String id, Class<?> operatorClass, String methodName) {
-        return operator(id, operatorClass, methodName, Collections.<String, Object>emptyMap());
+        return operator(id, operatorClass, methodName, Collections.emptyMap());
     }
 
     /**
@@ -192,7 +191,7 @@ public class MockFlowGraph {
                         methodName, Arrays.asList(method.getParameterTypes())),
                 inputs,
                 outputs,
-                Collections.<FlowResourceDescription>emptyList(),
+                Collections.emptyList(),
                 arguments,
                 Arrays.asList(attributes));
         return add(id, description);

--- a/compiler-project/api/src/main/java/com/asakusafw/lang/compiler/api/basic/AbstractJobflowProcessorContext.java
+++ b/compiler-project/api/src/main/java/com/asakusafw/lang/compiler/api/basic/AbstractJobflowProcessorContext.java
@@ -114,7 +114,7 @@ public abstract class AbstractJobflowProcessorContext extends BasicExtensionCont
             Location command,
             List<? extends CommandToken> arguments,
             TaskReference... blockers) {
-        return addTask(moduleName, profileName, command, arguments, Collections.<String>emptySet(), blockers);
+        return addTask(moduleName, profileName, command, arguments, Collections.emptySet(), blockers);
     }
 
     @Override
@@ -124,7 +124,7 @@ public abstract class AbstractJobflowProcessorContext extends BasicExtensionCont
             Location command,
             List<? extends CommandToken> arguments,
             TaskReference... blockers) {
-        return addFinalizer(moduleName, profileName, command, arguments, Collections.<String>emptySet(), blockers);
+        return addFinalizer(moduleName, profileName, command, arguments, Collections.emptySet(), blockers);
     }
 
     @Override

--- a/compiler-project/api/src/main/java/com/asakusafw/lang/compiler/api/reference/CommandTaskReference.java
+++ b/compiler-project/api/src/main/java/com/asakusafw/lang/compiler/api/reference/CommandTaskReference.java
@@ -62,7 +62,7 @@ public class CommandTaskReference extends BasicAttributeContainer implements Tas
             Location command,
             List<? extends CommandToken> arguments,
             List<? extends TaskReference> blockerTasks) {
-        this(moduleName, profileName, command, arguments, Collections.<String>emptySet(), blockerTasks);
+        this(moduleName, profileName, command, arguments, Collections.emptySet(), blockerTasks);
     }
 
     /**

--- a/compiler-project/cli/src/main/java/com/asakusafw/lang/compiler/cli/ValueHolder.java
+++ b/compiler-project/cli/src/main/java/com/asakusafw/lang/compiler/cli/ValueHolder.java
@@ -67,7 +67,7 @@ public class ValueHolder<T> implements Holder<T> {
     @Override
     public Iterator<T> iterator() {
         if (value == null) {
-            return Collections.<T>emptySet().iterator();
+            return Collections.emptyIterator();
         } else {
             return Collections.singleton(value).iterator();
         }

--- a/compiler-project/cli/src/test/java/com/asakusafw/lang/compiler/cli/mock/DelegateBatchCompiler.java
+++ b/compiler-project/cli/src/test/java/com/asakusafw/lang/compiler/cli/mock/DelegateBatchCompiler.java
@@ -26,12 +26,9 @@ public class DelegateBatchCompiler implements BatchCompiler {
     /**
      * delegate.
      */
-    public static final ThreadLocal<BatchCompiler> DELEGATE = new ThreadLocal<BatchCompiler>() {
-        @Override
-        protected BatchCompiler initialValue() {
-            throw new AssertionError();
-        }
-    };
+    public static final ThreadLocal<BatchCompiler> DELEGATE = ThreadLocal.withInitial(() -> {
+        throw new AssertionError();
+    });
 
     @Override
     public void compile(Context context, Batch batch) {

--- a/compiler-project/core/src/main/java/com/asakusafw/lang/compiler/core/adapter/JobflowProcessorAdapter.java
+++ b/compiler-project/core/src/main/java/com/asakusafw/lang/compiler/core/adapter/JobflowProcessorAdapter.java
@@ -138,7 +138,7 @@ public class JobflowProcessorAdapter implements JobflowProcessor.Context {
             Location command,
             List<? extends CommandToken> arguments,
             TaskReference... blockers) {
-        return addTask(moduleName, profileName, command, arguments, Collections.<String>emptySet(), blockers);
+        return addTask(moduleName, profileName, command, arguments, Collections.emptySet(), blockers);
     }
 
     @Override
@@ -148,7 +148,7 @@ public class JobflowProcessorAdapter implements JobflowProcessor.Context {
             Location command,
             List<? extends CommandToken> arguments,
             TaskReference... blockers) {
-        return addFinalizer(moduleName, profileName, command, arguments, Collections.<String>emptySet(), blockers);
+        return addFinalizer(moduleName, profileName, command, arguments, Collections.emptySet(), blockers);
     }
 
     @Override

--- a/compiler-project/core/src/test/java/com/asakusafw/lang/compiler/core/ToolRepositoryTest.java
+++ b/compiler-project/core/src/test/java/com/asakusafw/lang/compiler/core/ToolRepositoryTest.java
@@ -285,7 +285,7 @@ public class ToolRepositoryTest {
     static Matcher<Object> hasIds(String... ids) {
         Matcher<? super List<? extends String>> sub;
         if (ids.length == 0) {
-            sub = Matchers.<String>empty();
+            sub = Matchers.empty();
         } else {
             sub = contains(ids);
         }

--- a/compiler-project/core/src/test/java/com/asakusafw/lang/compiler/core/dummy/SimpleExternalPortProcessor.java
+++ b/compiler-project/core/src/test/java/com/asakusafw/lang/compiler/core/dummy/SimpleExternalPortProcessor.java
@@ -24,7 +24,6 @@ import java.util.Map;
 
 import com.asakusafw.lang.compiler.api.ExternalPortProcessor;
 import com.asakusafw.lang.compiler.api.reference.CommandTaskReference;
-import com.asakusafw.lang.compiler.api.reference.CommandToken;
 import com.asakusafw.lang.compiler.api.reference.ExternalInputReference;
 import com.asakusafw.lang.compiler.api.reference.ExternalOutputReference;
 import com.asakusafw.lang.compiler.api.reference.TaskReference;
@@ -140,9 +139,9 @@ public class SimpleExternalPortProcessor implements ExternalPortProcessor {
                 MODULE_NAME,
                 "testing",
                 Location.of("simple.sh"),
-                Collections.<CommandToken>emptyList(),
-                Collections.<String>emptySet(),
-                Collections.<TaskReference>emptyList()));
+                Collections.emptyList(),
+                Collections.emptySet(),
+                Collections.emptyList()));
     }
 
     @Override

--- a/compiler-project/core/src/test/java/com/asakusafw/lang/compiler/core/dummy/SimpleJobflowProcessor.java
+++ b/compiler-project/core/src/test/java/com/asakusafw/lang/compiler/core/dummy/SimpleJobflowProcessor.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 
 import com.asakusafw.lang.compiler.api.JobflowProcessor;
 import com.asakusafw.lang.compiler.api.reference.CommandTaskReference;
-import com.asakusafw.lang.compiler.api.reference.CommandToken;
 import com.asakusafw.lang.compiler.api.reference.TaskReference;
 import com.asakusafw.lang.compiler.common.Location;
 import com.asakusafw.lang.compiler.core.BatchCompiler;
@@ -112,7 +111,7 @@ public class SimpleJobflowProcessor implements JobflowProcessor {
                 MODULE_NAME,
                 "testing",
                 Location.of("simple.sh"),
-                Collections.<CommandToken>emptyList());
+                Collections.emptyList());
         if (useExternalPort) {
             for (ExternalInput port : source.getOperatorGraph().getInputs().values()) {
                 context.addExternalInput(port.getName(), port.getInfo());

--- a/compiler-project/description/src/main/java/com/asakusafw/lang/compiler/model/description/AnnotationDescription.java
+++ b/compiler-project/description/src/main/java/com/asakusafw/lang/compiler/model/description/AnnotationDescription.java
@@ -40,7 +40,7 @@ public class AnnotationDescription implements ValueDescription {
      * @param declaringClass the declaring annotation type
      */
     public AnnotationDescription(ClassDescription declaringClass) {
-        this(declaringClass, Collections.<String, ValueDescription>emptyMap());
+        this(declaringClass, Collections.emptyMap());
     }
 
     /**

--- a/compiler-project/description/src/test/java/com/asakusafw/lang/compiler/model/description/MethodDescriptionTest.java
+++ b/compiler-project/description/src/test/java/com/asakusafw/lang/compiler/model/description/MethodDescriptionTest.java
@@ -75,7 +75,7 @@ public class MethodDescriptionTest {
         MethodDescription desc = new MethodDescription(
                 classOf(Integer.class),
                 "intValue",
-                Collections.<ReifiableTypeDescription>emptyList());
+                Collections.emptyList());
 
         Method method = desc.resolve(getClass().getClassLoader());
         assertThat(method.invoke(100), is((Object) 100));
@@ -91,7 +91,7 @@ public class MethodDescriptionTest {
         MethodDescription desc = new MethodDescription(
                 classOf(getClass()),
                 "non_public",
-                Collections.<ReifiableTypeDescription>emptyList());
+                Collections.emptyList());
 
         Method method = desc.resolve(getClass().getClassLoader());
         assertThat(method.invoke(null), is((Object) "non public"));

--- a/compiler-project/extension-cleanup/src/test/java/com/asakusafw/lang/compiler/extension/cleanup/CleanupStageGeneratorTest.java
+++ b/compiler-project/extension-cleanup/src/test/java/com/asakusafw/lang/compiler/extension/cleanup/CleanupStageGeneratorTest.java
@@ -80,7 +80,7 @@ public class CleanupStageGeneratorTest {
                 new Configuration(),
                 client,
                 "testing",
-                Collections.<String, String>emptyMap(),
+                Collections.emptyMap(),
                 javac.compile());
         assertThat("exit status code", status, is(0));
         assertThat(file.exists(), is(false));

--- a/compiler-project/extension-directio/src/main/java/com/asakusafw/lang/compiler/extension/directio/DirectFileIoPortProcessor.java
+++ b/compiler-project/extension-directio/src/main/java/com/asakusafw/lang/compiler/extension/directio/DirectFileIoPortProcessor.java
@@ -553,7 +553,7 @@ public class DirectFileIoPortProcessor
                         DirectFileIoConstants.CLASS_INPUT_FORMAT,
                         inputAttributes),
                 HadoopFormatExtension.getOutputFormat(context),
-                Collections.<String, String>emptyMap());
+                Collections.emptyMap());
     }
 
     private Map<String, String> getInputAttributes(Context context, ResolvedInput resolved) {
@@ -595,7 +595,7 @@ public class DirectFileIoPortProcessor
                         reference.getPaths(),
                         reference.getDataModelClass(),
                         HadoopFormatExtension.getInputFormat(context),
-                        Collections.<String, String>emptyMap())),
+                        Collections.emptyMap())),
                 model.getBasePath(),
                 OutputPattern.compile(dataModel, model.getResourcePattern(), model.getOrder()),
                 deletePatterns,
@@ -607,7 +607,7 @@ public class DirectFileIoPortProcessor
         context.addTask(phase, new HadoopTaskReference(
                 getModuleName(),
                 clientClass,
-                Collections.<TaskReference>emptyList()));
+                Collections.emptyList()));
     }
 
     @Override

--- a/compiler-project/extension-directio/src/main/java/com/asakusafw/lang/compiler/extension/directio/OutputPattern.java
+++ b/compiler-project/extension-directio/src/main/java/com/asakusafw/lang/compiler/extension/directio/OutputPattern.java
@@ -137,7 +137,7 @@ public final class OutputPattern {
      * @return the compiled information
      */
     public static OutputPattern compile(DataModelReference dataModel, String resourcePattern) {
-        return compile(dataModel, resourcePattern, Collections.<String>emptyList());
+        return compile(dataModel, resourcePattern, Collections.emptyList());
     }
 
     /**

--- a/compiler-project/extension-directio/src/main/java/com/asakusafw/lang/compiler/extension/directio/emitter/OrderingClassEmitter.java
+++ b/compiler-project/extension-directio/src/main/java/com/asakusafw/lang/compiler/extension/directio/emitter/OrderingClassEmitter.java
@@ -32,12 +32,10 @@ import com.asakusafw.lang.compiler.model.description.ClassDescription;
 import com.asakusafw.lang.compiler.model.description.TypeDescription;
 import com.asakusafw.runtime.io.util.InvertOrder;
 import com.asakusafw.runtime.stage.directio.DirectOutputOrder;
-import com.asakusafw.utils.java.model.syntax.Comment;
 import com.asakusafw.utils.java.model.syntax.CompilationUnit;
 import com.asakusafw.utils.java.model.syntax.ConstructorDeclaration;
 import com.asakusafw.utils.java.model.syntax.Expression;
 import com.asakusafw.utils.java.model.syntax.FieldDeclaration;
-import com.asakusafw.utils.java.model.syntax.FormalParameterDeclaration;
 import com.asakusafw.utils.java.model.syntax.MethodDeclaration;
 import com.asakusafw.utils.java.model.syntax.ModelFactory;
 import com.asakusafw.utils.java.model.syntax.SimpleName;
@@ -45,7 +43,6 @@ import com.asakusafw.utils.java.model.syntax.Statement;
 import com.asakusafw.utils.java.model.syntax.Type;
 import com.asakusafw.utils.java.model.syntax.TypeBodyDeclaration;
 import com.asakusafw.utils.java.model.syntax.TypeDeclaration;
-import com.asakusafw.utils.java.model.syntax.TypeParameterDeclaration;
 import com.asakusafw.utils.java.model.util.AttributeBuilder;
 import com.asakusafw.utils.java.model.util.ExpressionBuilder;
 import com.asakusafw.utils.java.model.util.ImportBuilder;
@@ -100,7 +97,7 @@ public final class OrderingClassEmitter {
                 importer.getPackageDeclaration(),
                 importer.toImportDeclarations(),
                 Collections.singletonList(type),
-                Collections.<Comment>emptyList());
+                Collections.emptyList());
     }
 
     private TypeDeclaration createType() {
@@ -117,9 +114,9 @@ public final class OrderingClassEmitter {
                     .Final()
                     .toAttributes(),
                 name,
-                Collections.<TypeParameterDeclaration>emptyList(),
+                Collections.emptyList(),
                 t(DirectOutputOrder.class),
-                Collections.<Type>emptyList(),
+                Collections.emptyList(),
                 members);
     }
 
@@ -183,7 +180,7 @@ public final class OrderingClassEmitter {
                     .Public()
                     .toAttributes(),
                 f.newSimpleName(targetClass.getSimpleName()),
-                Collections.<FormalParameterDeclaration>emptyList(),
+                Collections.emptyList(),
                 statements);
     }
 

--- a/compiler-project/extension-directio/src/main/java/com/asakusafw/lang/compiler/extension/directio/emitter/OutputStageEmitter.java
+++ b/compiler-project/extension-directio/src/main/java/com/asakusafw/lang/compiler/extension/directio/emitter/OutputStageEmitter.java
@@ -49,11 +49,9 @@ import com.asakusafw.runtime.stage.directio.DirectOutputReducer;
 import com.asakusafw.runtime.stage.directio.DirectOutputSpec;
 import com.asakusafw.utils.java.model.syntax.ArrayType;
 import com.asakusafw.utils.java.model.syntax.ClassDeclaration;
-import com.asakusafw.utils.java.model.syntax.Comment;
 import com.asakusafw.utils.java.model.syntax.CompilationUnit;
 import com.asakusafw.utils.java.model.syntax.ConstructorDeclaration;
 import com.asakusafw.utils.java.model.syntax.Expression;
-import com.asakusafw.utils.java.model.syntax.FormalParameterDeclaration;
 import com.asakusafw.utils.java.model.syntax.ModelFactory;
 import com.asakusafw.utils.java.model.syntax.Statement;
 import com.asakusafw.utils.java.model.syntax.Type;
@@ -362,7 +360,7 @@ public final class OutputStageEmitter {
                     .Public()
                     .toAttributes(),
                 f.newSimpleName(aClass.getSimpleName()),
-                Collections.<FormalParameterDeclaration>emptyList(),
+                Collections.emptyList(),
                 Collections.singletonList(ctorChain));
         ClassDeclaration typeDecl = f.newClassDeclaration(
                 null,
@@ -372,13 +370,13 @@ public final class OutputStageEmitter {
                     .toAttributes(),
                 f.newSimpleName(aClass.getSimpleName()),
                 importer.resolve(baseClass),
-                Collections.<Type>emptyList(),
+                Collections.emptyList(),
                 Collections.singletonList(ctorDecl));
         CompilationUnit source = f.newCompilationUnit(
                 importer.getPackageDeclaration(),
                 importer.toImportDeclarations(),
                 Collections.singletonList(typeDecl),
-                Collections.<Comment>emptyList());
+                Collections.emptyList());
         return JavaDomUtil.emit(source, javac);
     }
 
@@ -420,7 +418,7 @@ public final class OutputStageEmitter {
                 new StageInfo(stageInfo.meta.getBatchId(), stageInfo.meta.getFlowId(), stageInfo.meta.getStageId()),
                 inputs,
                 outputs,
-                Collections.<MapReduceStageInfo.Resource>emptyList(),
+                Collections.emptyList(),
                 shuffle,
                 stageInfo.baseOutputPath);
 

--- a/compiler-project/extension-directio/src/main/java/com/asakusafw/lang/compiler/extension/directio/emitter/StringTemplateClassEmitter.java
+++ b/compiler-project/extension-directio/src/main/java/com/asakusafw/lang/compiler/extension/directio/emitter/StringTemplateClassEmitter.java
@@ -36,12 +36,10 @@ import com.asakusafw.runtime.stage.directio.StringTemplate;
 import com.asakusafw.runtime.stage.directio.StringTemplate.Format;
 import com.asakusafw.runtime.stage.directio.StringTemplate.FormatSpec;
 import com.asakusafw.runtime.value.IntOption;
-import com.asakusafw.utils.java.model.syntax.Comment;
 import com.asakusafw.utils.java.model.syntax.CompilationUnit;
 import com.asakusafw.utils.java.model.syntax.ConstructorDeclaration;
 import com.asakusafw.utils.java.model.syntax.Expression;
 import com.asakusafw.utils.java.model.syntax.FieldDeclaration;
-import com.asakusafw.utils.java.model.syntax.FormalParameterDeclaration;
 import com.asakusafw.utils.java.model.syntax.InfixOperator;
 import com.asakusafw.utils.java.model.syntax.MethodDeclaration;
 import com.asakusafw.utils.java.model.syntax.ModelFactory;
@@ -50,7 +48,6 @@ import com.asakusafw.utils.java.model.syntax.Statement;
 import com.asakusafw.utils.java.model.syntax.Type;
 import com.asakusafw.utils.java.model.syntax.TypeBodyDeclaration;
 import com.asakusafw.utils.java.model.syntax.TypeDeclaration;
-import com.asakusafw.utils.java.model.syntax.TypeParameterDeclaration;
 import com.asakusafw.utils.java.model.util.AttributeBuilder;
 import com.asakusafw.utils.java.model.util.ExpressionBuilder;
 import com.asakusafw.utils.java.model.util.ImportBuilder;
@@ -109,7 +106,7 @@ public final class StringTemplateClassEmitter {
                 importer.getPackageDeclaration(),
                 importer.toImportDeclarations(),
                 Collections.singletonList(type),
-                Collections.<Comment>emptyList());
+                Collections.emptyList());
     }
 
     private TypeDeclaration createType() {
@@ -132,9 +129,9 @@ public final class StringTemplateClassEmitter {
                     .Final()
                     .toAttributes(),
                 name,
-                Collections.<TypeParameterDeclaration>emptyList(),
+                Collections.emptyList(),
                 t(StringTemplate.class),
-                Collections.<Type>emptyList(),
+                Collections.emptyList(),
                 members);
     }
 
@@ -198,7 +195,7 @@ public final class StringTemplateClassEmitter {
                     .Public()
                     .toAttributes(),
                 f.newSimpleName(targetClass.getSimpleName()),
-                Collections.<FormalParameterDeclaration>emptyList(),
+                Collections.emptyList(),
                 statements);
     }
 

--- a/compiler-project/extension-directio/src/test/java/com/asakusafw/lang/compiler/extension/directio/DirectFileIoPortProcessorTest.java
+++ b/compiler-project/extension-directio/src/test/java/com/asakusafw/lang/compiler/extension/directio/DirectFileIoPortProcessorTest.java
@@ -743,7 +743,7 @@ public class DirectFileIoPortProcessorTest {
 
         MockExternalPortProcessorContext mock = mock();
         DirectFileIoPortProcessor processor = new DirectFileIoPortProcessor();
-        processor.process(mock, inputs, Collections.<ExternalOutputReference>emptyList());
+        processor.process(mock, inputs, Collections.emptyList());
 
         checkTasks(mock.getTasks(), 1, 0);
 
@@ -772,7 +772,7 @@ public class DirectFileIoPortProcessorTest {
 
         MockExternalPortProcessorContext mock = mock();
         DirectFileIoPortProcessor processor = new DirectFileIoPortProcessor();
-        processor.process(mock, inputs, Collections.<ExternalOutputReference>emptyList());
+        processor.process(mock, inputs, Collections.emptyList());
 
         checkTasks(mock.getTasks(), 1, 0);
 
@@ -802,7 +802,7 @@ public class DirectFileIoPortProcessorTest {
         MockExternalPortProcessorContext mock = mock(
                 Collections.singletonMap(DirectFileIoPortProcessor.OPTION_FILTER_ENABLED, String.valueOf(false)));
         DirectFileIoPortProcessor processor = new DirectFileIoPortProcessor();
-        processor.process(mock, inputs, Collections.<ExternalOutputReference>emptyList());
+        processor.process(mock, inputs, Collections.emptyList());
 
         checkTasks(mock.getTasks(), 1, 0);
 
@@ -834,7 +834,7 @@ public class DirectFileIoPortProcessorTest {
         MockExternalPortProcessorContext mock = mock(
                 Collections.singletonMap(DirectFileIoPortProcessor.OPTION_FILTER_ENABLED, String.valueOf(false)));
         DirectFileIoPortProcessor processor = new DirectFileIoPortProcessor();
-        processor.process(mock, inputs, Collections.<ExternalOutputReference>emptyList());
+        processor.process(mock, inputs, Collections.emptyList());
 
         checkTasks(mock.getTasks(), 1, 0);
 
@@ -1036,7 +1036,7 @@ public class DirectFileIoPortProcessorTest {
     }
 
     private MockExternalPortProcessorContext mock() {
-        return mock(Collections.<String, String>emptyMap());
+        return mock(Collections.emptyMap());
     }
 
     private MockExternalPortProcessorContext mock(Map<String, String> options) {
@@ -1135,7 +1135,7 @@ public class DirectFileIoPortProcessorTest {
     }
 
     private void run(MockExternalPortProcessorContext mock, File classes, Phase phase) throws Exception {
-        run(mock, classes, phase, Collections.<String, String>emptyMap());
+        run(mock, classes, phase, Collections.emptyMap());
     }
 
     private void run(

--- a/compiler-project/extension-directio/src/test/java/com/asakusafw/lang/compiler/extension/directio/emitter/OrderingClassEmitterTest.java
+++ b/compiler-project/extension-directio/src/test/java/com/asakusafw/lang/compiler/extension/directio/emitter/OrderingClassEmitterTest.java
@@ -35,7 +35,6 @@ import com.asakusafw.lang.compiler.mapreduce.testing.mock.MockData;
 import com.asakusafw.lang.compiler.mapreduce.testing.mock.MockDataFormat;
 import com.asakusafw.lang.compiler.mapreduce.testing.mock.WritableInputFormat;
 import com.asakusafw.lang.compiler.model.description.ClassDescription;
-import com.asakusafw.runtime.directio.FilePattern;
 import com.asakusafw.runtime.stage.directio.DirectOutputOrder;
 
 /**
@@ -64,10 +63,10 @@ public class OrderingClassEmitterTest {
                         "testing/input/*.txt",
                         classOf(MockData.class),
                         classOf(WritableInputFormat.class),
-                        Collections.<String, String>emptyMap())),
+                        Collections.emptyMap())),
                 "testing/stage",
                 OutputPattern.compile(dataModel, "testing/output/*.txt", Arrays.asList("+intValue", "-stringValue")),
-                Collections.<FilePattern>emptyList(),
+                Collections.emptyList(),
                 classOf(MockDataFormat.class));
 
         ClassDescription targetClass = new ClassDescription("com.example.Ordering");

--- a/compiler-project/extension-directio/src/test/java/com/asakusafw/lang/compiler/extension/directio/emitter/OutputStageEmitterTest.java
+++ b/compiler-project/extension-directio/src/test/java/com/asakusafw/lang/compiler/extension/directio/emitter/OutputStageEmitterTest.java
@@ -84,7 +84,7 @@ public class OutputStageEmitterTest {
                 Collections.singletonList(source("testing/input/file.bin", entries)),
                 "testing/output",
                 OutputPattern.compile(dataModel, "*.bin"),
-                Collections.<FilePattern>emptyList(),
+                Collections.emptyList(),
                 classOf(MockDataFormat.class));
         OutputStageInfo info = stage(operation);
         ClassDescription clientClass = OutputStageEmitter.emit(info, javac);
@@ -92,7 +92,7 @@ public class OutputStageEmitterTest {
                 context.newConfiguration(),
                 clientClass,
                 "testing",
-                Collections.<String, String>emptyMap(),
+                Collections.emptyMap(),
                 javac.compile());
         assertThat(status, is(0));
 
@@ -134,7 +134,7 @@ public class OutputStageEmitterTest {
                 context.newConfiguration(),
                 clientClass,
                 "testing",
-                Collections.<String, String>emptyMap(),
+                Collections.emptyMap(),
                 javac.compile());
         assertThat(status, is(0));
 
@@ -164,7 +164,7 @@ public class OutputStageEmitterTest {
                 Collections.singletonList(source("testing/input/file.bin", entries)),
                 "testing/output",
                 OutputPattern.compile(dataModel, "single.bin"),
-                Collections.<FilePattern>emptyList(),
+                Collections.emptyList(),
                 classOf(MockDataFormat.class));
         OutputStageInfo info = stage(operation);
         ClassDescription clientClass = OutputStageEmitter.emit(info, javac);
@@ -172,7 +172,7 @@ public class OutputStageEmitterTest {
                 context.newConfiguration(),
                 clientClass,
                 "testing",
-                Collections.<String, String>emptyMap(),
+                Collections.emptyMap(),
                 javac.compile());
         assertThat(status, is(0));
 
@@ -201,7 +201,7 @@ public class OutputStageEmitterTest {
                 Collections.singletonList(source("testing/input/file.bin", entries)),
                 "testing/output",
                 OutputPattern.compile(dataModel, "{stringValue}.bin", Arrays.asList("+intValue")),
-                Collections.<FilePattern>emptyList(),
+                Collections.emptyList(),
                 classOf(MockDataFormat.class));
         OutputStageInfo info = stage(operation);
         ClassDescription clientClass = OutputStageEmitter.emit(info, javac);
@@ -209,7 +209,7 @@ public class OutputStageEmitterTest {
                 context.newConfiguration(),
                 clientClass,
                 "testing",
-                Collections.<String, String>emptyMap(),
+                Collections.emptyMap(),
                 javac.compile());
         assertThat(status, is(0));
 
@@ -244,7 +244,7 @@ public class OutputStageEmitterTest {
                 Collections.singletonList(source),
                 "testing/o0",
                 OutputPattern.compile(dataModel, "*.bin"),
-                Collections.<FilePattern>emptyList(),
+                Collections.emptyList(),
                 classOf(MockDataFormat.class));
         OutputStageInfo.Operation o1 = new OutputStageInfo.Operation(
                 "t1",
@@ -252,7 +252,7 @@ public class OutputStageEmitterTest {
                 Collections.singletonList(source),
                 "testing/o1",
                 OutputPattern.compile(dataModel, "single.bin"),
-                Collections.<FilePattern>emptyList(),
+                Collections.emptyList(),
                 classOf(MockDataFormat.class));
         OutputStageInfo info = stage(o0, o1);
         ClassDescription clientClass = OutputStageEmitter.emit(info, javac);
@@ -260,7 +260,7 @@ public class OutputStageEmitterTest {
                 context.newConfiguration(),
                 clientClass,
                 "testing",
-                Collections.<String, String>emptyMap(),
+                Collections.emptyMap(),
                 javac.compile());
         assertThat(status, is(0));
 
@@ -276,7 +276,7 @@ public class OutputStageEmitterTest {
                 context.path(path).toString(),
                 classOf(MockData.class),
                 classOf(WritableInputFormat.class),
-                Collections.<String, String>emptyMap());
+                Collections.emptyMap());
     }
 
     private Map<Integer, String> collect(File file) throws IOException {

--- a/compiler-project/extension-directio/src/test/java/com/asakusafw/lang/compiler/extension/directio/emitter/StringTemplateClassEmitterTest.java
+++ b/compiler-project/extension-directio/src/test/java/com/asakusafw/lang/compiler/extension/directio/emitter/StringTemplateClassEmitterTest.java
@@ -36,7 +36,6 @@ import com.asakusafw.lang.compiler.mapreduce.testing.mock.MockData;
 import com.asakusafw.lang.compiler.mapreduce.testing.mock.MockDataFormat;
 import com.asakusafw.lang.compiler.mapreduce.testing.mock.WritableInputFormat;
 import com.asakusafw.lang.compiler.model.description.ClassDescription;
-import com.asakusafw.runtime.directio.FilePattern;
 import com.asakusafw.runtime.stage.directio.StringTemplate;
 
 /**
@@ -65,10 +64,10 @@ public class StringTemplateClassEmitterTest {
                         "testing/input/*.txt",
                         classOf(MockData.class),
                         classOf(WritableInputFormat.class),
-                        Collections.<String, String>emptyMap())),
+                        Collections.emptyMap())),
                 "testing/stage",
                 OutputPattern.compile(dataModel, "output/{intValue}/[100..999].txt"),
-                Collections.<FilePattern>emptyList(),
+                Collections.emptyList(),
                 classOf(MockDataFormat.class));
 
         ClassDescription targetClass = new ClassDescription("com.example.Template");

--- a/compiler-project/extension-test-moderator/src/main/java/com/asakusafw/lang/compiler/extension/testdriver/InternalIoPortProcessor.java
+++ b/compiler-project/extension-test-moderator/src/main/java/com/asakusafw/lang/compiler/extension/testdriver/InternalIoPortProcessor.java
@@ -250,9 +250,9 @@ public class InternalIoPortProcessor
                                 port.getPaths(),
                                 port.getDataModelClass(),
                                 HadoopFormatExtension.getInputFormat(context),
-                                Collections.<String, String>emptyMap()),
+                                Collections.emptyMap()),
                         HadoopFormatExtension.getOutputFormat(context),
-                        Collections.<String, String>emptyMap());
+                        Collections.emptyMap());
                 operations.add(operation);
             }
             CopyStageInfo info = new CopyStageInfo(
@@ -267,7 +267,7 @@ public class InternalIoPortProcessor
             context.addTask(PHASE_OUTPUT, new HadoopTaskReference(
                     getModuleName(),
                     client,
-                    Collections.<TaskReference>emptyList()));
+                    Collections.emptyList()));
         }
     }
 

--- a/compiler-project/extension-test-moderator/src/test/java/com/asakusafw/lang/compiler/extension/testdriver/InternalIoPortProcessorTest.java
+++ b/compiler-project/extension-test-moderator/src/test/java/com/asakusafw/lang/compiler/extension/testdriver/InternalIoPortProcessorTest.java
@@ -393,7 +393,7 @@ public class InternalIoPortProcessorTest {
                 new Configuration(),
                 hadoop.getMainClass(),
                 "testing",
-                Collections.<String, String>emptyMap(),
+                Collections.emptyMap(),
                 classes);
         assertThat(MessageFormat.format(
                 "unexpected exit status on {0}",

--- a/compiler-project/extension-trace/src/test/java/com/asakusafw/lang/compiler/extension/trace/TraceOperatorWeaverTest.java
+++ b/compiler-project/extension-trace/src/test/java/com/asakusafw/lang/compiler/extension/trace/TraceOperatorWeaverTest.java
@@ -58,7 +58,7 @@ public class TraceOperatorWeaverTest {
         settings.add(new TraceSetting(
                 new Tracepoint(Ops.class.getName(), "update", PortKind.INPUT, "in"),
                 Mode.IN_ORDER,
-                Collections.<String, String>emptyMap()));
+                Collections.emptyMap()));
 
         assertThat(graph.getOperators(), hasSize(1));
 
@@ -83,7 +83,7 @@ public class TraceOperatorWeaverTest {
         settings.add(new TraceSetting(
                 new Tracepoint(Ops.class.getName(), "update", PortKind.OUTPUT, "out"),
                 Mode.IN_ORDER,
-                Collections.<String, String>emptyMap()));
+                Collections.emptyMap()));
 
         assertThat(graph.getOperators(), hasSize(1));
 

--- a/compiler-project/extension-windgate/src/main/java/com/asakusafw/lang/compiler/extension/windgate/WindGatePortProcessor.java
+++ b/compiler-project/extension-windgate/src/main/java/com/asakusafw/lang/compiler/extension/windgate/WindGatePortProcessor.java
@@ -212,8 +212,8 @@ public class WindGatePortProcessor
                             CommandToken.EXECUTION_ID,
                             CommandToken.BATCH_ARGUMENTS,
                     }),
-                    Collections.<String>emptySet(),
-                    Collections.<TaskReference>emptyList()));
+                    Collections.emptySet(),
+                    Collections.emptyList()));
         }
         if (doExport) {
             LOG.debug("registering WindGate export: {}", profileName); //$NON-NLS-1$
@@ -230,8 +230,8 @@ public class WindGatePortProcessor
                             CommandToken.EXECUTION_ID,
                             CommandToken.BATCH_ARGUMENTS,
                     }),
-                    Collections.<String>emptySet(),
-                    Collections.<TaskReference>emptyList()));
+                    Collections.emptySet(),
+                    Collections.emptyList()));
         }
         LOG.debug("registering WindGate finalize: {}", profileName); //$NON-NLS-1$
         context.addTask(TaskReference.Phase.FINALIZE, new CommandTaskReference(
@@ -244,8 +244,8 @@ public class WindGatePortProcessor
                         CommandToken.FLOW_ID,
                         CommandToken.EXECUTION_ID,
                 }),
-                Collections.<String>emptySet(),
-                Collections.<TaskReference>emptyList()));
+                Collections.emptySet(),
+                Collections.emptyList()));
     }
 
     private static String getScriptUri(boolean importer, String profileName) {
@@ -326,7 +326,7 @@ public class WindGatePortProcessor
         if (locations.isEmpty()) {
             source = new DriverScript(
                     Constants.VOID_RESOURCE_NAME,
-                    Collections.<String, String>emptyMap());
+                    Collections.emptyMap());
         } else {
             source = new DriverScript(
                     Constants.HADOOP_FILE_RESOURCE_NAME,

--- a/compiler-project/extension-yaess/src/main/java/com/asakusafw/lang/compiler/extension/yaess/YaessBatchProcessor.java
+++ b/compiler-project/extension-yaess/src/main/java/com/asakusafw/lang/compiler/extension/yaess/YaessBatchProcessor.java
@@ -183,7 +183,7 @@ public class YaessBatchProcessor implements BatchProcessor {
         assert stageId != null;
         Set<String> blockerIds = toStageIds(task.getBlockers(), idMap);
         List<String> command = resolveCommandLine(batch, jobflow, phase, task);
-        Map<String, String> envs = Collections.<String, String>emptyMap();
+        Map<String, String> envs = Collections.emptyMap();
         Set<String> extensions = task.getExtensions();
         return new CommandScript(
                 stageId, blockerIds,

--- a/compiler-project/extension-yaess/src/test/java/com/asakusafw/lang/compiler/extension/yaess/YaessBatchProcessorTest.java
+++ b/compiler-project/extension-yaess/src/test/java/com/asakusafw/lang/compiler/extension/yaess/YaessBatchProcessorTest.java
@@ -275,7 +275,7 @@ public class YaessBatchProcessorTest {
                             CommandToken.BATCH_ARGUMENTS,
                     }),
                     Arrays.asList("e1", "e2"),
-                    Collections.<TaskReference>emptyList()));
+                    Collections.emptyList()));
         BatchReference batch = batch("B", jobflow("F", tasks));
 
         BatchScript script = execute(context, batch);
@@ -305,7 +305,7 @@ public class YaessBatchProcessorTest {
             .add(Phase.MAIN, new HadoopTaskReference(
                     new ClassDescription("HADOOP"),
                     Arrays.asList("e1", "e2"),
-                    Collections.<TaskReference>emptyList()));
+                    Collections.emptyList()));
         BatchReference batch = batch("B", jobflow("F", tasks));
 
         BatchScript script = execute(batch);
@@ -400,7 +400,7 @@ public class YaessBatchProcessorTest {
     }
 
     private CommandTaskReference task(String module, TaskReference... blockers) {
-        return task(module, Collections.<CommandToken>emptyList(), blockers);
+        return task(module, Collections.emptyList(), blockers);
     }
 
     private CommandTaskReference task(String module, List<? extends CommandToken> args, TaskReference... blockers) {
@@ -409,7 +409,7 @@ public class YaessBatchProcessorTest {
                 "dummy",
                 Location.of("dummy/command.sh"),
                 args,
-                Collections.<String>emptySet(),
+                Collections.emptySet(),
                 Arrays.asList(blockers));
     }
 }

--- a/compiler-project/hadoop/src/main/java/com/asakusafw/lang/compiler/hadoop/BasicHadoopTaskExtension.java
+++ b/compiler-project/hadoop/src/main/java/com/asakusafw/lang/compiler/hadoop/BasicHadoopTaskExtension.java
@@ -42,7 +42,7 @@ public class BasicHadoopTaskExtension implements HadoopTaskExtension {
 
     @Override
     public TaskReference addTask(Phase phase, ClassDescription mainClass, TaskReference... blockers) {
-        return addTask(phase, mainClass, Collections.<String>emptySet(), blockers);
+        return addTask(phase, mainClass, Collections.emptySet(), blockers);
     }
 
     @Override

--- a/compiler-project/hadoop/src/main/java/com/asakusafw/lang/compiler/hadoop/HadoopTaskReference.java
+++ b/compiler-project/hadoop/src/main/java/com/asakusafw/lang/compiler/hadoop/HadoopTaskReference.java
@@ -79,7 +79,7 @@ public class HadoopTaskReference extends BasicAttributeContainer implements Task
             String moduleName,
             ClassDescription mainClass,
             List<? extends TaskReference> blockerTasks) {
-        this(moduleName, mainClass, Collections.<String>emptySet(), blockerTasks);
+        this(moduleName, mainClass, Collections.emptySet(), blockerTasks);
     }
 
     /**

--- a/compiler-project/inspection/src/test/java/com/asakusafw/lang/compiler/inspection/TaskDriverTest.java
+++ b/compiler-project/inspection/src/test/java/com/asakusafw/lang/compiler/inspection/TaskDriverTest.java
@@ -67,8 +67,8 @@ public class TaskDriverTest {
                 "local",
                 Location.of("hello/world"),
                 Arrays.asList(CommandToken.of("a"), CommandToken.EXECUTION_ID),
-                Collections.<String>emptySet(),
-                Collections.<TaskReference>emptyList());
+                Collections.emptySet(),
+                Collections.emptyList());
 
         InspectionNode node = driver.inspect("t", ref);
         assertThat(node.getId(), is("t"));
@@ -81,7 +81,7 @@ public class TaskDriverTest {
     public void task_hadoop() {
         TaskReference ref = new HadoopTaskReference(
                 new ClassDescription("testing"),
-                Collections.<TaskReference>emptyList());
+                Collections.emptyList());
 
         InspectionNode node = driver.inspect("t", ref);
         assertThat(node.getId(), is("t"));
@@ -360,8 +360,8 @@ public class TaskDriverTest {
                 "testing",
                 "local",
                 Location.of("sh"),
-                Collections.<CommandToken>emptyList(),
-                Collections.<String>emptySet(),
+                Collections.emptyList(),
+                Collections.emptySet(),
                 Arrays.asList(blockers));
         ref.putAttribute(Bless.class, new Bless());
         return ref;

--- a/compiler-project/javac/src/test/java/com/asakusafw/lang/compiler/javac/BasicJavaCompilerSupportTest.java
+++ b/compiler-project/javac/src/test/java/com/asakusafw/lang/compiler/javac/BasicJavaCompilerSupportTest.java
@@ -59,7 +59,7 @@ public class BasicJavaCompilerSupportTest {
 
         BasicJavaCompilerSupport compiler = new BasicJavaCompilerSupport(
                 source,
-                Collections.<File>emptyList(),
+                Collections.emptyList(),
                 target);
         assertThat(compiler.getSourcePath(), is(source));
         assertThat(compiler.getDestinationPath(), is(target));
@@ -117,7 +117,7 @@ public class BasicJavaCompilerSupportTest {
         File target = deployer.getFile("target");
         JavaCompilerSupport compiler = new BasicJavaCompilerSupport(
                 source,
-                Collections.<File>emptyList(),
+                Collections.emptyList(),
                 target);
         compiler.process();
         assertThat(target.exists(), is(false));
@@ -134,7 +134,7 @@ public class BasicJavaCompilerSupportTest {
 
         JavaCompilerSupport compiler = new BasicJavaCompilerSupport(
                 source,
-                Collections.<File>emptyList(),
+                Collections.emptyList(),
                 target);
         put(compiler, "com.example.Hello", "?");
         compiler.process();
@@ -148,8 +148,8 @@ public class BasicJavaCompilerSupportTest {
     public void compile_error_bootclasspath() throws Exception {
         File source = deployer.getFile("source");
         File target = deployer.getFile("target");
-        JavaCompilerSupport compiler = new BasicJavaCompilerSupport(source, Collections.<File>emptyList(), target)
-            .withBootClassPath(Collections.<File>emptyList());
+        JavaCompilerSupport compiler = new BasicJavaCompilerSupport(source, Collections.emptyList(), target)
+            .withBootClassPath(Collections.emptyList());
         put(compiler, "com.example.Hello", new String[] {
                 "package com.example;",
                 "public class Hello {}",
@@ -165,7 +165,7 @@ public class BasicJavaCompilerSupportTest {
     public void compile_error_compliant_version() throws Exception {
         File source = deployer.getFile("source");
         File target = deployer.getFile("target");
-        JavaCompilerSupport compiler = new BasicJavaCompilerSupport(source, Collections.<File>emptyList(), target)
+        JavaCompilerSupport compiler = new BasicJavaCompilerSupport(source, Collections.emptyList(), target)
             .withCompliantVersion("INVALID");
         put(compiler, "com.example.Hello", new String[] {
                 "package com.example;",

--- a/compiler-project/mapreduce-testing/src/test/java/com/asakusafw/lang/compiler/mapreduce/testing/MapReduceRunnerTest.java
+++ b/compiler-project/mapreduce-testing/src/test/java/com/asakusafw/lang/compiler/mapreduce/testing/MapReduceRunnerTest.java
@@ -65,7 +65,7 @@ public class MapReduceRunnerTest {
                 new Configuration(),
                 Descriptions.classOf(SimpleClient.class),
                 "testing",
-                Collections.<String, String>emptyMap());
+                Collections.emptyMap());
         assertThat("exit status code", status, is(0));
         assertThat(collect("output"), contains("Hello, world!"));
     }
@@ -80,7 +80,7 @@ public class MapReduceRunnerTest {
                 new Configuration(),
                 new ClassDescription("___MISSING___"),
                 "testing",
-                Collections.<String, String>emptyMap());
+                Collections.emptyMap());
     }
 
     private List<String> collect(String path) {

--- a/compiler-project/mapreduce/src/main/java/com/asakusafw/lang/compiler/mapreduce/CleanupStageEmitter.java
+++ b/compiler-project/mapreduce/src/main/java/com/asakusafw/lang/compiler/mapreduce/CleanupStageEmitter.java
@@ -24,13 +24,10 @@ import com.asakusafw.lang.compiler.javac.JavaSourceExtension;
 import com.asakusafw.lang.compiler.model.description.ClassDescription;
 import com.asakusafw.runtime.stage.AbstractCleanupStageClient;
 import com.asakusafw.runtime.stage.BaseStageClient;
-import com.asakusafw.utils.java.model.syntax.Comment;
 import com.asakusafw.utils.java.model.syntax.CompilationUnit;
-import com.asakusafw.utils.java.model.syntax.FormalParameterDeclaration;
 import com.asakusafw.utils.java.model.syntax.Literal;
 import com.asakusafw.utils.java.model.syntax.MethodDeclaration;
 import com.asakusafw.utils.java.model.syntax.ModelFactory;
-import com.asakusafw.utils.java.model.syntax.Type;
 import com.asakusafw.utils.java.model.syntax.TypeBodyDeclaration;
 import com.asakusafw.utils.java.model.syntax.TypeDeclaration;
 import com.asakusafw.utils.java.model.util.AttributeBuilder;
@@ -78,7 +75,7 @@ public final class CleanupStageEmitter {
                 importer.getPackageDeclaration(),
                 importer.toImportDeclarations(),
                 Collections.singletonList(type),
-                Collections.<Comment>emptyList());
+                Collections.emptyList());
     }
 
     private TypeDeclaration generateType() {
@@ -92,7 +89,7 @@ public final class CleanupStageEmitter {
                     .toAttributes(),
                 f.newSimpleName(clientClass.getSimpleName()),
                 importer.toType(AbstractCleanupStageClient.class),
-                Collections.<Type>emptyList(),
+                Collections.emptyList(),
                 members);
     }
 
@@ -118,7 +115,7 @@ public final class CleanupStageEmitter {
                     .toAttributes(),
                 importer.toType(String.class),
                 f.newSimpleName(name),
-                Collections.<FormalParameterDeclaration>emptyList(),
+                Collections.emptyList(),
                 Collections.singletonList(f.newReturnStatement(literal)));
     }
 }

--- a/compiler-project/mapreduce/src/main/java/com/asakusafw/lang/compiler/mapreduce/CopyStageEmitter.java
+++ b/compiler-project/mapreduce/src/main/java/com/asakusafw/lang/compiler/mapreduce/CopyStageEmitter.java
@@ -27,12 +27,9 @@ import com.asakusafw.lang.compiler.mapreduce.CopyStageInfo.Operation;
 import com.asakusafw.lang.compiler.model.description.ClassDescription;
 import com.asakusafw.lang.compiler.model.description.Descriptions;
 import com.asakusafw.runtime.stage.preparator.PreparatorMapper;
-import com.asakusafw.utils.java.model.syntax.Comment;
 import com.asakusafw.utils.java.model.syntax.CompilationUnit;
-import com.asakusafw.utils.java.model.syntax.FormalParameterDeclaration;
 import com.asakusafw.utils.java.model.syntax.MethodDeclaration;
 import com.asakusafw.utils.java.model.syntax.ModelFactory;
-import com.asakusafw.utils.java.model.syntax.Type;
 import com.asakusafw.utils.java.model.syntax.TypeBodyDeclaration;
 import com.asakusafw.utils.java.model.syntax.TypeDeclaration;
 import com.asakusafw.utils.java.model.util.AttributeBuilder;
@@ -100,7 +97,7 @@ public final class CopyStageEmitter {
                 info.meta,
                 inputs,
                 outputs,
-                Collections.<MapReduceStageInfo.Resource>emptyList(),
+                Collections.emptyList(),
                 info.baseOutputPath);
     }
 
@@ -136,7 +133,7 @@ public final class CopyStageEmitter {
                     importer.getPackageDeclaration(),
                     importer.toImportDeclarations(),
                     Collections.singletonList(type),
-                    Collections.<Comment>emptyList());
+                    Collections.emptyList());
         }
 
         private TypeDeclaration generateType() {
@@ -151,7 +148,7 @@ public final class CopyStageEmitter {
                     f.newParameterizedType(
                             importer.toType(PreparatorMapper.class),
                             importer.toType(Object.class)),
-                    Collections.<Type>emptyList(),
+                    Collections.emptyList(),
                     members);
         }
 
@@ -164,7 +161,7 @@ public final class CopyStageEmitter {
                         .toAttributes(),
                     importer.toType(String.class),
                     f.newSimpleName(PreparatorMapper.NAME_GET_OUTPUT_NAME),
-                    Collections.<FormalParameterDeclaration>emptyList(),
+                    Collections.emptyList(),
                     Collections.singletonList(f.newReturnStatement(Models.toLiteral(f, operation.outputName))));
         }
     }

--- a/compiler-project/mapreduce/src/main/java/com/asakusafw/lang/compiler/mapreduce/MapReduceStageEmitter.java
+++ b/compiler-project/mapreduce/src/main/java/com/asakusafw/lang/compiler/mapreduce/MapReduceStageEmitter.java
@@ -32,10 +32,8 @@ import com.asakusafw.runtime.stage.StageInput;
 import com.asakusafw.runtime.stage.StageOutput;
 import com.asakusafw.runtime.stage.StageResource;
 import com.asakusafw.utils.java.model.syntax.ClassLiteral;
-import com.asakusafw.utils.java.model.syntax.Comment;
 import com.asakusafw.utils.java.model.syntax.CompilationUnit;
 import com.asakusafw.utils.java.model.syntax.Expression;
-import com.asakusafw.utils.java.model.syntax.FormalParameterDeclaration;
 import com.asakusafw.utils.java.model.syntax.Literal;
 import com.asakusafw.utils.java.model.syntax.MethodDeclaration;
 import com.asakusafw.utils.java.model.syntax.ModelFactory;
@@ -90,7 +88,7 @@ public final class MapReduceStageEmitter {
                 importer.getPackageDeclaration(),
                 importer.toImportDeclarations(),
                 Collections.singletonList(type),
-                Collections.<Comment>emptyList());
+                Collections.emptyList());
     }
 
     private TypeDeclaration generateType() {
@@ -108,7 +106,7 @@ public final class MapReduceStageEmitter {
                     .toAttributes(),
                 f.newSimpleName(clientClass.getSimpleName()),
                 importer.toType(AbstractStageClient.class),
-                Collections.<Type>emptyList(),
+                Collections.emptyList(),
                 members);
     }
 
@@ -291,7 +289,7 @@ public final class MapReduceStageEmitter {
                     .toAttributes(),
                 type,
                 f.newSimpleName(name),
-                Collections.<FormalParameterDeclaration>emptyList(),
+                Collections.emptyList(),
                 statements);
     }
 }

--- a/compiler-project/mapreduce/src/test/java/com/asakusafw/lang/compiler/mapreduce/CleanupStageEmitterTest.java
+++ b/compiler-project/mapreduce/src/test/java/com/asakusafw/lang/compiler/mapreduce/CleanupStageEmitterTest.java
@@ -73,7 +73,7 @@ public class CleanupStageEmitterTest {
                 new Configuration(),
                 client,
                 "testing",
-                Collections.<String, String>emptyMap(),
+                Collections.emptyMap(),
                 javac.compile());
         assertThat("exit status code", status, is(0));
 

--- a/compiler-project/mapreduce/src/test/java/com/asakusafw/lang/compiler/mapreduce/CopyStageEmitterTest.java
+++ b/compiler-project/mapreduce/src/test/java/com/asakusafw/lang/compiler/mapreduce/CopyStageEmitterTest.java
@@ -75,16 +75,16 @@ public class CopyStageEmitterTest {
                                 new Path(root, "input/*.txt").toString(),
                                 classOf(Text.class),
                                 classOf(TextInputFormat.class),
-                                Collections.<String, String>emptyMap()),
+                                Collections.emptyMap()),
                         classOf(TextOutputFormat.class),
-                        Collections.<String, String>emptyMap())),
+                        Collections.emptyMap())),
                 base.toString());
         CopyStageEmitter.emit(client, info, javac);
         int status = MapReduceRunner.execute(
                 new Configuration(),
                 client,
                 "testing",
-                Collections.<String, String>emptyMap(),
+                Collections.emptyMap(),
                 javac.compile());
         assertThat("exit status code", status, is(0));
 
@@ -113,27 +113,27 @@ public class CopyStageEmitterTest {
                                         new Path(root, "input/test0.txt").toString(),
                                         classOf(Text.class),
                                         classOf(TextInputFormat.class),
-                                        Collections.<String, String>emptyMap()),
+                                        Collections.emptyMap()),
                                 classOf(TextOutputFormat.class),
-                                Collections.<String, String>emptyMap()),
+                                Collections.emptyMap()),
                         new CopyStageInfo.Operation(
                                 "out1",
                                 new SourceInfo(
                                         new Path(root, "input/test1.txt").toString(),
                                         classOf(Text.class),
                                         classOf(TextInputFormat.class),
-                                        Collections.<String, String>emptyMap()),
+                                        Collections.emptyMap()),
                                 classOf(TextOutputFormat.class),
-                                Collections.<String, String>emptyMap()),
+                                Collections.emptyMap()),
                         new CopyStageInfo.Operation(
                                 "out2",
                                 new SourceInfo(
                                         new Path(root, "input/test2.txt").toString(),
                                         classOf(Text.class),
                                         classOf(TextInputFormat.class),
-                                        Collections.<String, String>emptyMap()),
+                                        Collections.emptyMap()),
                                 classOf(TextOutputFormat.class),
-                                Collections.<String, String>emptyMap()),
+                                Collections.emptyMap()),
                 }),
                 base.toString());
         CopyStageEmitter.emit(client, info, javac);
@@ -141,7 +141,7 @@ public class CopyStageEmitterTest {
                 new Configuration(),
                 client,
                 "testing",
-                Collections.<String, String>emptyMap(),
+                Collections.emptyMap(),
                 javac.compile());
         assertThat("exit status code", status, is(0));
 

--- a/compiler-project/mapreduce/src/test/java/com/asakusafw/lang/compiler/mapreduce/MapReduceStageEmitterTest.java
+++ b/compiler-project/mapreduce/src/test/java/com/asakusafw/lang/compiler/mapreduce/MapReduceStageEmitterTest.java
@@ -84,21 +84,21 @@ public class MapReduceStageEmitterTest {
                         classOf(Text.class),
                         classOf(TextInputFormat.class),
                         classOf(SimpleMapper.class),
-                        Collections.<String, String>emptyMap())),
+                        Collections.emptyMap())),
                 Arrays.asList(new MapReduceStageInfo.Output(
                         "out",
                         classOf(NullWritable.class),
                         classOf(Text.class),
                         classOf(TextOutputFormat.class),
-                        Collections.<String, String>emptyMap())),
-                Collections.<MapReduceStageInfo.Resource>emptyList(),
+                        Collections.emptyMap())),
+                Collections.emptyList(),
                 base.toString());
         MapReduceStageEmitter.emit(client, info, javac);
         int status = MapReduceRunner.execute(
                 new Configuration(),
                 client,
                 "testing",
-                Collections.<String, String>emptyMap(),
+                Collections.emptyMap(),
                 javac.compile());
         assertThat("exit status code", status, is(0));
         assertThat(collect("output"), contains("Hello, world!"));
@@ -121,14 +121,14 @@ public class MapReduceStageEmitterTest {
                         classOf(Text.class),
                         classOf(TextInputFormat.class),
                         classOf(Mapper.class),
-                        Collections.<String, String>emptyMap())),
+                        Collections.emptyMap())),
                 Arrays.asList(new MapReduceStageInfo.Output(
                         "out",
                         classOf(NullWritable.class),
                         classOf(Text.class),
                         classOf(TextOutputFormat.class),
-                        Collections.<String, String>emptyMap())),
-                Collections.<MapReduceStageInfo.Resource>emptyList(),
+                        Collections.emptyMap())),
+                Collections.emptyList(),
                 new MapReduceStageInfo.Shuffle(
                         classOf(LongWritable.class),
                         classOf(Text.class),
@@ -143,7 +143,7 @@ public class MapReduceStageEmitterTest {
                 new Configuration(),
                 client,
                 "testing",
-                Collections.<String, String>emptyMap(),
+                Collections.emptyMap(),
                 javac.compile());
         assertThat("exit status code", status, is(0));
         assertThat(collect("output"), contains("Hello, world!"));
@@ -167,13 +167,13 @@ public class MapReduceStageEmitterTest {
                         classOf(Text.class),
                         classOf(TextInputFormat.class),
                         classOf(ResourceMapper.class),
-                        Collections.<String, String>emptyMap())),
+                        Collections.emptyMap())),
                 Arrays.asList(new MapReduceStageInfo.Output(
                         "out",
                         classOf(NullWritable.class),
                         classOf(Text.class),
                         classOf(TextOutputFormat.class),
-                        Collections.<String, String>emptyMap())),
+                        Collections.emptyMap())),
                 Arrays.asList(new MapReduceStageInfo.Resource(
                         new Path(root, "resource/*.txt").toString(),
                         "resource")),
@@ -183,7 +183,7 @@ public class MapReduceStageEmitterTest {
                 new Configuration(),
                 client,
                 "testing",
-                Collections.<String, String>emptyMap(),
+                Collections.emptyMap(),
                 javac.compile());
         assertThat("exit status code", status, is(0));
         assertThat(collect("output"), contains("Hello, resource!"));

--- a/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/graph/Groups.java
+++ b/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/graph/Groups.java
@@ -87,7 +87,7 @@ public final class Groups {
      * @throws IllegalArgumentException if some expressions are unrecognized
      */
     public static Group parse(List<String> grouping) {
-        return parse(grouping, Collections.<String>emptyList());
+        return parse(grouping, Collections.emptyList());
     }
 
     /**

--- a/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/info/BatchInfo.java
+++ b/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/info/BatchInfo.java
@@ -191,7 +191,7 @@ public interface BatchInfo extends DescriptionInfo {
          */
         public Basic(String batchId, ClassDescription descriptionClass) {
             this(batchId, descriptionClass,
-                    null, Collections.<Parameter>emptyList(), Collections.<Attribute>emptyList());
+                    null, Collections.emptyList(), Collections.emptyList());
         }
 
         /**

--- a/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/info/ExternalInputInfo.java
+++ b/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/info/ExternalInputInfo.java
@@ -93,7 +93,7 @@ public interface ExternalInputInfo extends ExternalPortInfo {
                 String moduleName,
                 ClassDescription dataModelClass,
                 DataSize dataSize) {
-            this(descriptionClass, moduleName, dataModelClass, dataSize, Collections.<String>emptySet(), null);
+            this(descriptionClass, moduleName, dataModelClass, dataSize, Collections.emptySet(), null);
         }
 
         /**
@@ -110,7 +110,7 @@ public interface ExternalInputInfo extends ExternalPortInfo {
                 ClassDescription dataModelClass,
                 DataSize dataSize,
                 ValueDescription contents) {
-            this(descriptionClass, moduleName, dataModelClass, dataSize, Collections.<String>emptySet(), contents);
+            this(descriptionClass, moduleName, dataModelClass, dataSize, Collections.emptySet(), contents);
         }
 
         /**

--- a/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/info/ExternalOutputInfo.java
+++ b/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/info/ExternalOutputInfo.java
@@ -68,7 +68,7 @@ public interface ExternalOutputInfo extends ExternalPortInfo {
                 ClassDescription descriptionClass,
                 String moduleName,
                 ClassDescription dataModelClass) {
-            this(descriptionClass, moduleName, dataModelClass, Collections.<String>emptySet(), null);
+            this(descriptionClass, moduleName, dataModelClass, Collections.emptySet(), null);
         }
 
         /**
@@ -83,7 +83,7 @@ public interface ExternalOutputInfo extends ExternalPortInfo {
                 String moduleName,
                 ClassDescription dataModelClass,
                 ValueDescription contents) {
-            this(descriptionClass, moduleName, dataModelClass, Collections.<String>emptySet(), contents);
+            this(descriptionClass, moduleName, dataModelClass, Collections.emptySet(), contents);
         }
 
         /**
@@ -99,7 +99,7 @@ public interface ExternalOutputInfo extends ExternalPortInfo {
                 String moduleName,
                 ClassDescription dataModelClass,
                 Set<String> parameterNames) {
-            this(descriptionClass, moduleName, dataModelClass, Collections.<String>emptySet(), null);
+            this(descriptionClass, moduleName, dataModelClass, Collections.emptySet(), null);
         }
 
         /**
@@ -135,7 +135,7 @@ public interface ExternalOutputInfo extends ExternalPortInfo {
                 ClassDescription dataModelClass,
                 boolean generator,
                 Set<String> parameterNames) {
-            this(descriptionClass, moduleName, dataModelClass, generator, Collections.<String>emptySet(), null);
+            this(descriptionClass, moduleName, dataModelClass, generator, Collections.emptySet(), null);
         }
 
         /**

--- a/compiler-project/model/src/test/java/com/asakusafw/lang/compiler/model/graph/BatchTest.java
+++ b/compiler-project/model/src/test/java/com/asakusafw/lang/compiler/model/graph/BatchTest.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import org.junit.Test;
 
 import com.asakusafw.lang.compiler.model.description.ClassDescription;
-import com.asakusafw.lang.compiler.model.info.BatchInfo;
 
 /**
  * Test for {@link Batch}.
@@ -39,8 +38,8 @@ public class BatchTest {
                 "b0",
                 new ClassDescription("B0"),
                 null,
-                Collections.<BatchInfo.Parameter>emptyList(),
-                Collections.<BatchInfo.Attribute>emptyList());
+                Collections.emptyList(),
+                Collections.emptyList());
 
         assertThat(b0.toString(), b0.getBatchId(), is("b0"));
         assertThat(b0.toString(), b0.getDescriptionClass().getClassName(), is("B0"));

--- a/compiler-project/operator-project/core/src/main/java/com/asakusafw/lang/compiler/operator/flowpart/FlowPartFactoryEmitter.java
+++ b/compiler-project/operator-project/core/src/main/java/com/asakusafw/lang/compiler/operator/flowpart/FlowPartFactoryEmitter.java
@@ -47,12 +47,10 @@ import com.asakusafw.lang.compiler.operator.util.JavadocHelper;
 import com.asakusafw.utils.java.jsr269.bridge.Jsr269;
 import com.asakusafw.utils.java.model.syntax.ClassDeclaration;
 import com.asakusafw.utils.java.model.syntax.ClassLiteral;
-import com.asakusafw.utils.java.model.syntax.Comment;
 import com.asakusafw.utils.java.model.syntax.CompilationUnit;
 import com.asakusafw.utils.java.model.syntax.ConstructorDeclaration;
 import com.asakusafw.utils.java.model.syntax.Expression;
 import com.asakusafw.utils.java.model.syntax.FieldDeclaration;
-import com.asakusafw.utils.java.model.syntax.FormalParameterDeclaration;
 import com.asakusafw.utils.java.model.syntax.Javadoc;
 import com.asakusafw.utils.java.model.syntax.MethodDeclaration;
 import com.asakusafw.utils.java.model.syntax.ModelFactory;
@@ -156,7 +154,7 @@ public class FlowPartFactoryEmitter {
                     imports.getPackageDeclaration(),
                     imports.toImportDeclarations(),
                     Collections.singletonList(typeDecl),
-                    Collections.<Comment>emptyList());
+                    Collections.emptyList());
         }
 
         private ClassDeclaration generateClass() {
@@ -180,7 +178,7 @@ public class FlowPartFactoryEmitter {
                         .toAttributes(),
                     className,
                     null,
-                    Collections.<Type>emptyList(),
+                    Collections.emptyList(),
                     members);
         }
 
@@ -225,7 +223,7 @@ public class FlowPartFactoryEmitter {
                     generateNodeClassName(element),
                     ElementHelper.toTypeParameters(environment, typeElement.getTypeParameters(), imports),
                     null,
-                    Collections.<Type>emptyList(),
+                    Collections.emptyList(),
                     members);
         }
 
@@ -301,7 +299,7 @@ public class FlowPartFactoryEmitter {
                     f.newSimpleName(Constants.NAME_FLOW_PART_FACTORY_METHOD),
                     ElementHelper.toParameters(environment, element, imports),
                     0,
-                    Collections.<Type>emptyList(),
+                    Collections.emptyList(),
                     f.newBlock(new TypeBuilder(f, nodeType)
                         .newObject(ElementHelper.toArguments(environment, element, imports))
                         .toReturnStatement()));
@@ -316,7 +314,7 @@ public class FlowPartFactoryEmitter {
                         .Public()
                         .toAttributes(),
                     generateClassName(),
-                    Collections.<FormalParameterDeclaration>emptyList(),
+                    Collections.emptyList(),
                     Collections.singletonList(f.newReturnStatement()));
         }
 

--- a/compiler-project/operator-project/core/src/main/java/com/asakusafw/lang/compiler/operator/method/OperatorFactoryEmitter.java
+++ b/compiler-project/operator-project/core/src/main/java/com/asakusafw/lang/compiler/operator/method/OperatorFactoryEmitter.java
@@ -47,12 +47,10 @@ import com.asakusafw.lang.compiler.operator.util.JavadocHelper;
 import com.asakusafw.utils.java.jsr269.bridge.Jsr269;
 import com.asakusafw.utils.java.model.syntax.ClassDeclaration;
 import com.asakusafw.utils.java.model.syntax.ClassLiteral;
-import com.asakusafw.utils.java.model.syntax.Comment;
 import com.asakusafw.utils.java.model.syntax.CompilationUnit;
 import com.asakusafw.utils.java.model.syntax.ConstructorDeclaration;
 import com.asakusafw.utils.java.model.syntax.Expression;
 import com.asakusafw.utils.java.model.syntax.FieldDeclaration;
-import com.asakusafw.utils.java.model.syntax.FormalParameterDeclaration;
 import com.asakusafw.utils.java.model.syntax.Javadoc;
 import com.asakusafw.utils.java.model.syntax.MethodDeclaration;
 import com.asakusafw.utils.java.model.syntax.ModelFactory;
@@ -150,7 +148,7 @@ public class OperatorFactoryEmitter {
                     imports.getPackageDeclaration(),
                     imports.toImportDeclarations(),
                     Collections.singletonList(typeDecl),
-                    Collections.<Comment>emptyList());
+                    Collections.emptyList());
         }
 
         private ClassDeclaration generateClass() {
@@ -173,7 +171,7 @@ public class OperatorFactoryEmitter {
                         .toAttributes(),
                     className,
                     null,
-                    Collections.<Type>emptyList(),
+                    Collections.emptyList(),
                     members);
         }
 
@@ -217,7 +215,7 @@ public class OperatorFactoryEmitter {
                     generateNodeClassName(element),
                     ElementHelper.toTypeParameters(environment, element.getDeclaration().getTypeParameters(), imports),
                     null,
-                    Collections.<Type>emptyList(),
+                    Collections.emptyList(),
                     members);
         }
 
@@ -298,7 +296,7 @@ public class OperatorFactoryEmitter {
                     f.newSimpleName(element.getDeclaration().getSimpleName().toString()),
                     ElementHelper.toParameters(environment, element, imports),
                     0,
-                    Collections.<Type>emptyList(),
+                    Collections.emptyList(),
                     f.newBlock(new TypeBuilder(f, nodeType)
                         .newObject(ElementHelper.toArguments(environment, element, imports))
                         .toReturnStatement()));
@@ -313,7 +311,7 @@ public class OperatorFactoryEmitter {
                         .Public()
                         .toAttributes(),
                     generateClassName(),
-                    Collections.<FormalParameterDeclaration>emptyList(),
+                    Collections.emptyList(),
                     Collections.singletonList(f.newReturnStatement()));
         }
 

--- a/compiler-project/operator-project/core/src/main/java/com/asakusafw/lang/compiler/operator/method/OperatorImplementationEmitter.java
+++ b/compiler-project/operator-project/core/src/main/java/com/asakusafw/lang/compiler/operator/method/OperatorImplementationEmitter.java
@@ -44,9 +44,7 @@ import com.asakusafw.lang.compiler.operator.model.OperatorClass;
 import com.asakusafw.lang.compiler.operator.util.DescriptionHelper;
 import com.asakusafw.utils.java.jsr269.bridge.Jsr269;
 import com.asakusafw.utils.java.model.syntax.ArrayType;
-import com.asakusafw.utils.java.model.syntax.Attribute;
 import com.asakusafw.utils.java.model.syntax.ClassDeclaration;
-import com.asakusafw.utils.java.model.syntax.Comment;
 import com.asakusafw.utils.java.model.syntax.CompilationUnit;
 import com.asakusafw.utils.java.model.syntax.FormalParameterDeclaration;
 import com.asakusafw.utils.java.model.syntax.MethodDeclaration;
@@ -145,7 +143,7 @@ public class OperatorImplementationEmitter {
                     imports.getPackageDeclaration(),
                     imports.toImportDeclarations(),
                     Collections.singletonList(typeDecl),
-                    Collections.<Comment>emptyList());
+                    Collections.emptyList());
         }
 
         private ClassDeclaration generateClass() {
@@ -169,7 +167,7 @@ public class OperatorImplementationEmitter {
                         .toAttributes(),
                     className,
                     imports.resolve(converter.convert(superClass)),
-                    Collections.<Type>emptyList(),
+                    Collections.emptyList(),
                     members);
         }
 
@@ -182,7 +180,7 @@ public class OperatorImplementationEmitter {
                         .Public()
                         .toAttributes(),
                     generateClassName(),
-                    Collections.<FormalParameterDeclaration>emptyList(),
+                    Collections.emptyList(),
                     Collections.singletonList(f.newReturnStatement()));
         }
 
@@ -213,7 +211,7 @@ public class OperatorImplementationEmitter {
                     f.newSimpleName(method.getSimpleName().toString()),
                     toParameters(method),
                     0,
-                    Collections.<Type>emptyList(),
+                    Collections.emptyList(),
                     f.newBlock(new TypeBuilder(f, imports.toType(UnsupportedOperationException.class))
                         .newObject()
                         .toThrowStatement()));
@@ -231,7 +229,7 @@ public class OperatorImplementationEmitter {
                     type = ((ArrayType) type).getComponentType();
                 }
                 results.add(f.newFormalParameterDeclaration(
-                        Collections.<Attribute>emptyList(),
+                        Collections.emptyList(),
                         imports.resolve(type),
                         varArgs,
                         f.newSimpleName(var.getSimpleName().toString()),

--- a/compiler-project/operator-project/core/src/main/java/com/asakusafw/lang/compiler/operator/model/OperatorDescription.java
+++ b/compiler-project/operator-project/core/src/main/java/com/asakusafw/lang/compiler/operator/model/OperatorDescription.java
@@ -51,7 +51,7 @@ public class OperatorDescription {
             Document document,
             List<? extends Node> parameters,
             List<? extends Node> outputs) {
-        this(document, parameters, outputs, Collections.<EnumConstantDescription>emptyList());
+        this(document, parameters, outputs, Collections.emptyList());
     }
 
     /**

--- a/compiler-project/operator-project/core/src/main/java/com/asakusafw/lang/compiler/operator/util/JavadocHelper.java
+++ b/compiler-project/operator-project/core/src/main/java/com/asakusafw/lang/compiler/operator/util/JavadocHelper.java
@@ -81,7 +81,7 @@ public class JavadocHelper {
             appendBlock(tag, block.getElements());
         }
         if (sawSummary == false) {
-            appendBlock("", Collections.<DocElement>emptyList()); //$NON-NLS-1$
+            appendBlock("", Collections.emptyList()); //$NON-NLS-1$
         }
     }
 
@@ -95,13 +95,13 @@ public class JavadocHelper {
             environment.getProcessingEnvironment().getMessager().printMessage(Diagnostic.Kind.WARNING,
                     e.getMessage(),
                     element);
-            return Models.getModelFactory().newJavadoc(Collections.<DocBlock>emptyList());
+            return Models.getModelFactory().newJavadoc(Collections.emptyList());
         }
     }
 
     private Javadoc parseJavadoc(String comment) throws JavadocParseException {
         if (comment == null) {
-            return Models.getModelFactory().newJavadoc(Collections.<DocBlock>emptyList());
+            return Models.getModelFactory().newJavadoc(Collections.emptyList());
         }
         String string = comment;
         if (comment.startsWith("/**") == false) { //$NON-NLS-1$

--- a/compiler-project/operator-project/core/src/test/java/com/asakusafw/lang/compiler/operator/flowpart/FlowPartAnalyzerTest.java
+++ b/compiler-project/operator-project/core/src/test/java/com/asakusafw/lang/compiler/operator/flowpart/FlowPartAnalyzerTest.java
@@ -37,7 +37,6 @@ import com.asakusafw.lang.compiler.model.description.ClassDescription;
 import com.asakusafw.lang.compiler.operator.Callback;
 import com.asakusafw.lang.compiler.operator.CompileEnvironment;
 import com.asakusafw.lang.compiler.operator.OperatorCompilerTestRoot;
-import com.asakusafw.lang.compiler.operator.OperatorDriver;
 import com.asakusafw.lang.compiler.operator.StringDataModelMirrorRepository;
 import com.asakusafw.lang.compiler.operator.model.OperatorClass;
 import com.asakusafw.lang.compiler.operator.model.OperatorDescription;
@@ -427,7 +426,7 @@ public class FlowPartAnalyzerTest extends OperatorCompilerTestRoot {
         protected CompileEnvironment createCompileEnvironment(ProcessingEnvironment processingEnv) {
             return new CompileEnvironment(
                     processingEnv,
-                    Collections.<OperatorDriver>emptyList(),
+                    Collections.emptyList(),
                     Arrays.asList(new StringDataModelMirrorRepository())).withFlowpartExternalIo(true);
         }
 

--- a/compiler-project/operator-project/core/src/test/java/com/asakusafw/lang/compiler/operator/flowpart/FlowPartFactoryEmitterTest.java
+++ b/compiler-project/operator-project/core/src/test/java/com/asakusafw/lang/compiler/operator/flowpart/FlowPartFactoryEmitterTest.java
@@ -34,10 +34,8 @@ import com.asakusafw.lang.compiler.model.description.ClassDescription;
 import com.asakusafw.lang.compiler.operator.Callback;
 import com.asakusafw.lang.compiler.operator.CompileEnvironment;
 import com.asakusafw.lang.compiler.operator.Constants;
-import com.asakusafw.lang.compiler.operator.DataModelMirrorRepository;
 import com.asakusafw.lang.compiler.operator.MockSource;
 import com.asakusafw.lang.compiler.operator.OperatorCompilerTestRoot;
-import com.asakusafw.lang.compiler.operator.OperatorDriver;
 import com.asakusafw.lang.compiler.operator.model.OperatorClass;
 import com.asakusafw.lang.compiler.operator.model.OperatorDescription;
 import com.asakusafw.lang.compiler.operator.model.OperatorDescription.Document;
@@ -198,8 +196,8 @@ public class FlowPartFactoryEmitterTest extends OperatorCompilerTestRoot {
         protected CompileEnvironment createCompileEnvironment(ProcessingEnvironment processingEnv) {
             return new CompileEnvironment(
                     processingEnv,
-                    Collections.<OperatorDriver>emptyList(),
-                    Collections.<DataModelMirrorRepository>emptyList());
+                    Collections.emptyList(),
+                    Collections.emptyList());
         }
 
         @Override

--- a/compiler-project/operator-project/core/src/test/java/com/asakusafw/lang/compiler/operator/method/OperatorImplementationEmitterTest.java
+++ b/compiler-project/operator-project/core/src/test/java/com/asakusafw/lang/compiler/operator/method/OperatorImplementationEmitterTest.java
@@ -29,7 +29,6 @@ import com.asakusafw.lang.compiler.operator.Callback;
 import com.asakusafw.lang.compiler.operator.Constants;
 import com.asakusafw.lang.compiler.operator.OperatorCompilerTestRoot;
 import com.asakusafw.lang.compiler.operator.model.OperatorClass;
-import com.asakusafw.lang.compiler.operator.model.OperatorElement;
 
 /**
  * Test for {@link OperatorImplementationEmitter}.
@@ -90,7 +89,7 @@ public class OperatorImplementationEmitterTest extends OperatorCompilerTestRoot 
                 if (round.getRootElements().contains(element)) {
                     assertThat(name, element, is(notNullValue()));
                     OperatorImplementationEmitter emitter = new OperatorImplementationEmitter(env);
-                    emitter.emit(new OperatorClass(element, Collections.<OperatorElement>emptyList()));
+                    emitter.emit(new OperatorClass(element, Collections.emptyList()));
                 }
             }
         });

--- a/compiler-project/operator-project/core/src/test/java/com/asakusafw/lang/compiler/operator/method/OperatorMethodAnalyzerTest.java
+++ b/compiler-project/operator-project/core/src/test/java/com/asakusafw/lang/compiler/operator/method/OperatorMethodAnalyzerTest.java
@@ -34,7 +34,6 @@ import com.asakusafw.lang.compiler.model.description.ClassDescription;
 import com.asakusafw.lang.compiler.operator.AbstractOperatorDriver;
 import com.asakusafw.lang.compiler.operator.Callback;
 import com.asakusafw.lang.compiler.operator.CompileEnvironment;
-import com.asakusafw.lang.compiler.operator.DataModelMirrorRepository;
 import com.asakusafw.lang.compiler.operator.OperatorCompilerTestRoot;
 import com.asakusafw.lang.compiler.operator.model.OperatorClass;
 import com.asakusafw.lang.compiler.operator.model.OperatorDescription;
@@ -244,7 +243,7 @@ public class OperatorMethodAnalyzerTest extends OperatorCompilerTestRoot {
                     Arrays.asList(
                             new MockDriver("com.example.Mock"),
                             new MockDriver("com.example.Conflict")),
-                    Collections.<DataModelMirrorRepository>emptyList());
+                    Collections.emptyList());
         }
 
         @Override

--- a/compiler-project/operator-project/core/src/test/java/com/asakusafw/lang/compiler/operator/util/DescriptionHelperTest.java
+++ b/compiler-project/operator-project/core/src/test/java/com/asakusafw/lang/compiler/operator/util/DescriptionHelperTest.java
@@ -42,13 +42,10 @@ import com.asakusafw.lang.compiler.operator.OperatorCompilerTestRoot;
 import com.asakusafw.lang.compiler.operator.mock.MockMarker;
 import com.asakusafw.lang.compiler.operator.mock.MockNested;
 import com.asakusafw.lang.compiler.operator.mock.MockSingleElement;
-import com.asakusafw.utils.java.model.syntax.Comment;
 import com.asakusafw.utils.java.model.syntax.Expression;
-import com.asakusafw.utils.java.model.syntax.FormalParameterDeclaration;
 import com.asakusafw.utils.java.model.syntax.MethodDeclaration;
 import com.asakusafw.utils.java.model.syntax.ModelFactory;
 import com.asakusafw.utils.java.model.syntax.Type;
-import com.asakusafw.utils.java.model.syntax.TypeBodyDeclaration;
 import com.asakusafw.utils.java.model.syntax.TypeDeclaration;
 import com.asakusafw.utils.java.model.util.AttributeBuilder;
 import com.asakusafw.utils.java.model.util.ImportBuilder;
@@ -225,7 +222,7 @@ public class DescriptionHelperTest extends OperatorCompilerTestRoot {
                         new AttributeBuilder(f).Public().toAttributes(),
                         imports.toType(Object.class),
                         f.newSimpleName("call"),
-                        Collections.<FormalParameterDeclaration>emptyList(),
+                        Collections.emptyList(),
                         Collections.singletonList(f.newReturnStatement(f.newClassLiteral(target))));
                 TypeDeclaration type = f.newClassDeclaration(
                         null,
@@ -240,7 +237,7 @@ public class DescriptionHelperTest extends OperatorCompilerTestRoot {
                         imports.getPackageDeclaration(),
                         imports.toImportDeclarations(),
                         Collections.singletonList(type),
-                        Collections.<Comment>emptyList()));
+                        Collections.emptyList()));
             }
         });
         try {
@@ -268,7 +265,7 @@ public class DescriptionHelperTest extends OperatorCompilerTestRoot {
                         new AttributeBuilder(f).Public().toAttributes(),
                         imports.toType(Object.class),
                         f.newSimpleName("call"),
-                        Collections.<FormalParameterDeclaration>emptyList(),
+                        Collections.emptyList(),
                         Collections.singletonList(f.newReturnStatement(target)));
                 TypeDeclaration type = f.newClassDeclaration(
                         null,
@@ -283,7 +280,7 @@ public class DescriptionHelperTest extends OperatorCompilerTestRoot {
                         imports.getPackageDeclaration(),
                         imports.toImportDeclarations(),
                         Collections.singletonList(type),
-                        Collections.<Comment>emptyList()));
+                        Collections.emptyList()));
             }
         });
         try {
@@ -319,13 +316,13 @@ public class DescriptionHelperTest extends OperatorCompilerTestRoot {
                             .toAttributes(),
                         f.newSimpleName("Work"),
                         null,
-                        Collections.<Type>emptyList(),
-                        Collections.<TypeBodyDeclaration>emptyList());
+                        Collections.emptyList(),
+                        Collections.emptyList());
                 env.emit(f.newCompilationUnit(
                         imports.getPackageDeclaration(),
                         imports.toImportDeclarations(),
                         Collections.singletonList(type),
-                        Collections.<Comment>emptyList()));
+                        Collections.emptyList()));
             }
         });
         try {

--- a/compiler-project/packaging/src/test/java/com/asakusafw/lang/compiler/packaging/CompositeResourceRepositoryTest.java
+++ b/compiler-project/packaging/src/test/java/com/asakusafw/lang/compiler/packaging/CompositeResourceRepositoryTest.java
@@ -67,7 +67,7 @@ public class CompositeResourceRepositoryTest extends ResourceTestRoot {
      */
     @Test
     public void no_items() {
-        ResourceRepository repo = new CompositeResourceRepository(Collections.<ResourceRepository>emptyList());
+        ResourceRepository repo = new CompositeResourceRepository(Collections.emptyList());
         Map<String, String> results = dump(repo);
         assertThat(results.keySet(), hasSize(0));
     }

--- a/compiler-project/plan/src/test/java/com/asakusafw/lang/compiler/planning/PlanBuilderTest.java
+++ b/compiler-project/plan/src/test/java/com/asakusafw/lang/compiler/planning/PlanBuilderTest.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 
 import org.junit.Test;
 
-import com.asakusafw.lang.compiler.model.graph.Operator;
 import com.asakusafw.lang.compiler.model.testing.MockOperators;
 
 /**
@@ -285,7 +284,7 @@ public class PlanBuilderTest extends PlanningTestRoot {
             .marker("end", PlanMarker.END).connect("a", "end");
 
         PlanBuilder.from(mock.all())
-            .add(Collections.<Operator>emptySet(), mock.getAsSet("end"))
+            .add(Collections.emptySet(), mock.getAsSet("end"))
             .build();
     }
 
@@ -300,7 +299,7 @@ public class PlanBuilderTest extends PlanningTestRoot {
             .marker("end", PlanMarker.END).connect("a", "end");
 
         PlanBuilder.from(mock.all())
-            .add(mock.getAsSet("begin"), Collections.<Operator>emptySet())
+            .add(mock.getAsSet("begin"), Collections.emptySet())
             .build();
     }
 

--- a/compiler-project/tester/src/main/java/com/asakusafw/lang/compiler/tester/executor/BatchExecutor.java
+++ b/compiler-project/tester/src/main/java/com/asakusafw/lang/compiler/tester/executor/BatchExecutor.java
@@ -78,7 +78,7 @@ public class BatchExecutor implements ArtifactExecutor<BatchArtifact> {
 
     @Override
     public void execute(TesterContext context, BatchArtifact artifact) throws InterruptedException, IOException {
-        execute(context, artifact, Collections.<String, String>emptyMap());
+        execute(context, artifact, Collections.emptyMap());
     }
 
     @Override

--- a/compiler-project/tester/src/main/java/com/asakusafw/lang/compiler/tester/executor/HadoopTaskExecutor.java
+++ b/compiler-project/tester/src/main/java/com/asakusafw/lang/compiler/tester/executor/HadoopTaskExecutor.java
@@ -72,7 +72,7 @@ public class HadoopTaskExecutor implements TaskExecutor {
                 PATH_YAESS_HADOOP,
                 arguments,
                 task.getExtensions(),
-                Collections.<TaskReference>emptyList());
+                Collections.emptyList());
         delegate.execute(context, commandTask);
     }
 }

--- a/compiler-project/tester/src/main/java/com/asakusafw/lang/compiler/tester/executor/JobflowExecutor.java
+++ b/compiler-project/tester/src/main/java/com/asakusafw/lang/compiler/tester/executor/JobflowExecutor.java
@@ -101,7 +101,7 @@ public class JobflowExecutor implements ArtifactExecutor<JobflowArtifact> {
 
     @Override
     public void execute(TesterContext context, JobflowArtifact artifact) throws InterruptedException, IOException {
-        execute(context, artifact, Collections.<String, String>emptyMap());
+        execute(context, artifact, Collections.emptyMap());
     }
 
     @Override

--- a/compiler-project/tester/src/test/java/com/asakusafw/lang/compiler/tester/CompilerProfileTest.java
+++ b/compiler-project/tester/src/test/java/com/asakusafw/lang/compiler/tester/CompilerProfileTest.java
@@ -32,7 +32,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import com.asakusafw.lang.compiler.api.JobflowProcessor;
-import com.asakusafw.lang.compiler.api.reference.CommandToken;
 import com.asakusafw.lang.compiler.api.reference.TaskReference;
 import com.asakusafw.lang.compiler.api.reference.TaskReferenceMap;
 import com.asakusafw.lang.compiler.api.testing.MockBatchProcessor;
@@ -85,7 +84,7 @@ public class CompilerProfileTest {
                 public void process(Context context, Jobflow source) throws IOException {
                     context.addTask(
                             "testing", "testing",
-                            Location.of("testing"), Collections.<CommandToken>emptyList());
+                            Location.of("testing"), Collections.emptyList());
                 }
             });
 

--- a/compiler-project/tester/src/test/java/com/asakusafw/lang/compiler/tester/executor/BatchExecutorTest.java
+++ b/compiler-project/tester/src/test/java/com/asakusafw/lang/compiler/tester/executor/BatchExecutorTest.java
@@ -34,7 +34,6 @@ import com.asakusafw.lang.compiler.api.basic.BasicBatchReference;
 import com.asakusafw.lang.compiler.api.basic.BasicJobflowReference;
 import com.asakusafw.lang.compiler.api.basic.TaskContainerMap;
 import com.asakusafw.lang.compiler.api.reference.CommandTaskReference;
-import com.asakusafw.lang.compiler.api.reference.CommandToken;
 import com.asakusafw.lang.compiler.api.reference.JobflowReference;
 import com.asakusafw.lang.compiler.api.reference.TaskReference;
 import com.asakusafw.lang.compiler.common.Location;
@@ -178,9 +177,9 @@ public class BatchExecutorTest {
                 "testing",
                 "testing",
                 Location.of(id),
-                Collections.<CommandToken>emptyList(),
-                Collections.<String>emptySet(),
-                Collections.<TaskReference>emptyList());
+                Collections.emptyList(),
+                Collections.emptySet(),
+                Collections.emptyList());
     }
 
 
@@ -193,6 +192,6 @@ public class BatchExecutorTest {
     }
 
     private TesterContext context(File home) {
-        return new TesterContext(getClass().getClassLoader(), Collections.<String, String>emptyMap());
+        return new TesterContext(getClass().getClassLoader(), Collections.emptyMap());
     }
 }

--- a/compiler-project/tester/src/test/java/com/asakusafw/lang/compiler/tester/executor/CommandTaskExecutorTest.java
+++ b/compiler-project/tester/src/test/java/com/asakusafw/lang/compiler/tester/executor/CommandTaskExecutorTest.java
@@ -35,7 +35,6 @@ import org.junit.rules.TemporaryFolder;
 
 import com.asakusafw.lang.compiler.api.reference.CommandTaskReference;
 import com.asakusafw.lang.compiler.api.reference.CommandToken;
-import com.asakusafw.lang.compiler.api.reference.TaskReference;
 import com.asakusafw.lang.compiler.common.Location;
 import com.asakusafw.lang.compiler.common.testing.FileEditor;
 import com.asakusafw.lang.compiler.model.description.ClassDescription;
@@ -204,8 +203,8 @@ public class CommandTaskExecutorTest {
                 "testing",
                 Location.of(path),
                 Arrays.asList(args),
-                Collections.<String>emptySet(),
-                Collections.<TaskReference>emptyList());
+                Collections.emptySet(),
+                Collections.emptyList());
     }
 
     private Context context(File home) {

--- a/compiler-project/tester/src/test/java/com/asakusafw/lang/compiler/tester/executor/JobflowExecutorTest.java
+++ b/compiler-project/tester/src/test/java/com/asakusafw/lang/compiler/tester/executor/JobflowExecutorTest.java
@@ -32,8 +32,6 @@ import org.junit.rules.TemporaryFolder;
 import com.asakusafw.lang.compiler.api.basic.BasicJobflowReference;
 import com.asakusafw.lang.compiler.api.basic.TaskContainerMap;
 import com.asakusafw.lang.compiler.api.reference.CommandTaskReference;
-import com.asakusafw.lang.compiler.api.reference.CommandToken;
-import com.asakusafw.lang.compiler.api.reference.JobflowReference;
 import com.asakusafw.lang.compiler.api.reference.TaskReference;
 import com.asakusafw.lang.compiler.api.reference.TaskReferenceMap;
 import com.asakusafw.lang.compiler.common.Location;
@@ -225,7 +223,7 @@ public class JobflowExecutorTest {
         BasicJobflowReference reference = new BasicJobflowReference(
                 new JobflowInfo.Basic("FID", new ClassDescription("FID")),
                 tasks,
-                Collections.<JobflowReference>emptyList());
+                Collections.emptyList());
         return new JobflowArtifact(
                 new BatchInfo.Basic("BID", new ClassDescription("BID")),
                 reference,
@@ -237,8 +235,8 @@ public class JobflowExecutorTest {
                 "testing",
                 "testing",
                 Location.of(id),
-                Collections.<CommandToken>emptyList(),
-                Collections.<String>emptySet(),
+                Collections.emptyList(),
+                Collections.emptySet(),
                 Arrays.asList(blockers));
     }
 
@@ -251,6 +249,6 @@ public class JobflowExecutorTest {
     }
 
     private TesterContext context(File home) {
-        return new TesterContext(getClass().getClassLoader(), Collections.<String, String>emptyMap());
+        return new TesterContext(getClass().getClassLoader(), Collections.emptyMap());
     }
 }

--- a/inspection-project/processor/src/main/java/com/asakusafw/lang/inspection/processor/InspectionNodeProcessor.java
+++ b/inspection-project/processor/src/main/java/com/asakusafw/lang/inspection/processor/InspectionNodeProcessor.java
@@ -47,7 +47,7 @@ public interface InspectionNodeProcessor {
          * Creates a new instance w/ empty options.
          */
         public Context() {
-            this(Collections.<String, String>emptyMap());
+            this(Collections.emptyMap());
         }
 
         /**


### PR DESCRIPTION
## Summary

This PR fixes code style for Java8.

## Background, Problem or Goal of the patch

N/A.

## Design of the fix, or a new feature

This includes the following revisions:
* adds several `@FunctionalInterface`
* removes redundant type parameters (e.g. `f(Collections.<String>emptyList())`)
* introduces `ThreadLocal.withInitial` instead of anonymous classes of `ThreadLocal`

## Related Issue, Pull Request or Code

* #72 

## Wanted reviewer

N/A.