### PR TITLE
Fix code style for Java 8.

### DIFF
--- a/bridge-project/runtime-adapter/src/main/java/com/asakusafw/bridge/adapter/ResourceBrokerAdapter.java
+++ b/bridge-project/runtime-adapter/src/main/java/com/asakusafw/bridge/adapter/ResourceBrokerAdapter.java
@@ -18,7 +18,6 @@ package com.asakusafw.bridge.adapter;
 import java.io.IOException;
 
 import com.asakusafw.bridge.broker.ResourceBroker;
-import com.asakusafw.bridge.broker.ResourceBroker.Initializer;
 import com.asakusafw.bridge.broker.ResourceBroker.Scope;
 import com.asakusafw.bridge.broker.ResourceSession;
 import com.asakusafw.bridge.stage.StageInfo;
@@ -34,21 +33,18 @@ public class ResourceBrokerAdapter implements RuntimeResource {
     private ResourceSession current;
 
     @Override
-    public void setup(final ResourceConfiguration configuration) throws IOException, InterruptedException {
-        current = ResourceBroker.attach(Scope.THREAD, new Initializer() {
-            @Override
-            public void accept(ResourceSession session) throws IOException {
-                StageInfo info = new StageInfo(
-                        configuration.get(StageConstants.PROP_USER, System.getProperty("user.name")), //$NON-NLS-1$
-                        configuration.get(StageConstants.PROP_BATCH_ID, null),
-                        configuration.get(StageConstants.PROP_FLOW_ID, null),
-                        null, // no stage ID info
-                        configuration.get(StageConstants.PROP_EXECUTION_ID, null),
-                        configuration.get(StageConstants.PROP_ASAKUSA_BATCH_ARGS, null));
+    public void setup(ResourceConfiguration configuration) throws IOException, InterruptedException {
+        current = ResourceBroker.attach(Scope.THREAD, session -> {
+            StageInfo info = new StageInfo(
+                    configuration.get(StageConstants.PROP_USER, System.getProperty("user.name")), //$NON-NLS-1$
+                    configuration.get(StageConstants.PROP_BATCH_ID, null),
+                    configuration.get(StageConstants.PROP_FLOW_ID, null),
+                    null, // no stage ID info
+                    configuration.get(StageConstants.PROP_EXECUTION_ID, null),
+                    configuration.get(StageConstants.PROP_ASAKUSA_BATCH_ARGS, null));
 
-                session.put(ResourceConfiguration.class, configuration);
-                session.put(StageInfo.class, info);
-            }
+            session.put(ResourceConfiguration.class, configuration);
+            session.put(StageInfo.class, info);
         });
     }
 

--- a/bridge-project/runtime-directio/src/test/java/com/asakusafw/bridge/directio/api/DirectIoTest.java
+++ b/bridge-project/runtime-directio/src/test/java/com/asakusafw/bridge/directio/api/DirectIoTest.java
@@ -159,22 +159,12 @@ public class DirectIoTest {
         }
 
         @Override
-        public long getPreferredFragmentSize() {
-            return -1;
-        }
-
-        @Override
-        public long getMinimumFragmentSize() {
-            return -1;
-        }
-
-        @Override
         public ModelInput<StringBuilder> createInput(
                 Class<? extends StringBuilder> dataType, String path,
                 InputStream stream, long offset, long fragmentSize)
                 throws IOException, InterruptedException {
             assertThat(offset, is(0L));
-            final Scanner scanner = new Scanner(stream, "UTF-8");
+            Scanner scanner = new Scanner(stream, "UTF-8");
             return new ModelInput<StringBuilder>() {
                 @Override
                 public boolean readTo(StringBuilder model) throws IOException {

--- a/bridge-project/runtime-hadoop/src/test/java/com/asakusafw/bridge/hadoop/ModelInputRecordReaderTest.java
+++ b/bridge-project/runtime-hadoop/src/test/java/com/asakusafw/bridge/hadoop/ModelInputRecordReaderTest.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.NullWritable;
@@ -85,12 +86,12 @@ public class ModelInputRecordReaderTest {
         assertThat(collector.results, containsInAnyOrder("Hello1", "Hello2", "Hello3"));
     }
 
-    static class StringCollector implements InputFormatTester.Collector<StringBuilder> {
+    static class StringCollector implements Consumer<StringBuilder> {
 
         final Set<String> results = new HashSet<>();
 
         @Override
-        public void handle(StringBuilder object) {
+        public void accept(StringBuilder object) {
             results.add(object.toString());
         }
     }

--- a/bridge-project/runtime-hadoop/src/test/java/com/asakusafw/bridge/hadoop/directio/DirectFileInputFormatTest.java
+++ b/bridge-project/runtime-hadoop/src/test/java/com/asakusafw/bridge/hadoop/directio/DirectFileInputFormatTest.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 import com.asakusafw.bridge.hadoop.ConfigurationEditor;
 import com.asakusafw.bridge.stage.StageInfo;
 import com.asakusafw.lang.compiler.mapreduce.testing.InputFormatTester;
-import com.asakusafw.lang.compiler.mapreduce.testing.InputFormatTester.Collector;
 import com.asakusafw.lang.compiler.mapreduce.testing.mock.DirectIoContext;
 import com.asakusafw.lang.compiler.mapreduce.testing.mock.MockData;
 import com.asakusafw.lang.compiler.mapreduce.testing.mock.MockDataFormat;
@@ -47,7 +46,7 @@ public class DirectFileInputFormatTest {
      * context for testing.
      */
     @Rule
-    public DirectIoContext context = new DirectIoContext();
+    public final DirectIoContext context = new DirectIoContext();
 
     /**
      * simple case.
@@ -151,13 +150,8 @@ public class DirectFileInputFormatTest {
 
     private Map<Integer, String> collect(Configuration conf) throws IOException, InterruptedException {
         InputFormatTester tester = new InputFormatTester(conf, DirectFileInputFormat.class);
-        final Map<Integer, String> results = new LinkedHashMap<>();
-        tester.collect(new Collector<MockData>() {
-            @Override
-            public void handle(MockData object) {
-                results.put(object.getKey(), object.getValue());
-            }
-        });
+        Map<Integer, String> results = new LinkedHashMap<>();
+        tester.collect((MockData object) -> results.put(object.getKey(), object.getValue()));
         return results;
     }
 

--- a/bridge-project/runtime/src/main/java/com/asakusafw/bridge/broker/ResourceBroker.java
+++ b/bridge-project/runtime/src/main/java/com/asakusafw/bridge/broker/ResourceBroker.java
@@ -201,6 +201,7 @@ public final class ResourceBroker {
     /**
      * Initializes resource sessions.
      */
+    @FunctionalInterface
     public interface Initializer {
 
         /**

--- a/bridge-project/runtime/src/test/java/com/asakusafw/bridge/broker/ResourceSessionContainerTest.java
+++ b/bridge-project/runtime/src/test/java/com/asakusafw/bridge/broker/ResourceSessionContainerTest.java
@@ -18,7 +18,6 @@ package com.asakusafw.bridge.broker;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -106,15 +105,12 @@ public class ResourceSessionContainerTest {
         container.create(Scope.THREAD).close();
     }
 
-    private boolean createConcurrent(final ResourceSessionContainer container, final Scope scope) {
+    private boolean createConcurrent(ResourceSessionContainer container, Scope scope) {
         ExecutorService executor = Executors.newFixedThreadPool(1);
         try {
-            Future<Boolean> future = executor.submit(new Callable<Boolean>() {
-                @Override
-                public Boolean call() throws Exception {
-                    try (ResourceSession session = container.create(scope)) {
-                        return session != null;
-                    }
+            Future<Boolean> future = executor.submit(() -> {
+                try (ResourceSession session = container.create(scope)) {
+                    return session != null;
                 }
             });
             return future.get();

--- a/compiler-project/analyzer/src/main/java/com/asakusafw/lang/compiler/analyzer/OperatorAttributeAnalyzer.java
+++ b/compiler-project/analyzer/src/main/java/com/asakusafw/lang/compiler/analyzer/OperatorAttributeAnalyzer.java
@@ -28,18 +28,13 @@ import com.asakusafw.lang.compiler.model.graph.Operator.AbstractBuilder;
  * Analyzes extra operator attributes from the original declarations.
  * @since 0.3.0
  */
+@FunctionalInterface
 public interface OperatorAttributeAnalyzer {
 
     /**
      * A null implementation of {@link OperatorAttributeAnalyzer} that always returns an empty map.
      */
-    OperatorAttributeAnalyzer NULL = new OperatorAttributeAnalyzer() {
-
-        @Override
-        public AttributeMap analyze(OperatorSource source) {
-            return new AttributeMap();
-        }
-    };
+    OperatorAttributeAnalyzer NULL = source -> new AttributeMap();
 
     /**
      * Extracts attributes from the target operator source.

--- a/compiler-project/analyzer/src/test/java/com/asakusafw/lang/compiler/analyzer/OperatorGraphInspector.java
+++ b/compiler-project/analyzer/src/test/java/com/asakusafw/lang/compiler/analyzer/OperatorGraphInspector.java
@@ -100,7 +100,7 @@ public class OperatorGraphInspector {
      * @param name the port name
      * @return this
      */
-    public OperatorGraphInspector input(String id, final String name) {
+    public OperatorGraphInspector input(String id, String name) {
         return identify(id, argument -> {
             if (argument.getOperatorKind() != OperatorKind.INPUT) {
                 return false;
@@ -115,7 +115,7 @@ public class OperatorGraphInspector {
      * @param name the port name
      * @return this
      */
-    public OperatorGraphInspector output(String id, final String name) {
+    public OperatorGraphInspector output(String id, String name) {
         return identify(id, argument -> {
             if (argument.getOperatorKind() != OperatorKind.OUTPUT) {
                 return false;
@@ -130,7 +130,7 @@ public class OperatorGraphInspector {
      * @param description the description
      * @return this
      */
-    public OperatorGraphInspector flowpart(String id, final Class<?> description) {
+    public OperatorGraphInspector flowpart(String id, Class<?> description) {
         return identify(id, argument -> {
             if (argument.getOperatorKind() != OperatorKind.FLOW) {
                 return false;
@@ -149,7 +149,7 @@ public class OperatorGraphInspector {
      * @param kind the core operator kind
      * @return this
      */
-    public OperatorGraphInspector operator(String id, final CoreOperatorKind kind) {
+    public OperatorGraphInspector operator(String id, CoreOperatorKind kind) {
         return identify(id, argument -> {
             if (argument.getOperatorKind() != OperatorKind.CORE) {
                 return false;
@@ -164,7 +164,7 @@ public class OperatorGraphInspector {
      * @param operatorId the operator ID specified in {@link MockOperator#id()}
      * @return this
      */
-    public OperatorGraphInspector operator(String id, final String operatorId) {
+    public OperatorGraphInspector operator(String id, String operatorId) {
         return identify(id, argument -> {
             if (argument.getOperatorKind() != OperatorKind.USER) {
                 return false;
@@ -193,7 +193,7 @@ public class OperatorGraphInspector {
      * @param methodName the operator method name
      * @return this
      */
-    public OperatorGraphInspector operator(String id, final Class<?> operatorClass, final String methodName) {
+    public OperatorGraphInspector operator(String id, Class<?> operatorClass, String methodName) {
         return identify(id, argument -> {
             if (argument.getOperatorKind() != OperatorKind.USER) {
                 return false;

--- a/compiler-project/analyzer/src/test/java/com/asakusafw/lang/compiler/analyzer/OperatorGraphInspector.java
+++ b/compiler-project/analyzer/src/test/java/com/asakusafw/lang/compiler/analyzer/OperatorGraphInspector.java
@@ -25,8 +25,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
-import com.asakusafw.lang.compiler.common.Predicate;
 import com.asakusafw.lang.compiler.model.description.ClassDescription;
 import com.asakusafw.lang.compiler.model.description.MethodDescription;
 import com.asakusafw.lang.compiler.model.graph.CoreOperator;
@@ -101,14 +101,11 @@ public class OperatorGraphInspector {
      * @return this
      */
     public OperatorGraphInspector input(String id, final String name) {
-        return identify(id, new Predicate<Operator>() {
-            @Override
-            public boolean apply(Operator argument) {
-                if (argument.getOperatorKind() != OperatorKind.INPUT) {
-                    return false;
-                }
-                return ((ExternalPort) argument).getName().equals(name);
+        return identify(id, argument -> {
+            if (argument.getOperatorKind() != OperatorKind.INPUT) {
+                return false;
             }
+            return ((ExternalPort) argument).getName().equals(name);
         });
     }
 
@@ -119,14 +116,11 @@ public class OperatorGraphInspector {
      * @return this
      */
     public OperatorGraphInspector output(String id, final String name) {
-        return identify(id, new Predicate<Operator>() {
-            @Override
-            public boolean apply(Operator argument) {
-                if (argument.getOperatorKind() != OperatorKind.OUTPUT) {
-                    return false;
-                }
-                return ((ExternalPort) argument).getName().equals(name);
+        return identify(id, argument -> {
+            if (argument.getOperatorKind() != OperatorKind.OUTPUT) {
+                return false;
             }
+            return ((ExternalPort) argument).getName().equals(name);
         });
     }
 
@@ -137,18 +131,15 @@ public class OperatorGraphInspector {
      * @return this
      */
     public OperatorGraphInspector flowpart(String id, final Class<?> description) {
-        return identify(id, new Predicate<Operator>() {
-            @Override
-            public boolean apply(Operator argument) {
-                if (argument.getOperatorKind() != OperatorKind.FLOW) {
-                    return false;
-                }
-                ClassDescription desc = ((FlowOperator) argument).getDescriptionClass();
-                if (desc.getBinaryName().equals(description.getName()) == false) {
-                    return false;
-                }
-                return true;
+        return identify(id, argument -> {
+            if (argument.getOperatorKind() != OperatorKind.FLOW) {
+                return false;
             }
+            ClassDescription desc = ((FlowOperator) argument).getDescriptionClass();
+            if (desc.getBinaryName().equals(description.getName()) == false) {
+                return false;
+            }
+            return true;
         });
     }
 
@@ -159,14 +150,11 @@ public class OperatorGraphInspector {
      * @return this
      */
     public OperatorGraphInspector operator(String id, final CoreOperatorKind kind) {
-        return identify(id, new Predicate<Operator>() {
-            @Override
-            public boolean apply(Operator argument) {
-                if (argument.getOperatorKind() != OperatorKind.CORE) {
-                    return false;
-                }
-                return ((CoreOperator) argument).getCoreOperatorKind() == kind;
+        return identify(id, argument -> {
+            if (argument.getOperatorKind() != OperatorKind.CORE) {
+                return false;
             }
+            return ((CoreOperator) argument).getCoreOperatorKind() == kind;
         });
     }
 
@@ -177,26 +165,23 @@ public class OperatorGraphInspector {
      * @return this
      */
     public OperatorGraphInspector operator(String id, final String operatorId) {
-        return identify(id, new Predicate<Operator>() {
-            @Override
-            public boolean apply(Operator argument) {
-                if (argument.getOperatorKind() != OperatorKind.USER) {
+        return identify(id, argument -> {
+            if (argument.getOperatorKind() != OperatorKind.USER) {
+                return false;
+            }
+            MethodDescription method = ((UserOperator) argument).getMethod();
+            try {
+                Method resolved = method.resolve(getClass().getClassLoader());
+                MockOperator annotation = resolved.getAnnotation(MockOperator.class);
+                if (annotation == null) {
                     return false;
                 }
-                MethodDescription method = ((UserOperator) argument).getMethod();
-                try {
-                    Method resolved = method.resolve(getClass().getClassLoader());
-                    MockOperator annotation = resolved.getAnnotation(MockOperator.class);
-                    if (annotation == null) {
-                        return false;
-                    }
-                    if (annotation.id().equals(operatorId) == false) {
-                        return false;
-                    }
-                    return true;
-                } catch (NoSuchMethodException e) {
-                    throw new AssertionError(e);
+                if (annotation.id().equals(operatorId) == false) {
+                    return false;
                 }
+                return true;
+            } catch (NoSuchMethodException e) {
+                throw new AssertionError(e);
             }
         });
     }
@@ -209,21 +194,18 @@ public class OperatorGraphInspector {
      * @return this
      */
     public OperatorGraphInspector operator(String id, final Class<?> operatorClass, final String methodName) {
-        return identify(id, new Predicate<Operator>() {
-            @Override
-            public boolean apply(Operator argument) {
-                if (argument.getOperatorKind() != OperatorKind.USER) {
-                    return false;
-                }
-                MethodDescription method = ((UserOperator) argument).getMethod();
-                if (method.getDeclaringClass().getBinaryName().equals(operatorClass.getName()) == false) {
-                    return false;
-                }
-                if (method.getName().equals(methodName) == false) {
-                    return false;
-                }
-                return true;
+        return identify(id, argument -> {
+            if (argument.getOperatorKind() != OperatorKind.USER) {
+                return false;
             }
+            MethodDescription method = ((UserOperator) argument).getMethod();
+            if (method.getDeclaringClass().getBinaryName().equals(operatorClass.getName()) == false) {
+                return false;
+            }
+            if (method.getName().equals(methodName) == false) {
+                return false;
+            }
+            return true;
         });
     }
 
@@ -378,7 +360,7 @@ public class OperatorGraphInspector {
     private Set<Operator> findAll(Predicate<Operator> predicate) {
         Set<Operator> results = new HashSet<>(2);
         for (Operator operator : operators) {
-            if (predicate.apply(operator)) {
+            if (predicate.test(operator)) {
                 results.add(operator);
             }
         }

--- a/compiler-project/analyzer/src/test/java/com/asakusafw/lang/compiler/analyzer/builtin/BuiltInOptimizerTestRoot.java
+++ b/compiler-project/analyzer/src/test/java/com/asakusafw/lang/compiler/analyzer/builtin/BuiltInOptimizerTestRoot.java
@@ -129,7 +129,7 @@ public abstract class BuiltInOptimizerTestRoot {
      * @param methodName the target method name
      * @return the matcher
      */
-    public Matcher<OperatorGraph> hasOperator(final String methodName) {
+    public Matcher<OperatorGraph> hasOperator(String methodName) {
         return new BaseMatcher<OperatorGraph>() {
             @Override
             public boolean matches(Object item) {
@@ -158,7 +158,7 @@ public abstract class BuiltInOptimizerTestRoot {
      * @param kind the target operator kind
      * @return the matcher
      */
-    public Matcher<OperatorGraph> hasOperator(final CoreOperatorKind kind) {
+    public Matcher<OperatorGraph> hasOperator(CoreOperatorKind kind) {
         return new BaseMatcher<OperatorGraph>() {
             @Override
             public boolean matches(Object item) {

--- a/compiler-project/api/src/main/java/com/asakusafw/lang/compiler/api/BatchProcessor.java
+++ b/compiler-project/api/src/main/java/com/asakusafw/lang/compiler/api/BatchProcessor.java
@@ -28,6 +28,7 @@ import com.asakusafw.lang.compiler.common.Location;
 /**
  * Processes an Asakusa batch application.
  */
+@FunctionalInterface
 public interface BatchProcessor {
 
     /**

--- a/compiler-project/api/src/main/java/com/asakusafw/lang/compiler/api/DataModelLoader.java
+++ b/compiler-project/api/src/main/java/com/asakusafw/lang/compiler/api/DataModelLoader.java
@@ -22,6 +22,7 @@ import com.asakusafw.lang.compiler.model.description.TypeDescription;
 /**
  * Provides {@link DataModelReference}.
  */
+@FunctionalInterface
 public interface DataModelLoader {
 
     /**

--- a/compiler-project/api/src/main/java/com/asakusafw/lang/compiler/api/JobflowProcessor.java
+++ b/compiler-project/api/src/main/java/com/asakusafw/lang/compiler/api/JobflowProcessor.java
@@ -35,6 +35,7 @@ import com.asakusafw.lang.compiler.model.info.ExternalOutputInfo;
 /**
  * Processes operator graphs in jobflow.
  */
+@FunctionalInterface
 public interface JobflowProcessor {
 
     /**

--- a/compiler-project/cli/src/main/java/com/asakusafw/lang/compiler/cli/BatchCompilerCli.java
+++ b/compiler-project/cli/src/main/java/com/asakusafw/lang/compiler/cli/BatchCompilerCli.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import org.apache.commons.cli.BasicParser;
@@ -49,7 +50,6 @@ import com.asakusafw.lang.compiler.api.ExternalPortProcessor;
 import com.asakusafw.lang.compiler.api.JobflowProcessor;
 import com.asakusafw.lang.compiler.common.Diagnostic;
 import com.asakusafw.lang.compiler.common.DiagnosticException;
-import com.asakusafw.lang.compiler.common.Predicate;
 import com.asakusafw.lang.compiler.common.Predicates;
 import com.asakusafw.lang.compiler.core.AnalyzerContext;
 import com.asakusafw.lang.compiler.core.BatchCompiler;
@@ -565,13 +565,8 @@ public final class BatchCompilerCli {
 
     private static Predicate<? super Class<?>> loadPredicate(
             AnalyzerContext root, Configuration configuration, final ClassAnalyzer analyzer) {
-        final ClassAnalyzer.Context context = new ClassAnalyzer.Context(root);
-        Predicate<Class<?>> predicate = new Predicate<Class<?>>() {
-            @Override
-            public boolean apply(Class<?> argument) {
-                return analyzer.isBatchClass(context, argument);
-            }
-        };
+        ClassAnalyzer.Context context = new ClassAnalyzer.Context(root);
+        Predicate<Class<?>> predicate = aClass -> analyzer.isBatchClass(context, aClass);
         for (Predicate<? super Class<?>> p : configuration.sourcePredicate) {
             predicate = Predicates.and(predicate, p);
         }

--- a/compiler-project/cli/src/main/java/com/asakusafw/lang/compiler/cli/BatchCompilerCli.java
+++ b/compiler-project/cli/src/main/java/com/asakusafw/lang/compiler/cli/BatchCompilerCli.java
@@ -564,7 +564,7 @@ public final class BatchCompilerCli {
     }
 
     private static Predicate<? super Class<?>> loadPredicate(
-            AnalyzerContext root, Configuration configuration, final ClassAnalyzer analyzer) {
+            AnalyzerContext root, Configuration configuration, ClassAnalyzer analyzer) {
         ClassAnalyzer.Context context = new ClassAnalyzer.Context(root);
         Predicate<Class<?>> predicate = aClass -> analyzer.isBatchClass(context, aClass);
         for (Predicate<? super Class<?>> p : configuration.sourcePredicate) {

--- a/compiler-project/cli/src/main/java/com/asakusafw/lang/compiler/cli/ClassNamePredicate.java
+++ b/compiler-project/cli/src/main/java/com/asakusafw/lang/compiler/cli/ClassNamePredicate.java
@@ -15,12 +15,11 @@
  */
 package com.asakusafw.lang.compiler.cli;
 
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.asakusafw.lang.compiler.common.Predicate;
 
 /**
  * Predicate of class names.
@@ -70,7 +69,7 @@ public class ClassNamePredicate implements Predicate<Class<?>> {
     }
 
     @Override
-    public boolean apply(Class<?> argument) {
+    public boolean test(Class<?> argument) {
         String name = argument.getName();
         boolean match = pattern.matcher(name).matches();
         if (LOG.isDebugEnabled()) {

--- a/compiler-project/cli/src/test/java/com/asakusafw/lang/compiler/cli/BatchCompilerCliTest.java
+++ b/compiler-project/cli/src/test/java/com/asakusafw/lang/compiler/cli/BatchCompilerCliTest.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -50,7 +51,6 @@ import com.asakusafw.lang.compiler.cli.mock.DummyJobflowProcessor;
 import com.asakusafw.lang.compiler.common.Diagnostic;
 import com.asakusafw.lang.compiler.common.DiagnosticException;
 import com.asakusafw.lang.compiler.common.Location;
-import com.asakusafw.lang.compiler.common.Predicate;
 import com.asakusafw.lang.compiler.common.Predicates;
 import com.asakusafw.lang.compiler.common.testing.FileDeployer;
 import com.asakusafw.lang.compiler.core.BatchCompiler;
@@ -159,9 +159,9 @@ public class BatchCompilerCliTest {
         assertThat(conf.batchIdPrefix, contains("prefix."));
 
         Predicate<? super Class<?>> p = predicate(conf.sourcePredicate);
-        assertThat(p.apply(ByteBuffer.class), is(true));
-        assertThat(p.apply(ByteChannel.class), is(false));
-        assertThat(p.apply(StringBuffer.class), is(false));
+        assertThat(p.test(ByteBuffer.class), is(true));
+        assertThat(p.test(ByteChannel.class), is(false));
+        assertThat(p.test(StringBuffer.class), is(false));
 
         assertThat(conf.properties, hasEntry("a", "b"));
         assertThat(conf.properties, hasEntry("c", "d"));
@@ -179,11 +179,11 @@ public class BatchCompilerCliTest {
                 "--include", "*.String*,*Buffer",
         }));
         Predicate<? super Class<?>> p = predicate(conf.sourcePredicate);
-        assertThat(p.apply(String.class), is(true));
-        assertThat(p.apply(StringBuilder.class), is(true));
-        assertThat(p.apply(ByteBuffer.class), is(true));
-        assertThat(p.apply(Integer.class), is(false));
-        assertThat(p.apply(ByteChannel.class), is(false));
+        assertThat(p.test(String.class), is(true));
+        assertThat(p.test(StringBuilder.class), is(true));
+        assertThat(p.test(ByteBuffer.class), is(true));
+        assertThat(p.test(Integer.class), is(false));
+        assertThat(p.test(ByteChannel.class), is(false));
     }
 
     /**
@@ -198,11 +198,11 @@ public class BatchCompilerCliTest {
                 "--exclude", "*.String*,*Buffer",
         }));
         Predicate<? super Class<?>> p = predicate(conf.sourcePredicate);
-        assertThat(p.apply(String.class), is(false));
-        assertThat(p.apply(StringBuilder.class), is(false));
-        assertThat(p.apply(ByteBuffer.class), is(false));
-        assertThat(p.apply(Integer.class), is(true));
-        assertThat(p.apply(ByteChannel.class), is(true));
+        assertThat(p.test(String.class), is(false));
+        assertThat(p.test(StringBuilder.class), is(false));
+        assertThat(p.test(ByteBuffer.class), is(false));
+        assertThat(p.test(Integer.class), is(true));
+        assertThat(p.test(ByteChannel.class), is(true));
     }
 
     /**

--- a/compiler-project/cli/src/test/java/com/asakusafw/lang/compiler/cli/BatchCompilerCliTest.java
+++ b/compiler-project/cli/src/test/java/com/asakusafw/lang/compiler/cli/BatchCompilerCliTest.java
@@ -55,7 +55,6 @@ import com.asakusafw.lang.compiler.common.Predicates;
 import com.asakusafw.lang.compiler.common.testing.FileDeployer;
 import com.asakusafw.lang.compiler.core.BatchCompiler;
 import com.asakusafw.lang.compiler.core.util.CompositeElement;
-import com.asakusafw.lang.compiler.model.graph.Batch;
 import com.asakusafw.lang.compiler.packaging.ResourceRepository;
 import com.asakusafw.lang.compiler.packaging.ResourceUtil;
 
@@ -221,7 +220,7 @@ public class BatchCompilerCliTest {
      */
     @Test
     public void execute_minimal() throws Exception {
-        final File output = deployer.newFolder();
+        File output = deployer.newFolder();
         String[] args = strings(new Object[] {
                 "--explore", files(ResourceUtil.findLibraryByClass(DummyBatch.class)),
                 "--output", output,
@@ -230,15 +229,12 @@ public class BatchCompilerCliTest {
                 "--include", classes(DummyBatch.class),
                 "--externalPortProcessors", classes(DummyExternalPortProcessor.class),
         });
-        final AtomicInteger count = new AtomicInteger();
-        int status = execute(args, new BatchCompiler() {
-            @Override
-            public void compile(Context context, Batch batch) {
-                count.incrementAndGet();
-                assertThat(batch.getBatchId(), is("DummyBatch"));
-                assertThat(batch.getDescriptionClass(), is(classOf(DummyBatch.class)));
-                assertThat(context.getOutput().getBasePath(), is(new File(output, batch.getBatchId())));
-            }
+        AtomicInteger count = new AtomicInteger();
+        int status = execute(args, (context, batch) -> {
+            count.incrementAndGet();
+            assertThat(batch.getBatchId(), is("DummyBatch"));
+            assertThat(batch.getDescriptionClass(), is(classOf(DummyBatch.class)));
+            assertThat(context.getOutput().getBasePath(), is(new File(output, batch.getBatchId())));
         });
         assertThat(status, is(0));
         assertThat(count.get(), is(1));
@@ -250,11 +246,11 @@ public class BatchCompilerCliTest {
      */
     @Test
     public void execute_full() throws Exception {
-        final File output = deployer.newFolder();
-        final File explore = prepareLibrary("explore");
-        final File external = prepareLibrary("external");
-        final File embed = prepareLibrary("embed");
-        final File attach = prepareLibrary("attach");
+        File output = deployer.newFolder();
+        File explore = prepareLibrary("explore");
+        File external = prepareLibrary("external");
+        File embed = prepareLibrary("embed");
+        File attach = prepareLibrary("attach");
         String[] args = strings(new Object[] {
                 "--explore", files(ResourceUtil.findLibraryByClass(DummyBatch.class), explore),
                 "--output", output,
@@ -275,42 +271,39 @@ public class BatchCompilerCliTest {
                 "-P", "a=b",
                 "-property", "c=d",
         });
-        final AtomicInteger count = new AtomicInteger();
-        int status = execute(args, new BatchCompiler() {
-            @Override
-            public void compile(Context context, Batch batch) {
-                count.incrementAndGet();
-                assertThat(batch.getBatchId(), is("prefix.DummyBatch"));
-                assertThat(batch.getDescriptionClass(), is(classOf(DummyBatch.class)));
-                assertThat(context.getOutput().getBasePath(), is(new File(output, batch.getBatchId())));
+        AtomicInteger count = new AtomicInteger();
+        int status = execute(args, (context, batch) -> {
+            count.incrementAndGet();
+            assertThat(batch.getBatchId(), is("prefix.DummyBatch"));
+            assertThat(batch.getDescriptionClass(), is(classOf(DummyBatch.class)));
+            assertThat(context.getOutput().getBasePath(), is(new File(output, batch.getBatchId())));
 
-                assertThat(context.getProject().getClassLoader().getResource("explore"), is(notNullValue()));
-                assertThat(context.getProject().getClassLoader().getResource("embed"), is(notNullValue()));
-                assertThat(context.getProject().getClassLoader().getResource("attach"), is(notNullValue()));
-                assertThat(context.getProject().getClassLoader().getResource("external"), is(notNullValue()));
+            assertThat(context.getProject().getClassLoader().getResource("explore"), is(notNullValue()));
+            assertThat(context.getProject().getClassLoader().getResource("embed"), is(notNullValue()));
+            assertThat(context.getProject().getClassLoader().getResource("attach"), is(notNullValue()));
+            assertThat(context.getProject().getClassLoader().getResource("external"), is(notNullValue()));
 
-                assertThat(context.getProject().getProjectContents(), includes("explore"));
-                assertThat(context.getProject().getProjectContents(), not(includes("embed")));
-                assertThat(context.getProject().getProjectContents(), not(includes("attach")));
-                assertThat(context.getProject().getProjectContents(), not(includes("external")));
+            assertThat(context.getProject().getProjectContents(), includes("explore"));
+            assertThat(context.getProject().getProjectContents(), not(includes("embed")));
+            assertThat(context.getProject().getProjectContents(), not(includes("attach")));
+            assertThat(context.getProject().getProjectContents(), not(includes("external")));
 
-                // --explore -> implicitly embedded
-                assertThat(context.getProject().getEmbeddedContents(), includes("explore"));
-                assertThat(context.getProject().getEmbeddedContents(), includes("embed"));
-                assertThat(context.getProject().getEmbeddedContents(), not(includes("attach")));
-                assertThat(context.getProject().getEmbeddedContents(), not(includes("external")));
+            // --explore -> implicitly embedded
+            assertThat(context.getProject().getEmbeddedContents(), includes("explore"));
+            assertThat(context.getProject().getEmbeddedContents(), includes("embed"));
+            assertThat(context.getProject().getEmbeddedContents(), not(includes("attach")));
+            assertThat(context.getProject().getEmbeddedContents(), not(includes("external")));
 
-                assertThat(context.getProject().getAttachedLibraries(), not(deepIncludes("explore")));
-                assertThat(context.getProject().getAttachedLibraries(), not(deepIncludes("embed")));
-                assertThat(context.getProject().getAttachedLibraries(), deepIncludes("attach"));
-                assertThat(context.getProject().getAttachedLibraries(), not(deepIncludes("external")));
+            assertThat(context.getProject().getAttachedLibraries(), not(deepIncludes("explore")));
+            assertThat(context.getProject().getAttachedLibraries(), not(deepIncludes("embed")));
+            assertThat(context.getProject().getAttachedLibraries(), deepIncludes("attach"));
+            assertThat(context.getProject().getAttachedLibraries(), not(deepIncludes("external")));
 
-                assertThat(context.getTools().getDataModelProcessor(), is(consistsOf(DummyDataModelProcessor.class)));
-                assertThat(context.getTools().getExternalPortProcessor(), is(consistsOf(DummyExternalPortProcessor.class)));
-                assertThat(context.getTools().getBatchProcessor(), is(consistsOf(DummyBatchProcessor.class)));
-                assertThat(context.getTools().getJobflowProcessor(), is(consistsOf(DummyJobflowProcessor.class)));
-                assertThat(context.getTools().getParticipant(), is(consistsOf(DummyCompilerParticipant.class)));
-            }
+            assertThat(context.getTools().getDataModelProcessor(), is(consistsOf(DummyDataModelProcessor.class)));
+            assertThat(context.getTools().getExternalPortProcessor(), is(consistsOf(DummyExternalPortProcessor.class)));
+            assertThat(context.getTools().getBatchProcessor(), is(consistsOf(DummyBatchProcessor.class)));
+            assertThat(context.getTools().getJobflowProcessor(), is(consistsOf(DummyJobflowProcessor.class)));
+            assertThat(context.getTools().getParticipant(), is(consistsOf(DummyCompilerParticipant.class)));
         });
         assertThat(status, is(0));
         assertThat(count.get(), is(1));
@@ -322,7 +315,7 @@ public class BatchCompilerCliTest {
      */
     @Test
     public void execute_scoped_properties() throws Exception {
-        final File output = deployer.newFolder();
+        File output = deployer.newFolder();
         String[] args = strings(new Object[] {
                 "--explore", files(ResourceUtil.findLibraryByClass(DummyBatch.class)),
                 "--output", output,
@@ -337,16 +330,13 @@ public class BatchCompilerCliTest {
                 "-P", "DummyBatch:c=C",
                 "-P", "other:a=INVALID",
         });
-        final AtomicInteger count = new AtomicInteger();
-        int status = execute(args, new BatchCompiler() {
-            @Override
-            public void compile(Context context, Batch batch) {
-                count.incrementAndGet();
-                CompilerOptions options = context.getOptions();
-                assertThat(options.get("a", "?"), is("A"));
-                assertThat(options.get("b", "?"), is("!"));
-                assertThat(options.get("c", "?"), is("C"));
-            }
+        AtomicInteger count = new AtomicInteger();
+        int status = execute(args, (context, batch) -> {
+            count.incrementAndGet();
+            CompilerOptions options = context.getOptions();
+            assertThat(options.get("a", "?"), is("A"));
+            assertThat(options.get("b", "?"), is("!"));
+            assertThat(options.get("c", "?"), is("C"));
         });
         assertThat(status, is(0));
         assertThat(count.get(), is(1));
@@ -358,7 +348,7 @@ public class BatchCompilerCliTest {
      */
     @Test
     public void execute_conflict_batch() throws Exception {
-        final File output = deployer.newFolder();
+        File output = deployer.newFolder();
         String[] args = strings(new Object[] {
                 "--explore", files(ResourceUtil.findLibraryByClass(DummyBatch.class)),
                 "--output", output,
@@ -368,11 +358,8 @@ public class BatchCompilerCliTest {
                 "--externalPortProcessors", classes(DummyExternalPortProcessor.class),
                 "--failOnError",
         });
-        int status = execute(args, new BatchCompiler() {
-            @Override
-            public void compile(Context context, Batch batch) {
-                // do nothing
-            }
+        int status = execute(args, (context, batch) -> {
+            // do nothing
         });
         assertThat(status, is(not(0)));
     }
@@ -388,7 +375,7 @@ public class BatchCompilerCliTest {
     }
 
     static Matcher<List<ResourceRepository>> includes(String id) {
-        final Location location = Location.of(id);
+        Location location = Location.of(id);
         return new BaseMatcher<List<ResourceRepository>>() {
             @Override
             public boolean matches(Object item) {
@@ -414,7 +401,7 @@ public class BatchCompilerCliTest {
         };
     }
 
-    static Matcher<List<ResourceRepository>> deepIncludes(final String id) {
+    static Matcher<List<ResourceRepository>> deepIncludes(String id) {
         return new BaseMatcher<List<ResourceRepository>>() {
             @Override
             public boolean matches(Object item) {
@@ -448,7 +435,7 @@ public class BatchCompilerCliTest {
         };
     }
 
-    static Matcher<Object> consistsOf(final Class<?> type) {
+    static Matcher<Object> consistsOf(Class<?> type) {
         return new BaseMatcher<Object>() {
             @Override
             public boolean matches(Object item) {
@@ -480,7 +467,7 @@ public class BatchCompilerCliTest {
      */
     @Test
     public void compile_error() throws Exception {
-        final File output = deployer.newFolder();
+        File output = deployer.newFolder();
         String[] args = strings(new Object[] {
                 "--explore", files(ResourceUtil.findLibraryByClass(DummyBatch.class)),
                 "--output", output,
@@ -489,11 +476,8 @@ public class BatchCompilerCliTest {
                 "--include", classes(DummyBatch.class),
                 "--externalPortProcessors", classes(DummyExternalPortProcessor.class),
         });
-        int status = execute(args, new BatchCompiler() {
-            @Override
-            public void compile(Context context, Batch batch) {
-                throw new DiagnosticException(Diagnostic.Level.ERROR, "testing");
-            }
+        int status = execute(args, (context, batch) -> {
+            throw new DiagnosticException(Diagnostic.Level.ERROR, "testing");
         });
         assertThat(status, is(not(0)));
     }

--- a/compiler-project/cli/src/test/java/com/asakusafw/lang/compiler/cli/ClassNamePredicateTest.java
+++ b/compiler-project/cli/src/test/java/com/asakusafw/lang/compiler/cli/ClassNamePredicateTest.java
@@ -34,9 +34,9 @@ public class ClassNamePredicateTest {
     @Test
     public void literal() {
         ClassNamePredicate predicate = ClassNamePredicate.parse("java.lang.String");
-        assertThat(predicate.apply(String.class), is(true));
-        assertThat(predicate.apply(Object.class), is(false));
-        assertThat(predicate.apply(List.class), is(false));
+        assertThat(predicate.test(String.class), is(true));
+        assertThat(predicate.test(Object.class), is(false));
+        assertThat(predicate.test(List.class), is(false));
     }
 
     /**
@@ -45,9 +45,9 @@ public class ClassNamePredicateTest {
     @Test
     public void trailing() {
         ClassNamePredicate predicate = ClassNamePredicate.parse("java.lang.*");
-        assertThat(predicate.apply(String.class), is(true));
-        assertThat(predicate.apply(Object.class), is(true));
-        assertThat(predicate.apply(List.class), is(false));
+        assertThat(predicate.test(String.class), is(true));
+        assertThat(predicate.test(Object.class), is(true));
+        assertThat(predicate.test(List.class), is(false));
     }
 
     /**
@@ -56,9 +56,9 @@ public class ClassNamePredicateTest {
     @Test
     public void first() {
         ClassNamePredicate predicate = ClassNamePredicate.parse("*Buffer");
-        assertThat(predicate.apply(StringBuffer.class), is(true));
-        assertThat(predicate.apply(ByteBuffer.class), is(true));
-        assertThat(predicate.apply(StringBuilder.class), is(false));
+        assertThat(predicate.test(StringBuffer.class), is(true));
+        assertThat(predicate.test(ByteBuffer.class), is(true));
+        assertThat(predicate.test(StringBuilder.class), is(false));
     }
 
     /**
@@ -67,9 +67,9 @@ public class ClassNamePredicateTest {
     @Test
     public void middle() {
         ClassNamePredicate predicate = ClassNamePredicate.parse("java.*Buffer");
-        assertThat(predicate.apply(StringBuffer.class), is(true));
-        assertThat(predicate.apply(ByteBuffer.class), is(true));
-        assertThat(predicate.apply(StringBuilder.class), is(false));
+        assertThat(predicate.test(StringBuffer.class), is(true));
+        assertThat(predicate.test(ByteBuffer.class), is(true));
+        assertThat(predicate.test(StringBuilder.class), is(false));
     }
 
     /**
@@ -78,8 +78,8 @@ public class ClassNamePredicateTest {
     @Test
     public void multiple() {
         ClassNamePredicate predicate = ClassNamePredicate.parse("*.util.*");
-        assertThat(predicate.apply(List.class), is(true));
-        assertThat(predicate.apply(java.util.Date.class), is(true));
-        assertThat(predicate.apply(java.sql.Date.class), is(false));
+        assertThat(predicate.test(List.class), is(true));
+        assertThat(predicate.test(java.util.Date.class), is(true));
+        assertThat(predicate.test(java.sql.Date.class), is(false));
     }
 }

--- a/compiler-project/common/pom.xml
+++ b/compiler-project/common/pom.xml
@@ -10,6 +10,17 @@
   </parent>
 
   <packaging>jar</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <configuration>
+          <excludeFilterFile>src/conf/findbugs/exclude.xml</excludeFilterFile>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
   <dependencies>
     <dependency>

--- a/compiler-project/common/src/conf/findbugs/exclude.xml
+++ b/compiler-project/common/src/conf/findbugs/exclude.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <Match class="com.asakusafw.lang.compiler.common.Predicate">
+    <Bug pattern="NM_SAME_SIMPLE_NAME_AS_INTERFACE" />
+  </Match>
+</FindBugsFilter>

--- a/compiler-project/common/src/main/java/com/asakusafw/lang/compiler/common/ComplexAttribute.java
+++ b/compiler-project/common/src/main/java/com/asakusafw/lang/compiler/common/ComplexAttribute.java
@@ -20,6 +20,7 @@ import java.util.Map;
 /**
  * Represents an attribute which contains nested values.
  */
+@FunctionalInterface
 public interface ComplexAttribute {
 
     /**

--- a/compiler-project/common/src/main/java/com/asakusafw/lang/compiler/common/NamePattern.java
+++ b/compiler-project/common/src/main/java/com/asakusafw/lang/compiler/common/NamePattern.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.compiler.common;
+
+import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Represents name pattern.
+ * @since 0.4.0
+ */
+public class NamePattern implements Predicate<CharSequence> {
+
+    /**
+     * The wildcard character.
+     */
+    public static final char WILDCARD = '*';
+
+    /**
+     * The empty pattern which rejects any names.
+     */
+    public static final NamePattern EMPTY = new NamePattern(Collections.emptySet());
+
+    private final Set<String> alternatives;
+
+    private final Predicate<CharSequence> delegate;
+
+    /**
+     * Creates a new instance.
+     * @param alternatives the pattern elements
+     */
+    public NamePattern(String... alternatives) {
+        this(Arrays.asList(Objects.requireNonNull(alternatives)));
+    }
+
+    /**
+     * Creates a new instance.
+     * @param alternatives the pattern elements
+     */
+    public NamePattern(Collection<String> alternatives) {
+        Objects.requireNonNull(alternatives);
+        this.alternatives = alternatives.stream()
+                .map(String::trim)
+                .filter(s -> s.isEmpty() == false)
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toCollection(TreeSet::new),
+                        Collections::unmodifiableSortedSet));
+        this.delegate = build(this.alternatives);
+    }
+
+    private static Predicate<CharSequence> build(Collection<String> elements) {
+        List<String> compiled = elements.stream()
+                .map(NamePattern::compile)
+                .collect(Collectors.toList());
+        if (compiled.isEmpty()) {
+            return s -> false;
+        }
+        Pattern pattern = Pattern.compile(String.join("|", compiled));
+        return s -> pattern.matcher(s).matches();
+    }
+
+    private static String compile(String pattern) {
+        StringBuilder buf = new StringBuilder();
+        int start = 0;
+        while (true) {
+            int found = pattern.indexOf(WILDCARD, start);
+            if (found < 0) {
+                break;
+            }
+            buf.append(quote(pattern, start, found));
+            buf.append(".*"); //$NON-NLS-1$
+            start = found + 1;
+        }
+        buf.append(quote(pattern, start, pattern.length()));
+        return buf.toString();
+    }
+
+    private static String quote(String pattern, int start, int end) {
+        if (start == end) {
+            return ""; //$NON-NLS-1$
+        }
+        String sub = pattern.substring(start, end);
+        for (char c : sub.toCharArray()) {
+            if (isMeta(c)) {
+                return Pattern.quote(sub);
+            }
+        }
+        return sub;
+    }
+
+    private static boolean isMeta(char c) {
+        boolean known = ('0' <= c && c <= '9')
+                || ('A' <= c && c <= 'Z')
+                || ('a' <= c && c <= 'z')
+                || c == '-'
+                || c == '_'
+                || c == ' ';
+        return known == false;
+    }
+
+    @Override
+    public boolean test(CharSequence t) {
+        return delegate.test(t);
+    }
+
+    /**
+     * Returns the pattern elements.
+     * @return the pattern elements
+     */
+    public Set<String> getAlternatives() {
+        return alternatives;
+    }
+
+    @Override
+    public String toString() {
+        return MessageFormat.format(
+                "NamePattern({0})", //$NON-NLS-1$
+                getAlternatives().stream()
+                    .map(s -> String.format("'%s'", s)) //$NON-NLS-1$
+                    .collect(Collectors.joining(", "))); //$NON-NLS-1$
+    }
+}

--- a/compiler-project/common/src/main/java/com/asakusafw/lang/compiler/common/Predicate.java
+++ b/compiler-project/common/src/main/java/com/asakusafw/lang/compiler/common/Predicate.java
@@ -18,8 +18,13 @@ package com.asakusafw.lang.compiler.common;
 /**
  * Represents a predicate.
  * @param <T> member type
+ * @deprecated Use {@link java.util.function.Predicate} instead
+ * @since 0.1.0
+ * @version 0.4.0
  */
-public interface Predicate<T> {
+@Deprecated
+@FunctionalInterface
+public interface Predicate<T> extends java.util.function.Predicate<T> {
 
     /**
      * Returns whether the argument satisfies this predicate or not.
@@ -27,4 +32,9 @@ public interface Predicate<T> {
      * @return {@code true} if the argument satisfies this, otherwise {@code false}
      */
     boolean apply(T argument);
+
+    @Override
+    default boolean test(T t) {
+        return apply(t);
+    }
 }

--- a/compiler-project/common/src/main/java/com/asakusafw/lang/compiler/common/Predicates.java
+++ b/compiler-project/common/src/main/java/com/asakusafw/lang/compiler/common/Predicates.java
@@ -17,9 +17,12 @@ package com.asakusafw.lang.compiler.common;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * Utilities for {@link Predicate}.
+ * @since 0.1.0
+ * @version 0.4.0
  */
 public final class Predicates {
 
@@ -33,12 +36,7 @@ public final class Predicates {
      * @return {@code TRUE} predicate
      */
     public static <T> Predicate<T> anything() {
-        return new Predicate<T>() {
-            @Override
-            public boolean apply(T argument) {
-                return true;
-            }
-        };
+        return argument -> true;
     }
 
     /**
@@ -47,7 +45,7 @@ public final class Predicates {
      * @return {@code FALSE} predicate
      */
     public static <T> Predicate<T> nothing() {
-        return not(anything());
+        return arguments -> false;
     }
 
     /**
@@ -56,13 +54,8 @@ public final class Predicates {
      * @param p the predicate
      * @return {@code NOT} predicate
      */
-    public static <T> Predicate<T> not(final Predicate<? super T> p) {
-        return new Predicate<T>() {
-            @Override
-            public boolean apply(T argument) {
-                return !p.apply(argument);
-            }
-        };
+    public static <T> Predicate<T> not(Predicate<? super T> p) {
+        return argument -> !p.test(argument);
     }
 
     /**
@@ -75,9 +68,9 @@ public final class Predicates {
     public static <T> Predicate<T> and(Predicate<? super T> a, Predicate<? super T> b) {
         return new Composite<T>("All", a, b) { //$NON-NLS-1$
             @Override
-            public boolean apply(T argument) {
+            public boolean test(T argument) {
                 for (Predicate<? super T> p : elements) {
-                    if (p.apply(argument) == false) {
+                    if (p.test(argument) == false) {
                         return false;
                     }
                 }
@@ -96,9 +89,9 @@ public final class Predicates {
     public static <T> Predicate<T> or(final Predicate<? super T> a, final Predicate<? super T> b) {
         return new Composite<T>("Exists", a, b) { //$NON-NLS-1$
             @Override
-            public boolean apply(T argument) {
+            public boolean test(T argument) {
                 for (Predicate<? super T> p : elements) {
-                    if (p.apply(argument)) {
+                    if (p.test(argument)) {
                         return true;
                     }
                 }

--- a/compiler-project/common/src/main/java/com/asakusafw/lang/compiler/common/Predicates.java
+++ b/compiler-project/common/src/main/java/com/asakusafw/lang/compiler/common/Predicates.java
@@ -86,7 +86,7 @@ public final class Predicates {
      * @param b the second predicate
      * @return {@code OR} predicate
      */
-    public static <T> Predicate<T> or(final Predicate<? super T> a, final Predicate<? super T> b) {
+    public static <T> Predicate<T> or(Predicate<? super T> a, Predicate<? super T> b) {
         return new Composite<T>("Exists", a, b) { //$NON-NLS-1$
             @Override
             public boolean test(T argument) {

--- a/compiler-project/common/src/main/java/com/asakusafw/lang/compiler/common/ResourceContainer.java
+++ b/compiler-project/common/src/main/java/com/asakusafw/lang/compiler/common/ResourceContainer.java
@@ -21,6 +21,7 @@ import java.io.OutputStream;
 /**
  * An abstract super interface of resource containers.
  */
+@FunctionalInterface
 public interface ResourceContainer {
 
     /**

--- a/compiler-project/common/src/test/java/com/asakusafw/lang/compiler/common/NamePatternTest.java
+++ b/compiler-project/common/src/test/java/com/asakusafw/lang/compiler/common/NamePatternTest.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.compiler.common;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.junit.Test;
+
+/**
+ * Test for {@link NamePattern}.
+ */
+public class NamePatternTest {
+
+    /**
+     * simple case.
+     */
+    @Test
+    public void simple() {
+        NamePattern p = p("simple");
+        assertThat(p.getAlternatives(), containsInAnyOrder("simple"));
+        assertThat(p, accepts("simple"));
+        assertThat(p, not(accepts("other")));
+    }
+
+    /**
+     * w/ multiple alternatives.
+     */
+    @Test
+    public void multiple() {
+        NamePattern p = p("a", "b", "c");
+        assertThat(p.getAlternatives(), containsInAnyOrder("a", "b", "c"));
+        assertThat(p, accepts("a", "b", "c"));
+        assertThat(p, not(accepts("d")));
+    }
+
+    /**
+     * w/ wildcard.
+     */
+    @Test
+    public void wildcard() {
+        NamePattern p = p("*");
+        assertThat(p.getAlternatives(), containsInAnyOrder("*"));
+        assertThat(p, accepts("", "a", "anything"));
+    }
+
+    /**
+     * w/ partial wildcard.
+     */
+    @Test
+    public void wildcard_partial() {
+        NamePattern p = p("a-*-b");
+        assertThat(p.getAlternatives(), containsInAnyOrder("a-*-b"));
+        assertThat(p, accepts("a--b", "a-c-b", "a-anything-b"));
+        assertThat(p, not(accepts("a", "b-b-b", "a-a-a")));
+    }
+
+    /**
+     * w/ dot (not a wildcard).
+     */
+    @Test
+    public void dot() {
+        NamePattern p = p(".");
+        assertThat(p.getAlternatives(), containsInAnyOrder("."));
+        assertThat(p, accepts("."));
+        assertThat(p, not(accepts("a")));
+    }
+
+    /**
+     * w/ meta-characters.
+     */
+    @Test
+    public void meta() {
+        NamePattern p = p("(something)");
+        assertThat(p.getAlternatives(), containsInAnyOrder("(something)"));
+        assertThat(p, accepts("(something)"));
+        assertThat(p, not(accepts("something")));
+    }
+
+    private static NamePattern p(String... alternatives) {
+        return new NamePattern(alternatives);
+    }
+
+    private static Matcher<Predicate<CharSequence>> accepts(String... samples) {
+        return new BaseMatcher<Predicate<CharSequence>>() {
+            @Override
+            public boolean matches(Object item) {
+                @SuppressWarnings("unchecked")
+                Predicate<? super CharSequence> predicate = (Predicate<? super CharSequence>) item;
+                return Stream.of(samples)
+                        .anyMatch(predicate);
+            }
+            @Override
+            public void describeTo(Description description) {
+                // TODO Auto-generated method stub
+            }
+        };
+    }
+}

--- a/compiler-project/common/src/test/java/com/asakusafw/lang/compiler/common/PredicatesTest.java
+++ b/compiler-project/common/src/test/java/com/asakusafw/lang/compiler/common/PredicatesTest.java
@@ -18,6 +18,8 @@ package com.asakusafw.lang.compiler.common;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
+import java.util.function.Predicate;
+
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 import org.junit.Test;
@@ -36,7 +38,7 @@ public class PredicatesTest {
      */
     @Test
     public void anything() {
-        assertThat(T.apply("a"), is(true));
+        assertThat(T.test("a"), is(true));
     }
 
     /**
@@ -44,7 +46,7 @@ public class PredicatesTest {
      */
     @Test
     public void nothing() {
-        assertThat(F.apply("a"), is(false));
+        assertThat(F.test("a"), is(false));
     }
 
     /**
@@ -79,10 +81,10 @@ public class PredicatesTest {
     }
 
     private Matcher<Predicate<Object>> eq(Predicate<Object> p) {
-        return new FeatureMatcher<Predicate<Object>, Boolean>(is(p.apply(null)), "eq", "eq") {
+        return new FeatureMatcher<Predicate<Object>, Boolean>(is(p.test(null)), "eq", "eq") {
             @Override
             protected Boolean featureValueOf(Predicate<Object> actual) {
-                return actual.apply(null);
+                return actual.test(null);
             }
         };
     }

--- a/compiler-project/core/src/main/java/com/asakusafw/lang/compiler/core/BatchCompiler.java
+++ b/compiler-project/core/src/main/java/com/asakusafw/lang/compiler/core/BatchCompiler.java
@@ -24,6 +24,7 @@ import com.asakusafw.lang.compiler.packaging.FileContainerRepository;
 /**
  * Compiles Asakusa batches.
  */
+@FunctionalInterface
 public interface BatchCompiler {
 
     /**

--- a/compiler-project/core/src/main/java/com/asakusafw/lang/compiler/core/CompilerParticipant.java
+++ b/compiler-project/core/src/main/java/com/asakusafw/lang/compiler/core/CompilerParticipant.java
@@ -30,7 +30,9 @@ public interface CompilerParticipant {
      * @param context the current context
      * @param batch the target batch
      */
-    void beforeBatch(BatchCompiler.Context context, Batch batch);
+    default void beforeBatch(BatchCompiler.Context context, Batch batch) {
+        return;
+    }
 
     /**
      * Run after compiling batch.
@@ -38,7 +40,9 @@ public interface CompilerParticipant {
      * @param batch the target batch
      * @param reference the compilation result
      */
-    void afterBatch(BatchCompiler.Context context, Batch batch, BatchReference reference);
+    default void afterBatch(BatchCompiler.Context context, Batch batch, BatchReference reference) {
+        return;
+    }
 
     /**
      * Run before compiling jobflow.
@@ -46,7 +50,9 @@ public interface CompilerParticipant {
      * @param batch information of the jobflow owner
      * @param jobflow the target jobflow
      */
-    void beforeJobflow(JobflowCompiler.Context context, BatchInfo batch, Jobflow jobflow);
+    default void beforeJobflow(JobflowCompiler.Context context, BatchInfo batch, Jobflow jobflow) {
+        return;
+    }
 
     /**
      * Run after compiling jobflow.
@@ -54,5 +60,7 @@ public interface CompilerParticipant {
      * @param batch information of the jobflow owner
      * @param jobflow the target jobflow
      */
-    void afterJobflow(JobflowCompiler.Context context, BatchInfo batch, Jobflow jobflow);
+    default void afterJobflow(JobflowCompiler.Context context, BatchInfo batch, Jobflow jobflow) {
+        return;
+    }
 }

--- a/compiler-project/core/src/main/java/com/asakusafw/lang/compiler/core/JobflowCompiler.java
+++ b/compiler-project/core/src/main/java/com/asakusafw/lang/compiler/core/JobflowCompiler.java
@@ -27,6 +27,7 @@ import com.asakusafw.lang.compiler.packaging.FileContainerRepository;
 /**
  * Compiles Asakusa jobflows.
  */
+@FunctionalInterface
 public interface JobflowCompiler {
 
     /**

--- a/compiler-project/core/src/main/java/com/asakusafw/lang/compiler/core/ProjectRepository.java
+++ b/compiler-project/core/src/main/java/com/asakusafw/lang/compiler/core/ProjectRepository.java
@@ -31,13 +31,13 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.jar.JarOutputStream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.asakusafw.lang.compiler.common.Location;
-import com.asakusafw.lang.compiler.common.Predicate;
 import com.asakusafw.lang.compiler.packaging.FileItem;
 import com.asakusafw.lang.compiler.packaging.FileRepository;
 import com.asakusafw.lang.compiler.packaging.ResourceItem;
@@ -147,7 +147,7 @@ public class ProjectRepository implements Closeable {
                     if (aClass == null || results.contains(aClass)) {
                         continue;
                     }
-                    if (predicate.apply(aClass) == false) {
+                    if (predicate.test(aClass) == false) {
                         continue;
                     }
                     results.add(aClass);

--- a/compiler-project/core/src/main/java/com/asakusafw/lang/compiler/core/adapter/BatchProcessorAdapter.java
+++ b/compiler-project/core/src/main/java/com/asakusafw/lang/compiler/core/adapter/BatchProcessorAdapter.java
@@ -68,7 +68,7 @@ public class BatchProcessorAdapter implements BatchProcessor.Context {
         if (library.isFile() == false) {
             return null;
         }
-        final ZipFile zip = new ZipFile(library);
+        ZipFile zip = new ZipFile(library);
         boolean success = false;
         try {
             ZipEntry entry = zip.getEntry(location.toPath());

--- a/compiler-project/core/src/main/java/com/asakusafw/lang/compiler/core/basic/AbstractCompilerParticipant.java
+++ b/compiler-project/core/src/main/java/com/asakusafw/lang/compiler/core/basic/AbstractCompilerParticipant.java
@@ -15,36 +15,11 @@
  */
 package com.asakusafw.lang.compiler.core.basic;
 
-import com.asakusafw.lang.compiler.api.reference.BatchReference;
-import com.asakusafw.lang.compiler.core.BatchCompiler;
 import com.asakusafw.lang.compiler.core.CompilerParticipant;
-import com.asakusafw.lang.compiler.core.JobflowCompiler;
-import com.asakusafw.lang.compiler.model.graph.Batch;
-import com.asakusafw.lang.compiler.model.graph.Jobflow;
-import com.asakusafw.lang.compiler.model.info.BatchInfo;
 
 /**
  * An abstract implementation of {@link CompilerParticipant} with no actions.
  */
 public abstract class AbstractCompilerParticipant implements CompilerParticipant {
-
-    @Override
-    public void beforeBatch(BatchCompiler.Context context, Batch batch) {
-        return;
-    }
-
-    @Override
-    public void afterBatch(BatchCompiler.Context context, Batch batch, BatchReference reference) {
-        return;
-    }
-
-    @Override
-    public void beforeJobflow(JobflowCompiler.Context context, BatchInfo batch, Jobflow jobflow) {
-        return;
-    }
-
-    @Override
-    public void afterJobflow(JobflowCompiler.Context context, BatchInfo batch, Jobflow jobflow) {
-        return;
-    }
+    // no special members
 }

--- a/compiler-project/core/src/main/java/com/asakusafw/lang/compiler/core/basic/JobflowPackager.java
+++ b/compiler-project/core/src/main/java/com/asakusafw/lang/compiler/core/basic/JobflowPackager.java
@@ -18,6 +18,7 @@ package com.asakusafw.lang.compiler.core.basic;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.Collection;
+import java.util.function.Predicate;
 import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;
 
@@ -25,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.asakusafw.lang.compiler.common.Location;
-import com.asakusafw.lang.compiler.common.Predicate;
 import com.asakusafw.lang.compiler.common.ResourceContainer;
 import com.asakusafw.lang.compiler.packaging.ResourceAssembler;
 import com.asakusafw.lang.compiler.packaging.ResourceRepository;
@@ -70,17 +70,14 @@ public class JobflowPackager {
      */
     static final String PATTERN_JOBFLOW_LIBRARY = "jobflow-{0}.jar"; //$NON-NLS-1$
 
-    private static final Predicate<Location> EMBEDDED_CONTENT_ACCEPTOR = new Predicate<Location>() {
-        @Override
-        public boolean apply(Location location) {
-            if (location.equals(MANIFEST_FILE)) {
-                return false;
-            }
-            if (FRAMEWORK_INFO.isPrefixOf(location)) {
-                return false;
-            }
-            return true;
+    private static final Predicate<Location> EMBEDDED_CONTENT_ACCEPTOR = location -> {
+        if (location.equals(MANIFEST_FILE)) {
+            return false;
         }
+        if (FRAMEWORK_INFO.isPrefixOf(location)) {
+            return false;
+        }
+        return true;
     };
 
     /**

--- a/compiler-project/core/src/test/java/com/asakusafw/lang/compiler/core/ProjectRepositoryTest.java
+++ b/compiler-project/core/src/test/java/com/asakusafw/lang/compiler/core/ProjectRepositoryTest.java
@@ -215,7 +215,7 @@ public class ProjectRepositoryTest {
         }
     }
 
-    private Matcher<ClassLoader> hasClass(final String name) {
+    private Matcher<ClassLoader> hasClass(String name) {
         return new BaseMatcher<ClassLoader>() {
 
             @Override

--- a/compiler-project/core/src/test/java/com/asakusafw/lang/compiler/core/ProjectRepositoryTest.java
+++ b/compiler-project/core/src/test/java/com/asakusafw/lang/compiler/core/ProjectRepositoryTest.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -35,7 +36,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import com.asakusafw.lang.compiler.common.Location;
-import com.asakusafw.lang.compiler.common.Predicate;
+import com.asakusafw.lang.compiler.common.Predicates;
 import com.asakusafw.lang.compiler.common.testing.FileDeployer;
 import com.asakusafw.lang.compiler.packaging.FileRepository;
 import com.asakusafw.lang.compiler.packaging.ResourceRepository;
@@ -46,12 +47,7 @@ import com.asakusafw.lang.compiler.packaging.ZipRepository;
  */
 public class ProjectRepositoryTest {
 
-    private static final Predicate<Object> ANY = new Predicate<Object>() {
-        @Override
-        public boolean apply(Object argument) {
-            return true;
-        }
-    };
+    private static final Predicate<Object> ANY = Predicates.anything();
 
     /**
      * temporary file deployer.
@@ -73,12 +69,7 @@ public class ProjectRepositoryTest {
             assertThat(locations(repo.getProjectContents()), hasItem("com/example/Hello$World.class"));
             assertThat(locations(repo.getEmbeddedContents()), is(empty()));
             assertThat(locations(repo.getAttachedLibraries()), is(empty()));
-            Set<Class<?>> classes = repo.getProjectClasses(new Predicate<Class<?>>() {
-                @Override
-                public boolean apply(Class<?> argument) {
-                    return argument.getDeclaringClass() == null;
-                }
-            });
+            Set<Class<?>> classes = repo.getProjectClasses(aClass -> aClass.getDeclaringClass() == null);
             assertThat(names(classes), containsInAnyOrder("com.example.Hello"));
         }
     }
@@ -97,12 +88,7 @@ public class ProjectRepositoryTest {
             assertThat(locations(repo.getProjectContents()), hasItem("com/example/Hello$World.class"));
             assertThat(locations(repo.getEmbeddedContents()), is(empty()));
             assertThat(locations(repo.getAttachedLibraries()), is(empty()));
-            Set<Class<?>> classes = repo.getProjectClasses(new Predicate<Class<?>>() {
-                @Override
-                public boolean apply(Class<?> argument) {
-                    return argument.getDeclaringClass() == null;
-                }
-            });
+            Set<Class<?>> classes = repo.getProjectClasses(aClass -> aClass.getDeclaringClass() == null);
             assertThat(names(classes), containsInAnyOrder("com.example.Hello"));
         }
     }

--- a/compiler-project/core/src/test/java/com/asakusafw/lang/compiler/core/participant/HadoopFormatExtensionParticipantTest.java
+++ b/compiler-project/core/src/test/java/com/asakusafw/lang/compiler/core/participant/HadoopFormatExtensionParticipantTest.java
@@ -18,19 +18,16 @@ package com.asakusafw.lang.compiler.core.participant;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
-import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
 
-import com.asakusafw.lang.compiler.api.JobflowProcessor;
 import com.asakusafw.lang.compiler.core.CompilerTestRoot;
 import com.asakusafw.lang.compiler.core.JobflowCompiler;
 import com.asakusafw.lang.compiler.core.basic.BasicJobflowCompiler;
 import com.asakusafw.lang.compiler.core.dummy.SimpleExternalPortProcessor;
 import com.asakusafw.lang.compiler.hadoop.HadoopFormatExtension;
 import com.asakusafw.lang.compiler.model.description.ClassDescription;
-import com.asakusafw.lang.compiler.model.graph.Jobflow;
 import com.asakusafw.lang.compiler.packaging.FileContainer;
 
 /**
@@ -43,20 +40,17 @@ public class HadoopFormatExtensionParticipantTest extends CompilerTestRoot {
      */
     @Test
     public void simple() {
-        final AtomicBoolean executed = new AtomicBoolean();
+        AtomicBoolean executed = new AtomicBoolean();
         externalPortProcessors.add(new SimpleExternalPortProcessor());
         compilerParticipants.add(new HadoopFormatExtensionParticipant());
-        jobflowProcessors.add(new JobflowProcessor() {
-            @Override
-            public void process(Context context, Jobflow source) throws IOException {
-                HadoopFormatExtension extension = context.getExtension(HadoopFormatExtension.class);
-                assertThat(extension, is(notNullValue()));
+        jobflowProcessors.add((context, source) -> {
+            HadoopFormatExtension extension = context.getExtension(HadoopFormatExtension.class);
+            assertThat(extension, is(notNullValue()));
 
-                assertThat(extension.getInputFormat(), is(HadoopFormatExtension.DEFAULT_INPUT_FORMAT));
-                assertThat(extension.getOutputFormat(), is(HadoopFormatExtension.DEFAULT_OUTPUT_FORMAT));
+            assertThat(extension.getInputFormat(), is(HadoopFormatExtension.DEFAULT_INPUT_FORMAT));
+            assertThat(extension.getOutputFormat(), is(HadoopFormatExtension.DEFAULT_OUTPUT_FORMAT));
 
-                executed.set(true);
-            }
+            executed.set(true);
         });
 
         FileContainer output = container();
@@ -78,20 +72,17 @@ public class HadoopFormatExtensionParticipantTest extends CompilerTestRoot {
             .withProperty(HadoopFormatExtensionParticipant.KEY_INPUT_FORMAT, "TestingInput")
             .withProperty(HadoopFormatExtensionParticipant.KEY_OUTPUT_FORMAT, "TestingOutput");
 
-        final AtomicBoolean executed = new AtomicBoolean();
+        AtomicBoolean executed = new AtomicBoolean();
         externalPortProcessors.add(new SimpleExternalPortProcessor());
         compilerParticipants.add(new HadoopFormatExtensionParticipant());
-        jobflowProcessors.add(new JobflowProcessor() {
-            @Override
-            public void process(Context context, Jobflow source) throws IOException {
-                HadoopFormatExtension extension = context.getExtension(HadoopFormatExtension.class);
-                assertThat(extension, is(notNullValue()));
+        jobflowProcessors.add((context, source) -> {
+            HadoopFormatExtension extension = context.getExtension(HadoopFormatExtension.class);
+            assertThat(extension, is(notNullValue()));
 
-                assertThat(extension.getInputFormat(), is(new ClassDescription("TestingInput")));
-                assertThat(extension.getOutputFormat(), is(new ClassDescription("TestingOutput")));
+            assertThat(extension.getInputFormat(), is(new ClassDescription("TestingInput")));
+            assertThat(extension.getOutputFormat(), is(new ClassDescription("TestingOutput")));
 
-                executed.set(true);
-            }
+            executed.set(true);
         });
 
         FileContainer output = container();

--- a/compiler-project/core/src/test/java/com/asakusafw/lang/compiler/core/participant/HadoopTaskExtensionParticipantTest.java
+++ b/compiler-project/core/src/test/java/com/asakusafw/lang/compiler/core/participant/HadoopTaskExtensionParticipantTest.java
@@ -18,12 +18,10 @@ package com.asakusafw.lang.compiler.core.participant;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
-import java.io.IOException;
 import java.util.List;
 
 import org.junit.Test;
 
-import com.asakusafw.lang.compiler.api.JobflowProcessor;
 import com.asakusafw.lang.compiler.api.reference.TaskReference;
 import com.asakusafw.lang.compiler.api.reference.TaskReference.Phase;
 import com.asakusafw.lang.compiler.core.CompilerTestRoot;
@@ -33,7 +31,6 @@ import com.asakusafw.lang.compiler.core.dummy.SimpleExternalPortProcessor;
 import com.asakusafw.lang.compiler.hadoop.HadoopTaskExtension;
 import com.asakusafw.lang.compiler.hadoop.HadoopTaskReference;
 import com.asakusafw.lang.compiler.model.description.ClassDescription;
-import com.asakusafw.lang.compiler.model.graph.Jobflow;
 import com.asakusafw.lang.compiler.packaging.FileContainer;
 
 /**
@@ -48,13 +45,10 @@ public class HadoopTaskExtensionParticipantTest extends CompilerTestRoot {
     public void simple() {
         externalPortProcessors.add(new SimpleExternalPortProcessor());
         compilerParticipants.add(new HadoopTaskExtensionParticipant());
-        jobflowProcessors.add(new JobflowProcessor() {
-            @Override
-            public void process(Context context, Jobflow source) throws IOException {
-                HadoopTaskExtension extension = context.getExtension(HadoopTaskExtension.class);
-                assertThat(extension, is(notNullValue()));
-                extension.addTask(Phase.MAIN, new ClassDescription("testing"));
-            }
+        jobflowProcessors.add((context, source) -> {
+            HadoopTaskExtension extension = context.getExtension(HadoopTaskExtension.class);
+            assertThat(extension, is(notNullValue()));
+            extension.addTask(Phase.MAIN, new ClassDescription("testing"));
         });
 
         FileContainer output = container();

--- a/compiler-project/core/src/test/java/com/asakusafw/lang/compiler/core/participant/InspectionExtensionParticipantTest.java
+++ b/compiler-project/core/src/test/java/com/asakusafw/lang/compiler/core/participant/InspectionExtensionParticipantTest.java
@@ -18,14 +18,10 @@ package com.asakusafw.lang.compiler.core.participant;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
-import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
 
-import com.asakusafw.lang.compiler.api.BatchProcessor;
-import com.asakusafw.lang.compiler.api.JobflowProcessor;
-import com.asakusafw.lang.compiler.api.reference.BatchReference;
 import com.asakusafw.lang.compiler.core.BatchCompiler;
 import com.asakusafw.lang.compiler.core.CompilerTestRoot;
 import com.asakusafw.lang.compiler.core.basic.BasicBatchCompiler;
@@ -33,7 +29,6 @@ import com.asakusafw.lang.compiler.core.dummy.SimpleExternalPortProcessor;
 import com.asakusafw.lang.compiler.core.dummy.SimpleJobflowProcessor;
 import com.asakusafw.lang.compiler.inspection.InspectionExtension;
 import com.asakusafw.lang.compiler.model.graph.Batch;
-import com.asakusafw.lang.compiler.model.graph.Jobflow;
 import com.asakusafw.lang.compiler.packaging.FileContainer;
 
 /**
@@ -46,25 +41,19 @@ public class InspectionExtensionParticipantTest extends CompilerTestRoot {
      */
     @Test
     public void simple() {
-        final AtomicBoolean jobflowExecuted = new AtomicBoolean();
-        final AtomicBoolean batchExecuted = new AtomicBoolean();
+        AtomicBoolean jobflowExecuted = new AtomicBoolean();
+        AtomicBoolean batchExecuted = new AtomicBoolean();
         externalPortProcessors.add(new SimpleExternalPortProcessor());
         compilerParticipants.add(new InspectionExtensionParticipant());
-        jobflowProcessors.add(new JobflowProcessor() {
-            @Override
-            public void process(JobflowProcessor.Context context, Jobflow source) throws IOException {
-                InspectionExtension extension = context.getExtension(InspectionExtension.class);
-                assertThat(extension, is(notNullValue()));
-                jobflowExecuted.set(true);
-            }
+        jobflowProcessors.add((context, source) -> {
+            InspectionExtension extension = context.getExtension(InspectionExtension.class);
+            assertThat(extension, is(notNullValue()));
+            jobflowExecuted.set(true);
         });
-        batchProcessors.add(new BatchProcessor() {
-            @Override
-            public void process(BatchProcessor.Context context, BatchReference source) throws IOException {
-                InspectionExtension extension = context.getExtension(InspectionExtension.class);
-                assertThat(extension, is(notNullValue()));
-                batchExecuted.set(true);
-            }
+        batchProcessors.add((context, source) -> {
+            InspectionExtension extension = context.getExtension(InspectionExtension.class);
+            assertThat(extension, is(notNullValue()));
+            batchExecuted.set(true);
         });
 
         FileContainer output = container();

--- a/compiler-project/core/src/test/java/com/asakusafw/lang/compiler/core/participant/JavaSourceExtensionParticipantTest.java
+++ b/compiler-project/core/src/test/java/com/asakusafw/lang/compiler/core/participant/JavaSourceExtensionParticipantTest.java
@@ -19,7 +19,6 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -28,7 +27,6 @@ import java.util.concurrent.Callable;
 
 import org.junit.Test;
 
-import com.asakusafw.lang.compiler.api.JobflowProcessor;
 import com.asakusafw.lang.compiler.common.DiagnosticException;
 import com.asakusafw.lang.compiler.core.CompilerTestRoot;
 import com.asakusafw.lang.compiler.core.JobflowCompiler;
@@ -36,7 +34,6 @@ import com.asakusafw.lang.compiler.core.basic.BasicJobflowCompiler;
 import com.asakusafw.lang.compiler.core.dummy.SimpleExternalPortProcessor;
 import com.asakusafw.lang.compiler.javac.JavaSourceExtension;
 import com.asakusafw.lang.compiler.model.description.ClassDescription;
-import com.asakusafw.lang.compiler.model.graph.Jobflow;
 import com.asakusafw.lang.compiler.packaging.FileContainer;
 
 /**
@@ -50,7 +47,7 @@ public class JavaSourceExtensionParticipantTest extends CompilerTestRoot {
      */
     @Test
     public void simple() throws Exception {
-        final ClassDescription aClass = new ClassDescription("com.example.JavaSourceExtension");
+        ClassDescription aClass = new ClassDescription("com.example.JavaSourceExtension");
         initialize(aClass, new String[] {
                 "package com.example;",
                 String.format(
@@ -78,7 +75,7 @@ public class JavaSourceExtensionParticipantTest extends CompilerTestRoot {
      */
     @Test(expected = DiagnosticException.class)
     public void invalid_version() throws Exception {
-        final ClassDescription aClass = new ClassDescription("com.example.JavaSourceExtension");
+        ClassDescription aClass = new ClassDescription("com.example.JavaSourceExtension");
         initialize(aClass, new String[] {
                 "package com.example;",
                 String.format("public class %s {}", aClass.getSimpleName()),
@@ -98,7 +95,7 @@ public class JavaSourceExtensionParticipantTest extends CompilerTestRoot {
      */
     @Test(expected = DiagnosticException.class)
     public void invalid_bootclasspath() throws Exception {
-        final ClassDescription aClass = new ClassDescription("com.example.JavaSourceExtension");
+        ClassDescription aClass = new ClassDescription("com.example.JavaSourceExtension");
         initialize(aClass, new String[] {
                 "package com.example;",
                 String.format("public class %s {}", aClass.getSimpleName()),
@@ -113,22 +110,18 @@ public class JavaSourceExtensionParticipantTest extends CompilerTestRoot {
                 jobflow("testing"));
     }
 
-    private void initialize(final ClassDescription aClass, final String... lines) {
+    private void initialize(ClassDescription aClass, String... lines) {
         externalPortProcessors.add(new SimpleExternalPortProcessor());
         compilerParticipants.add(new JavaSourceExtensionParticipant());
-        jobflowProcessors.add(new JobflowProcessor() {
-            @Override
-            public void process(Context context, Jobflow source) throws IOException {
-                JavaSourceExtension extension = context.getExtension(JavaSourceExtension.class);
-                assertThat(extension, is(notNullValue()));
-                try (PrintWriter pw = new PrintWriter(extension.addJavaFile(aClass))) {
-                    for (String line : lines) {
-                        pw.println(line);
-                    }
+        jobflowProcessors.add((context, source) -> {
+            JavaSourceExtension extension = context.getExtension(JavaSourceExtension.class);
+            assertThat(extension, is(notNullValue()));
+            try (PrintWriter pw = new PrintWriter(extension.addJavaFile(aClass))) {
+                for (String line : lines) {
+                    pw.println(line);
                 }
             }
         });
-
     }
 
     private URLClassLoader loader(File path) {

--- a/compiler-project/extension-directio/src/test/java/com/asakusafw/lang/compiler/extension/directio/DirectFileIoPortProcessorTest.java
+++ b/compiler-project/extension-directio/src/test/java/com/asakusafw/lang/compiler/extension/directio/DirectFileIoPortProcessorTest.java
@@ -58,7 +58,6 @@ import com.asakusafw.lang.compiler.hadoop.InputFormatInfoSupport;
 import com.asakusafw.lang.compiler.javac.JavaSourceExtension;
 import com.asakusafw.lang.compiler.javac.testing.JavaCompiler;
 import com.asakusafw.lang.compiler.mapreduce.testing.InputFormatTester;
-import com.asakusafw.lang.compiler.mapreduce.testing.InputFormatTester.Collector;
 import com.asakusafw.lang.compiler.mapreduce.testing.MapReduceRunner;
 import com.asakusafw.lang.compiler.mapreduce.testing.mock.DirectIoContext;
 import com.asakusafw.lang.compiler.mapreduce.testing.mock.MockData;
@@ -1170,13 +1169,8 @@ public class DirectFileIoPortProcessorTest {
         ConfigurationEditor.merge(conf, info.getExtraConfiguration());
         ConfigurationEditor.putStageInfo(conf, new StageInfo("u", "b", "f", "s", "e", args));
         InputFormatTester tester = new InputFormatTester(conf, info.getFormatClass().resolve(conf.getClassLoader()));
-        final Map<Integer, String> results = new LinkedHashMap<>();
-        tester.collect(new Collector<MockData>() {
-            @Override
-            public void handle(MockData object) {
-                results.put(object.getKey(), object.getValue());
-            }
-        });
+        Map<Integer, String> results = new LinkedHashMap<>();
+        tester.collect((MockData object) -> results.put(object.getKey(), object.getValue()));
         return results;
     }
 

--- a/compiler-project/extension-hive/src/main/java/com/asakusafw/lang/compiler/extension/hive/Util.java
+++ b/compiler-project/extension-hive/src/main/java/com/asakusafw/lang/compiler/extension/hive/Util.java
@@ -17,7 +17,6 @@ package com.asakusafw.lang.compiler.extension.hive;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -65,12 +64,7 @@ final class Util {
             saw.add(element);
             normalized.add(element);
         }
-        Collections.sort(normalized, new Comparator<T>() {
-            @Override
-            public int compare(T o1, T o2) {
-                return o1.getSchema().getName().compareTo(o2.getSchema().getName());
-            }
-        });
+        Collections.sort(normalized, (o1, o2) -> o1.getSchema().getName().compareTo(o2.getSchema().getName()));
         return normalized;
     }
 }

--- a/compiler-project/extension-hive/src/test/java/com/asakusafw/lang/compiler/extension/hive/testing/HiveSchemaProcessorTester.java
+++ b/compiler-project/extension-hive/src/test/java/com/asakusafw/lang/compiler/extension/hive/testing/HiveSchemaProcessorTester.java
@@ -57,7 +57,7 @@ public class HiveSchemaProcessorTester implements TestRule {
     CompilerTester tester;
 
     @Override
-    public Statement apply(final Statement base, final Description description) {
+    public Statement apply(Statement base, Description description) {
         return new Statement() {
             @Override
             public void evaluate() throws Throwable {

--- a/compiler-project/extension-test-moderator/src/main/java/com/asakusafw/lang/compiler/extension/testdriver/InternalIoPortProcessor.java
+++ b/compiler-project/extension-test-moderator/src/main/java/com/asakusafw/lang/compiler/extension/testdriver/InternalIoPortProcessor.java
@@ -82,18 +82,15 @@ public class InternalIoPortProcessor
 
     private static final TaskReference.Phase PHASE_OUTPUT = TaskReference.Phase.EPILOGUE;
 
-    private static final Comparator<String> LOCATION_GROUP_COMPARATOR = new Comparator<String>() {
-        @Override
-        public int compare(String o1, String o2) {
-            int l1 = o1.length();
-            int l2 = o2.length();
-            if (l1 < l2) {
-                return +1;
-            } else if (l1 > l2) {
-                return -1;
-            }
-            return o1.compareTo(o2);
+    private static final Comparator<String> LOCATION_GROUP_COMPARATOR = (o1, o2) -> {
+        int l1 = o1.length();
+        int l2 = o2.length();
+        if (l1 < l2) {
+            return +1;
+        } else if (l1 > l2) {
+            return -1;
         }
+        return o1.compareTo(o2);
     };
 
     @Override

--- a/compiler-project/hadoop/src/main/java/com/asakusafw/lang/compiler/hadoop/BasicHadoopTaskExtension.java
+++ b/compiler-project/hadoop/src/main/java/com/asakusafw/lang/compiler/hadoop/BasicHadoopTaskExtension.java
@@ -17,7 +17,6 @@ package com.asakusafw.lang.compiler.hadoop;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 
 import com.asakusafw.lang.compiler.api.basic.TaskContainer;
 import com.asakusafw.lang.compiler.api.basic.TaskContainerMap;
@@ -38,11 +37,6 @@ public class BasicHadoopTaskExtension implements HadoopTaskExtension {
      */
     public BasicHadoopTaskExtension(TaskContainerMap tasks) {
         this.tasks = tasks;
-    }
-
-    @Override
-    public TaskReference addTask(Phase phase, ClassDescription mainClass, TaskReference... blockers) {
-        return addTask(phase, mainClass, Collections.emptySet(), blockers);
     }
 
     @Override

--- a/compiler-project/hadoop/src/main/java/com/asakusafw/lang/compiler/hadoop/HadoopTaskExtension.java
+++ b/compiler-project/hadoop/src/main/java/com/asakusafw/lang/compiler/hadoop/HadoopTaskExtension.java
@@ -16,6 +16,7 @@
 package com.asakusafw.lang.compiler.hadoop;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import com.asakusafw.lang.compiler.api.reference.TaskReference;
 import com.asakusafw.lang.compiler.model.description.ClassDescription;
@@ -25,6 +26,7 @@ import com.asakusafw.lang.compiler.model.description.ClassDescription;
  * @since 0.1.0
  * @version 0.3.0
  */
+@FunctionalInterface
 public interface HadoopTaskExtension {
 
     /**
@@ -34,7 +36,9 @@ public interface HadoopTaskExtension {
      * @param blockers the blocker sub-applications
      * @return a symbol that represents the added sub-application
      */
-    TaskReference addTask(TaskReference.Phase phase, ClassDescription mainClass, TaskReference... blockers);
+    default TaskReference addTask(TaskReference.Phase phase, ClassDescription mainClass, TaskReference... blockers) {
+        return addTask(phase, mainClass, Collections.emptySet(), blockers);
+    }
 
     /**
      * Adds a Hadoop sub-application to execute in this application.

--- a/compiler-project/hadoop/src/main/java/com/asakusafw/lang/compiler/hadoop/InputFormatInfoSupport.java
+++ b/compiler-project/hadoop/src/main/java/com/asakusafw/lang/compiler/hadoop/InputFormatInfoSupport.java
@@ -22,6 +22,7 @@ import com.asakusafw.lang.compiler.model.info.ExternalInputInfo;
  * An interface who can provides {@link InputFormatInfo}.
  * The supported {@link ExternalPortProcessor} must
  */
+@FunctionalInterface
 public interface InputFormatInfoSupport {
 
     /**

--- a/compiler-project/inspection/src/test/java/com/asakusafw/lang/compiler/inspection/InspectionExtensionTest.java
+++ b/compiler-project/inspection/src/test/java/com/asakusafw/lang/compiler/inspection/InspectionExtensionTest.java
@@ -36,7 +36,7 @@ public class InspectionExtensionTest {
      */
     @Test
     public void simple() {
-        final AtomicReference<Object> ref = new AtomicReference<>();
+        AtomicReference<Object> ref = new AtomicReference<>();
         ExtensionContainer container = container(new InspectionExtension() {
             @Override
             public boolean isSupported(Object element) {

--- a/compiler-project/internalio/src/main/java/com/asakusafw/lang/compiler/internalio/InternalImporterDescription.java
+++ b/compiler-project/internalio/src/main/java/com/asakusafw/lang/compiler/internalio/InternalImporterDescription.java
@@ -25,11 +25,6 @@ import com.asakusafw.vocabulary.external.ImporterDescription;
  */
 public abstract class InternalImporterDescription implements ImporterDescription {
 
-    @Override
-    public DataSize getDataSize() {
-        return DataSize.UNKNOWN;
-    }
-
     /**
      * Returns the import target path prefix.
      * <p>

--- a/compiler-project/javac-testing/src/main/java/com/asakusafw/lang/compiler/javac/testing/JavaCompiler.java
+++ b/compiler-project/javac-testing/src/main/java/com/asakusafw/lang/compiler/javac/testing/JavaCompiler.java
@@ -47,7 +47,7 @@ public class JavaCompiler implements JavaSourceExtension, TestRule {
     private BasicJavaCompilerSupport entity;
 
     @Override
-    public Statement apply(final Statement base, final Description description) {
+    public Statement apply(Statement base, Description description) {
         return temporary.apply(new Statement() {
             @Override
             public void evaluate() throws Throwable {

--- a/compiler-project/javac/src/main/java/com/asakusafw/lang/compiler/javac/JavaSourceExtension.java
+++ b/compiler-project/javac/src/main/java/com/asakusafw/lang/compiler/javac/JavaSourceExtension.java
@@ -23,6 +23,7 @@ import com.asakusafw.lang.compiler.model.description.ClassDescription;
 /**
  * An extension for using Java source files.
  */
+@FunctionalInterface
 public interface JavaSourceExtension {
 
     /**

--- a/compiler-project/mapreduce-testing/src/main/java/com/asakusafw/lang/compiler/mapreduce/testing/ClassLoaderContext.java
+++ b/compiler-project/mapreduce-testing/src/main/java/com/asakusafw/lang/compiler/mapreduce/testing/ClassLoaderContext.java
@@ -41,14 +41,11 @@ public class ClassLoaderContext implements AutoCloseable {
         swap(escaped);
     }
 
-    private static ClassLoader swap(final ClassLoader classLoader) {
-        return AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
-            @Override
-            public ClassLoader run() {
-                ClassLoader old = Thread.currentThread().getContextClassLoader();
-                Thread.currentThread().setContextClassLoader(classLoader);
-                return old;
-            }
+    private static ClassLoader swap(ClassLoader classLoader) {
+        return AccessController.doPrivileged((PrivilegedAction<ClassLoader>) () -> {
+            ClassLoader old = Thread.currentThread().getContextClassLoader();
+            Thread.currentThread().setContextClassLoader(classLoader);
+            return old;
         });
     }
 }

--- a/compiler-project/mapreduce-testing/src/main/java/com/asakusafw/lang/compiler/mapreduce/testing/mock/DirectIoContext.java
+++ b/compiler-project/mapreduce-testing/src/main/java/com/asakusafw/lang/compiler/mapreduce/testing/mock/DirectIoContext.java
@@ -34,7 +34,7 @@ public class DirectIoContext implements TestRule {
     private final TemporaryFolder temporary = new TemporaryFolder();
 
     @Override
-    public Statement apply(final Statement base, final Description description) {
+    public Statement apply(Statement base, Description description) {
         return temporary.apply(base, description);
     }
 

--- a/compiler-project/mapreduce-testing/src/main/java/com/asakusafw/lang/compiler/mapreduce/testing/mock/WritableDataFormat.java
+++ b/compiler-project/mapreduce-testing/src/main/java/com/asakusafw/lang/compiler/mapreduce/testing/mock/WritableDataFormat.java
@@ -17,7 +17,6 @@ package com.asakusafw.lang.compiler.mapreduce.testing.mock;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
@@ -32,16 +31,6 @@ import com.asakusafw.runtime.io.ModelOutput;
  * @param <T> the target data type
  */
 public abstract class WritableDataFormat<T extends Writable> extends BinaryStreamFormat<T> {
-
-    @Override
-    public long getPreferredFragmentSize() throws IOException, InterruptedException {
-        return -1;
-    }
-
-    @Override
-    public long getMinimumFragmentSize() throws IOException, InterruptedException {
-        return -1;
-    }
 
     @Override
     public ModelInput<T> createInput(

--- a/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/graph/Operators.java
+++ b/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/graph/Operators.java
@@ -20,8 +20,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
-
-import com.asakusafw.lang.compiler.common.Predicate;
+import java.util.function.Predicate;
 
 /**
  * Utilities for {@link Operator}.
@@ -242,7 +241,7 @@ public final class Operators {
                 continue;
             }
             saw.add(operator);
-            if (predicate.apply(operator)) {
+            if (predicate.test(operator)) {
                 results.add(operator);
             } else {
                 collectOpposites(operator.getOutputs(), work);
@@ -270,7 +269,7 @@ public final class Operators {
                 continue;
             }
             saw.add(operator);
-            if (predicate.apply(operator)) {
+            if (predicate.test(operator)) {
                 results.add(operator);
             } else {
                 collectOpposites(operator.getInputs(), work);
@@ -300,7 +299,7 @@ public final class Operators {
                 continue;
             }
             saw.add(operator);
-            if (predicate.apply(operator)) {
+            if (predicate.test(operator)) {
                 if (inclusive) {
                     results.add(operator);
                 }
@@ -333,7 +332,7 @@ public final class Operators {
                 continue;
             }
             saw.add(operator);
-            if (predicate.apply(operator)) {
+            if (predicate.test(operator)) {
                 if (inclusive) {
                     results.add(operator);
                 }

--- a/compiler-project/model/src/test/java/com/asakusafw/lang/compiler/model/graph/GroupsTest.java
+++ b/compiler-project/model/src/test/java/com/asakusafw/lang/compiler/model/graph/GroupsTest.java
@@ -181,7 +181,7 @@ public class GroupsTest {
     }
 
     private static Matcher<Group> subgroupOf(String... expressions) {
-        final Group b = group(expressions);
+        Group b = group(expressions);
         return new BaseMatcher<Group>() {
             @Override
             public void describeTo(Description description) {

--- a/compiler-project/model/src/test/java/com/asakusafw/lang/compiler/model/graph/OperatorsTest.java
+++ b/compiler-project/model/src/test/java/com/asakusafw/lang/compiler/model/graph/OperatorsTest.java
@@ -21,10 +21,10 @@ import static org.junit.Assert.*;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import org.junit.Test;
 
-import com.asakusafw.lang.compiler.common.Predicate;
 import com.asakusafw.lang.compiler.model.graph.Operator.OperatorKind;
 
 /**
@@ -32,12 +32,7 @@ import com.asakusafw.lang.compiler.model.graph.Operator.OperatorKind;
  */
 public class OperatorsTest {
 
-    private static final Predicate<Operator> MARKERS = new Predicate<Operator>() {
-        @Override
-        public boolean apply(Operator argument) {
-            return argument.getOperatorKind() == OperatorKind.MARKER;
-        }
-    };
+    private static final Predicate<Operator> MARKERS = operator -> operator.getOperatorKind() == OperatorKind.MARKER;
 
     /**
      * inputs.

--- a/compiler-project/optimizer/src/main/java/com/asakusafw/lang/compiler/optimizer/OperatorCharacterizer.java
+++ b/compiler-project/optimizer/src/main/java/com/asakusafw/lang/compiler/optimizer/OperatorCharacterizer.java
@@ -25,6 +25,7 @@ import com.asakusafw.lang.compiler.model.graph.Operator;
  * Extracts {@link OperatorCharacteristics}.
  * @param <T> the characteristics type
  */
+@FunctionalInterface
 public interface OperatorCharacterizer<T extends OperatorCharacteristics> {
 
     /**

--- a/compiler-project/optimizer/src/main/java/com/asakusafw/lang/compiler/optimizer/OperatorEstimator.java
+++ b/compiler-project/optimizer/src/main/java/com/asakusafw/lang/compiler/optimizer/OperatorEstimator.java
@@ -26,16 +26,14 @@ import com.asakusafw.lang.compiler.model.graph.OperatorOutput;
 /**
  * Estimates statistics of each {@link Operator}.
  */
+@FunctionalInterface
 public interface OperatorEstimator {
 
     /**
      * Null implementation of {@link OperatorEstimator}.
      */
-    OperatorEstimator NULL = new OperatorEstimator() {
-        @Override
-        public void perform(Context context, Operator operator) {
-            return;
-        }
+    OperatorEstimator NULL = (context, operator) -> {
+        return;
     };
 
     /**

--- a/compiler-project/optimizer/src/main/java/com/asakusafw/lang/compiler/optimizer/OperatorRewriter.java
+++ b/compiler-project/optimizer/src/main/java/com/asakusafw/lang/compiler/optimizer/OperatorRewriter.java
@@ -25,16 +25,14 @@ import com.asakusafw.lang.compiler.model.graph.OperatorGraph;
 /**
  * Rewrites {@link OperatorGraph} objects.
  */
+@FunctionalInterface
 public interface OperatorRewriter {
 
     /**
      * Null implementation of {@link OperatorRewriter}.
      */
-    OperatorRewriter NULL = new OperatorRewriter() {
-        @Override
-        public void perform(Context context, OperatorGraph graph) {
-            return;
-        }
+    OperatorRewriter NULL = (context, graph) -> {
+        return;
     };
 
     /**

--- a/compiler-project/optimizer/src/test/java/com/asakusafw/lang/compiler/optimizer/basic/CompositeOperatorCharacterizerTest.java
+++ b/compiler-project/optimizer/src/test/java/com/asakusafw/lang/compiler/optimizer/basic/CompositeOperatorCharacterizerTest.java
@@ -92,13 +92,8 @@ public class CompositeOperatorCharacterizerTest extends OptimizerTestRoot {
         return Arrays.asList(operators);
     }
 
-    static OperatorCharacterizer<Mock> engine(final String mark) {
-        return new OperatorCharacterizer<Mock>() {
-            @Override
-            public Mock extract(Context context, Operator operator) {
-                return new Mock(mark);
-            }
-        };
+    static OperatorCharacterizer<Mock> engine(String mark) {
+        return (context, operator) -> new Mock(mark);
     }
 
     static Matcher<Mock> hasMark(String mark) {

--- a/compiler-project/optimizer/src/test/java/com/asakusafw/lang/compiler/optimizer/basic/CompositeOperatorEstimatorTest.java
+++ b/compiler-project/optimizer/src/test/java/com/asakusafw/lang/compiler/optimizer/basic/CompositeOperatorEstimatorTest.java
@@ -252,13 +252,8 @@ public class CompositeOperatorEstimatorTest extends OptimizerTestRoot {
         assertThat(e7, hasMark(null));
     }
 
-    static OperatorEstimator engine(final String mark) {
-        return new OperatorEstimator() {
-            @Override
-            public void perform(Context context, Operator operator) {
-                context.putAttribute(String.class, mark);
-            }
-        };
+    static OperatorEstimator engine(String mark) {
+        return (context, operator) -> context.putAttribute(String.class, mark);
     }
 
     static Matcher<OperatorEstimate> hasMark(String mark) {

--- a/compiler-project/packaging/src/main/java/com/asakusafw/lang/compiler/packaging/ContentProvider.java
+++ b/compiler-project/packaging/src/main/java/com/asakusafw/lang/compiler/packaging/ContentProvider.java
@@ -21,6 +21,7 @@ import java.io.OutputStream;
 /**
  * Provides binary contents.
  */
+@FunctionalInterface
 public interface ContentProvider {
 
     /**

--- a/compiler-project/packaging/src/main/java/com/asakusafw/lang/compiler/packaging/FilePackageBuilder.java
+++ b/compiler-project/packaging/src/main/java/com/asakusafw/lang/compiler/packaging/FilePackageBuilder.java
@@ -103,7 +103,7 @@ public class FilePackageBuilder {
             }
             for (Map.Entry<Location, ContentProvider> entry : providers.entrySet()) {
                 Location location = entry.getKey();
-                final ContentProvider provider = entry.getValue();
+                ContentProvider provider = entry.getValue();
                 sink.add(location, provider);
             }
         }

--- a/compiler-project/packaging/src/main/java/com/asakusafw/lang/compiler/packaging/FileRepository.java
+++ b/compiler-project/packaging/src/main/java/com/asakusafw/lang/compiler/packaging/FileRepository.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -67,12 +66,7 @@ public class FileRepository implements ResourceRepository {
         }
         List<FileItem> results = new ArrayList<>();
         collect(results, null, root);
-        Collections.sort(results, new Comparator<FileItem>() {
-            @Override
-            public int compare(FileItem o1, FileItem o2) {
-                return o1.getLocation().compareTo(o2.getLocation());
-            }
-        });
+        Collections.sort(results, (o1, o2) -> o1.getLocation().compareTo(o2.getLocation()));
         return new ResourceItemRepository.ItemCursor(results.iterator());
     }
 

--- a/compiler-project/packaging/src/main/java/com/asakusafw/lang/compiler/packaging/FileVisitor.java
+++ b/compiler-project/packaging/src/main/java/com/asakusafw/lang/compiler/packaging/FileVisitor.java
@@ -23,6 +23,7 @@ import com.asakusafw.lang.compiler.common.Location;
 /**
  * A file visitor in containers.
  */
+@FunctionalInterface
 public interface FileVisitor {
 
     /**

--- a/compiler-project/packaging/src/main/java/com/asakusafw/lang/compiler/packaging/ResourceSink.java
+++ b/compiler-project/packaging/src/main/java/com/asakusafw/lang/compiler/packaging/ResourceSink.java
@@ -32,7 +32,11 @@ public interface ResourceSink extends Closeable {
      * @param contents the resource contents (will be consumed immediately)
      * @throws IOException if failed to accept the resource by I/O error
      */
-    void add(Location location, InputStream contents) throws IOException;
+    default void add(Location location, InputStream contents) throws IOException {
+        add(location, output -> {
+            ResourceUtil.copy(contents, output);
+        });
+    }
 
     /**
      * Accepts an resource.

--- a/compiler-project/packaging/src/test/java/com/asakusafw/lang/compiler/packaging/FileContainerTest.java
+++ b/compiler-project/packaging/src/test/java/com/asakusafw/lang/compiler/packaging/FileContainerTest.java
@@ -149,15 +149,12 @@ public class FileContainerTest extends ResourceTestRoot {
     @Test
     public void visit() throws Exception {
         FileContainer container = new FileContainer(open("structured.zip"));
-        final Set<String> locations = new HashSet<>();
-        container.accept(new FileVisitor() {
-            @Override
-            public boolean process(Location location, File file) throws IOException {
-                if (file.isFile()) {
-                    locations.add(location.toPath());
-                }
-                return true;
+        Set<String> locations = new HashSet<>();
+        container.accept((location, file) -> {
+            if (file.isFile()) {
+                locations.add(location.toPath());
             }
+            return true;
         });
         assertThat(locations, containsInAnyOrder("a.txt", "a/b.txt", "a/b/c.txt"));
     }

--- a/compiler-project/packaging/src/test/java/com/asakusafw/lang/compiler/packaging/FilePackageBuilderTest.java
+++ b/compiler-project/packaging/src/test/java/com/asakusafw/lang/compiler/packaging/FilePackageBuilderTest.java
@@ -19,7 +19,6 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -100,14 +99,11 @@ public class FilePackageBuilderTest extends ResourceTestRoot {
         builder.add(item("hello.txt", "Hello"));
         builder.add(item("hello.csv", "Hello"));
         builder.add(item("hello.bin", "Hello"));
-        builder.add(new FileVisitor() {
-            @Override
-            public boolean process(Location location, File file) throws IOException {
-                if (file.getName().endsWith(".bin")) {
-                    assertThat(file.delete(), is(true));
-                }
-                return false;
+        builder.add((FileVisitor) (location, file) -> {
+            if (file.getName().endsWith(".bin")) {
+                assertThat(file.delete(), is(true));
             }
+            return false;
         });
 
         File base = folder.getRoot();

--- a/compiler-project/packaging/src/test/java/com/asakusafw/lang/compiler/packaging/FileRepositoryTest.java
+++ b/compiler-project/packaging/src/test/java/com/asakusafw/lang/compiler/packaging/FileRepositoryTest.java
@@ -151,15 +151,12 @@ public class FileRepositoryTest {
     @Test
     public void visit_all() throws Exception {
         FileRepository repository = new FileRepository(open("structured.zip"));
-        final Set<String> locations = new HashSet<>();
-        repository.accept(new FileVisitor() {
-            @Override
-            public boolean process(Location location, File file) throws IOException {
-                if (file.isFile()) {
-                    locations.add(location.toPath());
-                }
-                return true;
+        Set<String> locations = new HashSet<>();
+        repository.accept((location, file) -> {
+            if (file.isFile()) {
+                locations.add(location.toPath());
             }
+            return true;
         });
         assertThat(locations, containsInAnyOrder("a.txt", "a/b.txt", "a/b/c.txt"));
     }
@@ -171,15 +168,12 @@ public class FileRepositoryTest {
     @Test
     public void visit_flat() throws Exception {
         FileRepository repository = new FileRepository(open("structured.zip"));
-        final Set<String> locations = new HashSet<>();
-        repository.accept(new FileVisitor() {
-            @Override
-            public boolean process(Location location, File file) throws IOException {
-                if (file.isFile()) {
-                    locations.add(location.toPath());
-                }
-                return false;
+        Set<String> locations = new HashSet<>();
+        repository.accept((location, file) -> {
+            if (file.isFile()) {
+                locations.add(location.toPath());
             }
+            return false;
         });
         assertThat(locations, containsInAnyOrder("a.txt"));
     }

--- a/compiler-project/packaging/src/test/java/com/asakusafw/lang/compiler/packaging/FileSinkTest.java
+++ b/compiler-project/packaging/src/test/java/com/asakusafw/lang/compiler/packaging/FileSinkTest.java
@@ -19,7 +19,6 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -120,15 +119,12 @@ public class FileSinkTest extends ResourceTestRoot {
             put(sink, item("a/b.txt", "B"));
             put(sink, item("a/b/c.txt", "C"));
 
-            final Set<String> locations = new HashSet<>();
-            sink.accept(new FileVisitor() {
-                @Override
-                public boolean process(Location location, File file) throws IOException {
-                    if (file.isFile()) {
-                        locations.add(location.toPath());
-                    }
-                    return true;
+            Set<String> locations = new HashSet<>();
+            sink.accept((location, file) -> {
+                if (file.isFile()) {
+                    locations.add(location.toPath());
                 }
+                return true;
             });
             assertThat(locations, containsInAnyOrder("a.txt", "a/b.txt", "a/b/c.txt"));
         }

--- a/compiler-project/packaging/src/test/java/com/asakusafw/lang/compiler/packaging/ResourceAssemblerTest.java
+++ b/compiler-project/packaging/src/test/java/com/asakusafw/lang/compiler/packaging/ResourceAssemblerTest.java
@@ -20,12 +20,12 @@ import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import org.junit.Test;
 
 import com.asakusafw.lang.compiler.common.Location;
-import com.asakusafw.lang.compiler.common.Predicate;
 
 /**
  * Test for {@link ResourceAssembler}.
@@ -219,12 +219,7 @@ public class ResourceAssemblerTest extends ResourceTestRoot {
     }
 
     private Predicate<Location> pattern(String pattern) {
-        final Pattern p = Pattern.compile(pattern);
-        return new Predicate<Location>() {
-            @Override
-            public boolean apply(Location argument) {
-                return p.matcher(argument.toPath()).matches();
-            }
-        };
+        Pattern p = Pattern.compile(pattern);
+        return argument -> p.matcher(argument.toPath()).matches();
     }
 }

--- a/compiler-project/packaging/src/test/java/com/asakusafw/lang/compiler/packaging/ResourceTestRoot.java
+++ b/compiler-project/packaging/src/test/java/com/asakusafw/lang/compiler/packaging/ResourceTestRoot.java
@@ -47,13 +47,8 @@ public abstract class ResourceTestRoot {
      * @param contents the target contents
      * @return the content provider
      */
-    public static ContentProvider provider(final String contents) {
-        return new ContentProvider() {
-            @Override
-            public void writeTo(OutputStream output) throws IOException {
-                output.write(contents.getBytes(ENCODING));
-            }
-        };
+    public static ContentProvider provider(String contents) {
+        return output -> output.write(contents.getBytes(ENCODING));
     }
 
     /**

--- a/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/OperatorEquivalence.java
+++ b/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/OperatorEquivalence.java
@@ -20,17 +20,13 @@ import com.asakusafw.lang.compiler.model.graph.Operator;
 /**
  * Extracts ID of operator equivalences.
  */
+@FunctionalInterface
 public interface OperatorEquivalence {
 
     /**
      * Use original serial number as ID.
      */
-    OperatorEquivalence SAME_ORIGIN = new OperatorEquivalence() {
-        @Override
-        public Object extract(SubPlan owner, Operator operator) {
-            return operator.getOriginalSerialNumber();
-        }
-    };
+    OperatorEquivalence SAME_ORIGIN = (owner, operator) -> operator.getOriginalSerialNumber();
 
     /**
      * Returns the equivalence ID from the target operator.

--- a/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/PlanBuilder.java
+++ b/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/PlanBuilder.java
@@ -200,7 +200,7 @@ public final class PlanBuilder {
         Set<Operator> saw = new LinkedHashSet<>();
         for (MarkerOperator operator : inputs) {
             Set<Operator> reachables = Operators.findNearestReachableSuccessors(
-                    operator.getOutputs(), Planning.PLAN_MARKERS);
+                    operator.getOutputs(), PlanMarkers::exists);
             if (strict) {
                 for (MarkerOperator other : inputs) {
                     if (reachables.contains(other)) {
@@ -231,7 +231,7 @@ public final class PlanBuilder {
         if (strict) {
             for (MarkerOperator operator : outputs) {
                 Set<Operator> reachables = Operators.findNearestReachablePredecessors(
-                        operator.getInputs(), Planning.PLAN_MARKERS);
+                        operator.getInputs(), PlanMarkers::exists);
                 for (MarkerOperator other : outputs) {
                     if (reachables.contains(other)) {
                         throw new IllegalArgumentException(MessageFormat.format(
@@ -279,11 +279,11 @@ public final class PlanBuilder {
         Set<Operator> range = new HashSet<>();
         range.addAll(Operators.collectUntilNearestReachableSuccessors(
                 Operators.getOutputs(in),
-                Planning.PLAN_MARKERS,
+                PlanMarkers::exists,
                 false));
         range.retainAll(Operators.collectUntilNearestReachablePredecessors(
                 Operators.getInputs(out),
-                Planning.PLAN_MARKERS,
+                PlanMarkers::exists,
                 false));
         range.addAll(in);
         range.addAll(out);

--- a/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/PlanMarkers.java
+++ b/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/PlanMarkers.java
@@ -26,6 +26,8 @@ import com.asakusafw.lang.compiler.model.graph.Operators;
 /**
  * Utilities for {@link PlanMarker}.
  * @see Operators
+ * @since 0.1.0
+ * @version 0.4.0
  */
 public final class PlanMarkers {
 
@@ -43,6 +45,15 @@ public final class PlanMarkers {
         return MarkerOperator.builder(dataType)
                 .attribute(PlanMarker.class, marker)
                 .build();
+    }
+
+    /**
+     * Returns whether or not the operator has {@link PlanMarker}.
+     * @param operator the target operator
+     * @return {@code true} if the operator has a marker, otherwise {@code false}
+     */
+    public static boolean exists(Operator operator) {
+        return get(operator) != null;
     }
 
     /**

--- a/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/Planning.java
+++ b/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/Planning.java
@@ -20,8 +20,8 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
-import com.asakusafw.lang.compiler.common.Predicate;
 import com.asakusafw.lang.compiler.model.graph.ExternalInput;
 import com.asakusafw.lang.compiler.model.graph.ExternalOutput;
 import com.asakusafw.lang.compiler.model.graph.FlowOperator;
@@ -48,12 +48,7 @@ public final class Planning {
     /**
      * A predicate only accepts plan markers.
      */
-    public static final Predicate<Operator> PLAN_MARKERS = new Predicate<Operator>() {
-        @Override
-        public boolean apply(Operator argument) {
-            return PlanMarkers.get(argument) != null;
-        }
-    };
+    public static final Predicate<Operator> PLAN_MARKERS = PlanMarkers::exists;
 
     private Planning() {
         return;

--- a/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/SubPlan.java
+++ b/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/SubPlan.java
@@ -147,7 +147,9 @@ public interface SubPlan extends AttributeContainer {
          * @param opposite the opposite port
          * @return {@code true} if their are connected, otherwise {@code false}
          */
-        boolean isConnected(Output opposite);
+        default boolean isConnected(Output opposite) {
+            return getOpposites().contains(opposite);
+        }
 
         /**
          * Returns the upstream outputs.
@@ -167,7 +169,9 @@ public interface SubPlan extends AttributeContainer {
          * @param opposite the opposite port
          * @return {@code true} if their are connected, otherwise {@code false}
          */
-        boolean isConnected(Input opposite);
+        default boolean isConnected(Input opposite) {
+            return getOpposites().contains(opposite);
+        }
 
         /**
          * Returns the downstream inputs.

--- a/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/basic/BasicSubPlan.java
+++ b/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/basic/BasicSubPlan.java
@@ -284,15 +284,6 @@ public final class BasicSubPlan extends BasicAttributeContainer implements SubPl
             opposites.remove(opposite);
         }
 
-        /**
-         * Returns whether this is connected to the specified opposite or not.
-         * @param opposite the opposite port
-         * @return {@code true} if their are connected, otherwise {@code false}
-         */
-        protected boolean isConnected(Port opposite) {
-            return opposites.contains(opposite);
-        }
-
         @Override
         public Set<TOpposite> getOpposites() {
             return new LinkedHashSet<>(opposites);
@@ -315,11 +306,6 @@ public final class BasicSubPlan extends BasicAttributeContainer implements SubPl
         @Override
         BasicInput getSelf() {
             return this;
-        }
-
-        @Override
-        public boolean isConnected(Output opposite) {
-            return isConnected((Port) opposite);
         }
 
         @Override
@@ -347,11 +333,6 @@ public final class BasicSubPlan extends BasicAttributeContainer implements SubPl
         @Override
         BasicOutput getSelf() {
             return this;
-        }
-
-        @Override
-        public boolean isConnected(Input opposite) {
-            return isConnected((Port) opposite);
         }
 
         @Override

--- a/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/basic/BasicSubPlanEditor.java
+++ b/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/basic/BasicSubPlanEditor.java
@@ -167,7 +167,7 @@ final class BasicSubPlanEditor {
     }
 
     private boolean removeRedundantInputs() {
-        final Set<Operator> candidates = collectOpenPorts(target.getInputs());
+        Set<Operator> candidates = collectOpenPorts(target.getInputs());
         if (candidates.isEmpty()) {
             return false;
         }
@@ -187,7 +187,7 @@ final class BasicSubPlanEditor {
     }
 
     private boolean removeRedundantOutputs() {
-        final Set<Operator> candidates = collectOpenPorts(target.getOutputs());
+        Set<Operator> candidates = collectOpenPorts(target.getOutputs());
         if (candidates.isEmpty()) {
             return false;
         }
@@ -206,7 +206,7 @@ final class BasicSubPlanEditor {
     }
 
     private static Set<Operator> collectOpenPorts(Collection<? extends SubPlan.Port> ports) {
-        final Set<Operator> results = new HashSet<>();
+        Set<Operator> results = new HashSet<>();
         for (SubPlan.Port port : ports) {
             if (port.getOpposites().isEmpty()) {
                 results.add(port.getOperator());

--- a/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/basic/OperatorGroup.java
+++ b/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/basic/OperatorGroup.java
@@ -133,12 +133,7 @@ final class OperatorGroup {
     }
 
     public boolean applyRedundantOutputElimination() {
-        return applyCombination(new Applier() {
-            @Override
-            public boolean apply(Operator base, Operator target) {
-                return applyRedundantOutputElimination(base, target);
-            }
-        });
+        return applyCombination((base, target) -> applyRedundantOutputElimination(base, target));
     }
 
     boolean applyRedundantOutputElimination(Operator base, Operator target) {
@@ -190,12 +185,7 @@ final class OperatorGroup {
                 || attributes.contains(Attribute.GENERATOR)) {
             return false;
         }
-        return applyCombination(new Applier() {
-            @Override
-            public boolean apply(Operator base, Operator target) {
-                return applyUnionPushDown(base, target);
-            }
-        });
+        return applyCombination((base, target) -> applyUnionPushDown(base, target));
     }
 
     boolean applyUnionPushDown(Operator base, Operator target) {
@@ -520,6 +510,7 @@ final class OperatorGroup {
         }
     }
 
+    @FunctionalInterface
     private interface Applier {
 
         boolean apply(Operator base, Operator target);

--- a/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/basic/PrimitivePlanner.java
+++ b/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/basic/PrimitivePlanner.java
@@ -191,7 +191,7 @@ public final class PrimitivePlanner {
         Operator gathering = successors.iterator().next();
         Set<Operator> gatherGroupCandidates = Operators.findNearestReachablePredecessors(
                 gathering.getInputs(),
-                Planning.PLAN_MARKERS);
+                PlanMarkers::exists);
         assert gatherGroupCandidates.contains(gather);
         Set<MarkerOperator> results = new HashSet<>();
         for (Operator operator : gatherGroupCandidates) {
@@ -234,7 +234,7 @@ public final class PrimitivePlanner {
     private Set<MarkerOperator> collectPossibleOutputOperatorsFor(Set<MarkerOperator> inputs) {
         Set<MarkerOperator> outputCandidates = toMarkers(Operators.findNearestReachableSuccessors(
                 Operators.getOutputs(inputs),
-                Planning.PLAN_MARKERS));
+                PlanMarkers::exists));
         return outputCandidates;
     }
 
@@ -256,11 +256,11 @@ public final class PrimitivePlanner {
         Set<Operator> bodyOperators = new HashSet<>();
         bodyOperators.addAll(Operators.collectUntilNearestReachableSuccessors(
                 Operators.getOutputs(inputs),
-                Planning.PLAN_MARKERS,
+                PlanMarkers::exists,
                 false));
         bodyOperators.retainAll(Operators.collectUntilNearestReachablePredecessors(
                 Operators.getInputs(outputs),
-                Planning.PLAN_MARKERS,
+                PlanMarkers::exists,
                 false));
 
         // find for broadcast consumers, and returns the corresponded BROADCAST plan markers

--- a/compiler-project/plan/src/test/java/com/asakusafw/lang/compiler/planning/PlanAssemblerTest.java
+++ b/compiler-project/plan/src/test/java/com/asakusafw/lang/compiler/planning/PlanAssemblerTest.java
@@ -385,14 +385,11 @@ in0 +-- c0 --- out0
             .add(ownersOf(origin, mock.getAsSet("out2")))
             .withRedundantOutputElimination(true)
             .withDuplicateCheckpointElimination(true)
-            .withCustomEquivalence(new OperatorEquivalence() {
-                @Override
-                public Object extract(SubPlan owner, Operator operator) {
-                    if (owner.findOutput(operator) != null) {
-                        return PlanMarkers.get(operator);
-                    }
-                    return PlanAssembler.DEFAULT_EQUIVALENCE.extract(owner, operator);
+            .withCustomEquivalence((owner, operator) -> {
+                if (owner.findOutput(operator) != null) {
+                    return PlanMarkers.get(operator);
                 }
+                return PlanAssembler.DEFAULT_EQUIVALENCE.extract(owner, operator);
             })
             .build();
         assertThat(detail.getPlan().getElements(), hasSize(4));

--- a/compiler-project/plan/src/test/java/com/asakusafw/lang/compiler/planning/PlanningTestRoot.java
+++ b/compiler-project/plan/src/test/java/com/asakusafw/lang/compiler/planning/PlanningTestRoot.java
@@ -123,7 +123,7 @@ public abstract class PlanningTestRoot {
      * @param constraint the constraint
      * @return the predicate
      */
-    public static Predicate<Operator> only(final OperatorConstraint constraint) {
+    public static Predicate<Operator> only(OperatorConstraint constraint) {
         return operator -> operator.getConstraints().contains(constraint);
     }
 

--- a/compiler-project/plan/src/test/java/com/asakusafw/lang/compiler/planning/PlanningTestRoot.java
+++ b/compiler-project/plan/src/test/java/com/asakusafw/lang/compiler/planning/PlanningTestRoot.java
@@ -24,11 +24,11 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 
-import com.asakusafw.lang.compiler.common.Predicate;
 import com.asakusafw.lang.compiler.model.graph.MarkerOperator;
 import com.asakusafw.lang.compiler.model.graph.Operator;
 import com.asakusafw.lang.compiler.model.graph.OperatorConstraint;
@@ -124,12 +124,7 @@ public abstract class PlanningTestRoot {
      * @return the predicate
      */
     public static Predicate<Operator> only(final OperatorConstraint constraint) {
-        return new Predicate<Operator>() {
-            @Override
-            public boolean apply(Operator argument) {
-                return argument.getConstraints().contains(constraint);
-            }
-        };
+        return operator -> operator.getConstraints().contains(constraint);
     }
 
     /**

--- a/compiler-project/test-adapter/src/main/java/com/asakusafw/lang/compiler/testdriver/adapter/CompilerProfileInitializer.java
+++ b/compiler-project/test-adapter/src/main/java/com/asakusafw/lang/compiler/testdriver/adapter/CompilerProfileInitializer.java
@@ -22,6 +22,7 @@ import com.asakusafw.testdriver.compiler.CompilerConfiguration;
  * Initializes {@link CompilerProfile} for Asakusa DSL TestKit.
  * @since 0.8.0
  */
+@FunctionalInterface
 public interface CompilerProfileInitializer {
 
     /**

--- a/compiler-project/test-adapter/src/test/java/com/asakusafw/lang/compiler/testdriver/adapter/CompilerToolkitAdapterTest.java
+++ b/compiler-project/test-adapter/src/test/java/com/asakusafw/lang/compiler/testdriver/adapter/CompilerToolkitAdapterTest.java
@@ -33,7 +33,6 @@ import com.asakusafw.lang.compiler.testdriver.adapter.mock.SimpleBatch;
 import com.asakusafw.lang.compiler.testdriver.adapter.mock.SimpleInputDescription;
 import com.asakusafw.lang.compiler.testdriver.adapter.mock.SimpleJobflow;
 import com.asakusafw.lang.compiler.testdriver.adapter.mock.SimpleOutputDescription;
-import com.asakusafw.lang.compiler.tester.CompilerProfile;
 import com.asakusafw.testdriver.compiler.ArtifactMirror;
 import com.asakusafw.testdriver.compiler.BatchMirror;
 import com.asakusafw.testdriver.compiler.CompilerConfiguration;
@@ -141,13 +140,9 @@ public class CompilerToolkitAdapterTest {
         CompilerConfiguration conf = tk.newConfiguration();
         conf.withClassLoader(getClass().getClassLoader());
         conf.withWorkingDirectory(temporary.newFolder());
-        ((CompilerConfigurationAdapter) conf).withEdit(new CompilerProfile.Edit() {
-            @Override
-            public void perform(CompilerProfile profile) throws IOException {
-                profile.forToolRepository()
-                    .use(new MockJobflowProcessor());
-            }
-        });
+        ((CompilerConfigurationAdapter) conf).withEdit(profile -> profile
+                .forToolRepository()
+                .use(new MockJobflowProcessor()));
         return conf;
     }
 

--- a/compiler-project/tester/src/main/java/com/asakusafw/lang/compiler/tester/CompilerProfile.java
+++ b/compiler-project/tester/src/main/java/com/asakusafw/lang/compiler/tester/CompilerProfile.java
@@ -281,6 +281,7 @@ public final class CompilerProfile {
     /**
      * A callback object for {@link CompilerProfile}.
      */
+    @FunctionalInterface
     public interface Edit {
 
         /**

--- a/compiler-project/tester/src/main/java/com/asakusafw/lang/compiler/tester/executor/ArtifactExecutor.java
+++ b/compiler-project/tester/src/main/java/com/asakusafw/lang/compiler/tester/executor/ArtifactExecutor.java
@@ -16,6 +16,7 @@
 package com.asakusafw.lang.compiler.tester.executor;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 
 import com.asakusafw.lang.compiler.tester.TesterContext;
@@ -24,6 +25,7 @@ import com.asakusafw.lang.compiler.tester.TesterContext;
  * Executes a compilation artifact for testing.
  * @param <T> the artifact type
  */
+@FunctionalInterface
 public interface ArtifactExecutor<T> {
 
     /**
@@ -33,7 +35,9 @@ public interface ArtifactExecutor<T> {
      * @throws InterruptedException if interrupted while executing the artifact
      * @throws IOException if failed to execute the target artifact
      */
-    void execute(TesterContext context, T artifact) throws InterruptedException, IOException;
+    default void execute(TesterContext context, T artifact) throws InterruptedException, IOException {
+        execute(context, artifact, Collections.emptyMap());
+    }
 
     /**
      * Executes the artifact with empty batch arguments.

--- a/compiler-project/tester/src/main/java/com/asakusafw/lang/compiler/tester/executor/BatchExecutor.java
+++ b/compiler-project/tester/src/main/java/com/asakusafw/lang/compiler/tester/executor/BatchExecutor.java
@@ -18,7 +18,6 @@ package com.asakusafw.lang.compiler.tester.executor;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,11 +76,6 @@ public class BatchExecutor implements ArtifactExecutor<BatchArtifact> {
     }
 
     @Override
-    public void execute(TesterContext context, BatchArtifact artifact) throws InterruptedException, IOException {
-        execute(context, artifact, Collections.emptyMap());
-    }
-
-    @Override
     public void execute(
             TesterContext context,
             BatchArtifact artifact,
@@ -132,6 +126,7 @@ public class BatchExecutor implements ArtifactExecutor<BatchArtifact> {
     /**
      * Represents an action for {@link BatchExecutor}.
      */
+    @FunctionalInterface
     public interface Action {
 
         /**

--- a/compiler-project/tester/src/main/java/com/asakusafw/lang/compiler/tester/executor/JobflowExecutor.java
+++ b/compiler-project/tester/src/main/java/com/asakusafw/lang/compiler/tester/executor/JobflowExecutor.java
@@ -100,11 +100,6 @@ public class JobflowExecutor implements ArtifactExecutor<JobflowArtifact> {
     }
 
     @Override
-    public void execute(TesterContext context, JobflowArtifact artifact) throws InterruptedException, IOException {
-        execute(context, artifact, Collections.emptyMap());
-    }
-
-    @Override
     public void execute(
             TesterContext context,
             JobflowArtifact artifact,
@@ -175,6 +170,7 @@ public class JobflowExecutor implements ArtifactExecutor<JobflowArtifact> {
     /**
      * Represents an action for {@link JobflowExecutor}.
      */
+    @FunctionalInterface
     public interface Action {
 
         /**

--- a/compiler-project/tester/src/test/java/com/asakusafw/lang/compiler/tester/CompilerProfileTest.java
+++ b/compiler-project/tester/src/test/java/com/asakusafw/lang/compiler/tester/CompilerProfileTest.java
@@ -19,7 +19,6 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -52,7 +51,6 @@ import com.asakusafw.lang.compiler.model.info.ExternalInputInfo;
 import com.asakusafw.lang.compiler.model.info.ExternalOutputInfo;
 import com.asakusafw.lang.compiler.packaging.ByteArrayItem;
 import com.asakusafw.lang.compiler.packaging.ResourceItem;
-import com.asakusafw.lang.compiler.tester.CompilerProfile.Edit;
 import com.asakusafw.lang.compiler.tester.executor.DummyTaskExecutor;
 import com.asakusafw.lang.compiler.tester.executor.JobflowExecutor;
 
@@ -79,14 +77,9 @@ public class CompilerProfileTest {
 
         CompilerProfile profile = newProfile();
         profile.forToolRepository()
-            .use(new JobflowProcessor() {
-                @Override
-                public void process(Context context, Jobflow source) throws IOException {
-                    context.addTask(
-                            "testing", "testing",
-                            Location.of("testing"), Collections.emptyList());
-                }
-            });
+            .use((JobflowProcessor) (context, source) -> context.addTask(
+                    "testing", "testing",
+                    Location.of("testing"), Collections.emptyList()));
 
         File home;
         File batchapps;
@@ -195,12 +188,7 @@ public class CompilerProfileTest {
     @Test
     public void edit() throws Exception {
         CompilerProfile profile = newProfile();
-        profile.apply(new Edit() {
-            @Override
-            public void perform(CompilerProfile p) throws IOException {
-                p.withEnvironmentVariables(Collections.singletonMap("a", "A"));
-            }
-        });
+        profile.apply(p -> p.withEnvironmentVariables(Collections.singletonMap("a", "A")));
         try (CompilerTester compiler = profile.build()) {
             Map<String, String> env = compiler.getTesterContext().getEnvironmentVariables();
             assertThat(env, hasEntry("a", "A"));
@@ -215,11 +203,8 @@ public class CompilerProfileTest {
     public void copy() throws Exception {
         CompilerProfile profile = newProfile();
         profile.forToolRepository()
-            .use(new JobflowProcessor() {
-                @Override
-                public void process(Context context, Jobflow source) throws IOException {
-                    return;
-                }
+            .use((JobflowProcessor) (context, source) -> {
+                return;
             });
 
         File copy = new File(folder.getRoot(), "copy");

--- a/inspection-project/gui/src/main/java/com/asakusafw/lang/inspection/gui/Main.java
+++ b/inspection-project/gui/src/main/java/com/asakusafw/lang/inspection/gui/Main.java
@@ -16,7 +16,6 @@
 package com.asakusafw.lang.inspection.gui;
 
 import java.awt.Window;
-import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -196,7 +195,7 @@ public class Main implements Runnable {
     }
 
     private JTree createOverviewTree(InspectionNode root) {
-        final JTree tree = new JTree(new InspectionTreeNode(root));
+        JTree tree = new JTree(new InspectionTreeNode(root));
         tree.getSelectionModel().setSelectionMode(TreeSelectionModel.SINGLE_TREE_SELECTION);
         tree.addMouseListener(new MouseAdapter() {
             @Override
@@ -218,27 +217,12 @@ public class Main implements Runnable {
                 if (path == null) {
                     return;
                 }
-                final InspectionTreeNode node = (InspectionTreeNode) path.getLastPathComponent();
+                InspectionTreeNode node = (InspectionTreeNode) path.getLastPathComponent();
                 JPopupMenu menu = new JPopupMenu();
-                menu.add(item("Open Detail", new ActionListener() {
-                    @Override
-                    public void actionPerformed(ActionEvent e) {
-                        onOpenDetail(tree, node);
-                    }
-                }));
+                menu.add(item("Open Detail", e -> onOpenDetail(tree, node)));
                 if (pdfExporter != null && node.isLeaf() == false) {
-                    menu.add(item("Export PDF", new ActionListener() {
-                        @Override
-                        public void actionPerformed(ActionEvent e) {
-                            onExportPdf(tree, node, false);
-                        }
-                    }));
-                    menu.add(item("Export PDF (Verbose)", new ActionListener() {
-                        @Override
-                        public void actionPerformed(ActionEvent e) {
-                            onExportPdf(tree, node, true);
-                        }
-                    }));
+                    menu.add(item("Export PDF", e -> onExportPdf(tree, node, false)));
+                    menu.add(item("Export PDF (Verbose)", e -> onExportPdf(tree, node, true)));
                 }
                 menu.show(tree, event.getX(), event.getY());
             }

--- a/inspection-project/processor/src/main/java/com/asakusafw/lang/inspection/processor/InspectionNodeProcessor.java
+++ b/inspection-project/processor/src/main/java/com/asakusafw/lang/inspection/processor/InspectionNodeProcessor.java
@@ -25,6 +25,7 @@ import com.asakusafw.lang.inspection.InspectionNode;
 /**
  * Processes an {@link InspectionNode}.
  */
+@FunctionalInterface
 public interface InspectionNodeProcessor {
 
     /**


### PR DESCRIPTION
## Summary

This fixes code style for Java 8.

## Background, Problem or Goal of the patch

This is similar to the upstream asakusafw/asakusafw#667, and includes changes for the upstream.

## Design of the fix, or a new feature

This includes the following revisions:
* remove redundant members changed in the upstream
* lambda expressions instead of anonymous classes
* effective final instead of explicit final
* interface default methods instead of abstract adapter classes
* standard functional interfaces instead of custom interfaces

## Related Issue, Pull Request or Code

* asakusafw/asakusafw#667

## Wanted reviewer

N/A.