### PR TITLE
Support `asakusafw.sdk.*` convention on Gradle.

### DIFF
--- a/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaBasePlugin.groovy
+++ b/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaBasePlugin.groovy
@@ -47,6 +47,8 @@ class AsakusaVanillaBasePlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
         this.project = project
+        project.apply plugin: AsakusafwBasePlugin
+
         this.extension = project.extensions.create('asakusaVanillaBase', AsakusaVanillaBaseExtension)
         configureExtension()
         configureTasks()
@@ -121,13 +123,5 @@ class AsakusaVanillaBasePlugin implements Plugin<Project> {
         project.tasks.getByName(AsakusafwBasePlugin.TASK_VERSIONS) << {
             logger.lifecycle "Asakusa Vanilla: ${extension.featureVersion}"
         }
-    }
-
-    /**
-     * Returns the extension.
-     * @return the extension
-     */
-    AsakusaVanillaBaseExtension getExtension() {
-        return extension
     }
 }

--- a/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaSdkBasePlugin.groovy
+++ b/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaSdkBasePlugin.groovy
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.gradle.plugins.internal
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+import com.asakusafw.gradle.plugins.AsakusafwCompilerExtension
+import com.asakusafw.gradle.plugins.AsakusafwPluginConvention
+import com.asakusafw.gradle.plugins.AsakusafwSdkExtension
+import com.asakusafw.gradle.plugins.internal.AsakusaSdkPlugin
+import com.asakusafw.gradle.plugins.internal.PluginUtils
+
+/**
+ * A base plug-in of {@link AsakusaVanillaSdkPlugin}.
+ * This only organizes conventions and dependencies.
+ * @since 0.4.0
+ */
+class AsakusaVanillaSdkBasePlugin implements Plugin<Project> {
+
+    private Project project
+
+    private AsakusafwCompilerExtension extension
+
+    @Override
+    void apply(Project project) {
+        this.project = project
+
+        project.apply plugin: AsakusaSdkPlugin
+        project.apply plugin: AsakusaVanillaBasePlugin
+        this.extension = AsakusaSdkPlugin.get(project).extensions.create('vanilla', AsakusafwCompilerExtension)
+
+        configureExtension()
+        configureConfigurations()
+    }
+
+    private void configureExtension() {
+        AsakusaVanillaBaseExtension base = AsakusaVanillaBasePlugin.get(project)
+        AsakusafwPluginConvention sdk = AsakusaSdkPlugin.get(project)
+        extension.conventionMapping.with {
+            outputDirectory = { project.relativePath(new File(project.buildDir, 'vanilla-batchapps')) }
+            batchIdPrefix = { (String) 'vanilla.' }
+            failOnError = { true }
+        }
+        extension.compilerProperties.put('javac.version', { sdk.javac.sourceCompatibility.toString() })
+        PluginUtils.injectVersionProperty(extension, { base.featureVersion })
+        sdk.sdk.availableTestkits << new AsakusaVanillaTestkit()
+    }
+
+    private void configureConfigurations() {
+        project.configurations {
+            asakusaVanillaCommon {
+                description 'Common libraries of Asakusa DSL Compiler for Vanilla'
+                exclude group: 'asm', module: 'asm'
+            }
+            asakusaVanillaCompiler {
+                description 'Full classpath of Asakusa DSL Compiler for Vanilla'
+                extendsFrom project.configurations.compile
+                extendsFrom project.configurations.asakusaVanillaCommon
+            }
+            asakusaVanillaTestkit {
+                description 'Asakusa DSL testkit classpath for Vanilla'
+                extendsFrom project.configurations.asakusaVanillaCommon
+                exclude group: 'com.asakusafw', module: 'asakusa-test-mapreduce'
+            }
+        }
+        PluginUtils.afterEvaluate(project) {
+            AsakusaVanillaBaseExtension base = AsakusaVanillaBasePlugin.get(project)
+            AsakusafwPluginConvention sdk = AsakusaSdkPlugin.get(project)
+            AsakusafwSdkExtension features = sdk.sdk
+            project.dependencies {
+                if (features.core) {
+                    asakusaVanillaCommon "com.asakusafw.vanilla.compiler:asakusa-vanilla-compiler-core:${base.featureVersion}"
+                    asakusaVanillaCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-cleanup:${base.featureVersion}"
+                    asakusaVanillaCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-redirector:${base.featureVersion}"
+                    asakusaVanillaCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-yaess:${base.featureVersion}"
+                    asakusaVanillaCommon "com.asakusafw.lang.compiler:asakusa-compiler-cli:${base.featureVersion}"
+                    asakusaVanillaCommon "com.asakusafw:simple-graph:${sdk.asakusafwVersion}"
+                    asakusaVanillaCommon "com.asakusafw:java-dom:${sdk.asakusafwVersion}"
+                    asakusaVanillaCompiler "com.asakusafw:asakusa-dsl-vocabulary:${sdk.asakusafwVersion}"
+                    asakusaVanillaCompiler "com.asakusafw:asakusa-runtime:${sdk.asakusafwVersion}"
+                    asakusaVanillaCompiler "com.asakusafw:asakusa-yaess-core:${sdk.asakusafwVersion}"
+
+                    if (features.directio) {
+                        asakusaVanillaCommon "com.asakusafw.dag.compiler:asakusa-dag-compiler-extension-directio:${base.featureVersion}"
+                        asakusaVanillaCompiler "com.asakusafw:asakusa-directio-vocabulary:${sdk.asakusafwVersion}"
+                    }
+                    if (features.windgate) {
+                        asakusaVanillaCommon "com.asakusafw.dag.compiler:asakusa-dag-compiler-extension-windgate:${base.featureVersion}"
+                        asakusaVanillaCompiler "com.asakusafw:asakusa-windgate-vocabulary:${sdk.asakusafwVersion}"
+                    }
+                    if (features.hive) {
+                        asakusaVanillaCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-hive:${base.featureVersion}"
+                    }
+                }
+                if (features.testing) {
+                    asakusaVanillaTestkit "com.asakusafw.vanilla.runtime:asakusa-vanilla-assembly:${base.featureVersion}"
+                    asakusaVanillaTestkit "com.asakusafw.vanilla.testkit:asakusa-vanilla-test-adapter:${base.featureVersion}"
+                    asakusaVanillaTestkit "com.asakusafw.vanilla.testkit:asakusa-vanilla-test-inprocess:${base.featureVersion}"
+                    asakusaVanillaTestkit "com.asakusafw:asakusa-test-inprocess:${sdk.asakusafwVersion}"
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns the extension object of this plug-in.
+     * The plug-in will be applied automatically.
+     * @param project the target project
+     * @return the related extension
+     */
+    static AsakusafwCompilerExtension get(Project project) {
+        project.apply plugin: AsakusaVanillaSdkBasePlugin
+        AsakusaVanillaSdkBasePlugin plugin = project.plugins.getPlugin(AsakusaVanillaSdkBasePlugin)
+        if (plugin == null) {
+            throw new IllegalStateException('AsakusaVanillaSdkBasePlugin has not been applied')
+        }
+        return plugin.extension
+    }
+}

--- a/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaSdkPlugin.groovy
+++ b/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaSdkPlugin.groovy
@@ -29,6 +29,7 @@ import com.asakusafw.gradle.tasks.internal.ResolutionUtils
 /**
  * A Gradle sub plug-in for Asakusa Vanilla SDK.
  * @since 0.4.0
+ * @see AsakusaVanillaSdkBasePlugin
  */
 class AsakusaVanillaSdkPlugin implements Plugin<Project> {
 
@@ -45,70 +46,10 @@ class AsakusaVanillaSdkPlugin implements Plugin<Project> {
     void apply(Project project) {
         this.project = project
 
-        project.apply plugin: 'asakusafw-sdk'
-        project.apply plugin: AsakusaVanillaBasePlugin
-        extension = AsakusaSdkPlugin.get(project).extensions.create('vanilla', AsakusafwCompilerExtension)
+        project.apply plugin: AsakusaVanillaSdkBasePlugin
+        this.extension = AsakusaVanillaSdkBasePlugin.get(project)
 
-        configureExtension()
-        configureConfigurations()
         defineTasks()
-    }
-
-    private void configureExtension() {
-        AsakusafwPluginConvention sdk = AsakusaSdkPlugin.get(project)
-        extension.conventionMapping.with {
-            outputDirectory = { project.relativePath(new File(project.buildDir, 'vanilla-batchapps')) }
-            batchIdPrefix = { (String) 'vanilla.' }
-            failOnError = { true }
-        }
-        extension.compilerProperties.put('javac.version', { sdk.javac.sourceCompatibility.toString() })
-    }
-
-    private void configureConfigurations() {
-        project.configurations {
-            asakusaVanillaCommon {
-                description 'Common libraries of Asakusa DSL Compiler for Vanilla'
-                exclude group: 'asm', module: 'asm'
-            }
-            asakusaVanillaCompiler {
-                description 'Full classpath of Asakusa DSL Compiler for Vanilla'
-                extendsFrom project.configurations.compile
-                extendsFrom project.configurations.asakusaVanillaCommon
-            }
-            asakusaVanillaTestkit {
-                description 'Asakusa DSL testkit classpath for Vanilla'
-                extendsFrom project.configurations.asakusaVanillaCommon
-                exclude group: 'com.asakusafw', module: 'asakusa-test-mapreduce'
-            }
-        }
-        PluginUtils.afterEvaluate(project) {
-            AsakusaVanillaBaseExtension base = AsakusaVanillaBasePlugin.get(project)
-            AsakusafwPluginConvention sdk = AsakusaSdkPlugin.get(project)
-            project.dependencies {
-                asakusaVanillaCommon "com.asakusafw.vanilla.compiler:asakusa-vanilla-compiler-core:${base.featureVersion}"
-                asakusaVanillaCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-redirector:${base.featureVersion}"
-                asakusaVanillaCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-yaess:${base.featureVersion}"
-                asakusaVanillaCommon "com.asakusafw:simple-graph:${sdk.asakusafwVersion}"
-                asakusaVanillaCommon "com.asakusafw:java-dom:${sdk.asakusafwVersion}"
-                asakusaVanillaCommon "com.asakusafw.lang.compiler:asakusa-compiler-cli:${base.featureVersion}"
-                asakusaVanillaCompiler "com.asakusafw:asakusa-dsl-vocabulary:${sdk.asakusafwVersion}"
-                asakusaVanillaCompiler "com.asakusafw:asakusa-runtime:${sdk.asakusafwVersion}"
-                asakusaVanillaCompiler "com.asakusafw:asakusa-yaess-core:${sdk.asakusafwVersion}"
-
-                asakusaVanillaCommon "com.asakusafw.dag.compiler:asakusa-dag-compiler-extension-directio:${base.featureVersion}"
-                asakusaVanillaCompiler "com.asakusafw:asakusa-directio-vocabulary:${sdk.asakusafwVersion}"
-
-                asakusaVanillaCommon "com.asakusafw.dag.compiler:asakusa-dag-compiler-extension-windgate:${base.featureVersion}"
-                asakusaVanillaCompiler "com.asakusafw:asakusa-windgate-vocabulary:${sdk.asakusafwVersion}"
-
-                asakusaVanillaCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-hive:${base.featureVersion}"
-
-                asakusaVanillaTestkit "com.asakusafw.vanilla.runtime:asakusa-vanilla-assembly:${base.featureVersion}"
-                asakusaVanillaTestkit "com.asakusafw.vanilla.testkit:asakusa-vanilla-test-adapter:${base.featureVersion}"
-                asakusaVanillaTestkit "com.asakusafw.vanilla.testkit:asakusa-vanilla-test-inprocess:${base.featureVersion}"
-                asakusaVanillaTestkit "com.asakusafw:asakusa-test-inprocess:${sdk.asakusafwVersion}"
-            }
-        }
     }
 
     private void defineTasks() {

--- a/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaTestkit.groovy
+++ b/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaTestkit.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.gradle.plugins.internal
+
+import org.gradle.api.Project
+
+import com.asakusafw.gradle.plugins.AsakusaTestkit
+import com.asakusafw.gradle.plugins.AsakusafwPluginConvention
+import com.asakusafw.gradle.plugins.internal.AsakusaSdkPlugin
+
+/**
+ * An implementation of {@link AsakusaTestkit} which uses Asakusa Vanilla.
+ * @since 0.4.0
+ */
+class AsakusaVanillaTestkit implements AsakusaTestkit {
+
+    @Override
+    String getName() {
+        return 'vanilla'
+    }
+
+    @Override
+    int getPriority() {
+        return 10
+    }
+
+    @Override
+    void apply(Project project) {
+        project.logger.info "enabling Vanilla Testkit (${name})"
+        project.configurations {
+            testCompile.extendsFrom asakusaVanillaTestkit
+        }
+    }
+
+    @Override
+    String toString() {
+        return "Testkit(${name})"
+    }
+}

--- a/vanilla/gradle/src/test/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaSdkPluginTest.groovy
+++ b/vanilla/gradle/src/test/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaSdkPluginTest.groovy
@@ -84,6 +84,15 @@ class AsakusaVanillaSdkPluginTest {
     }
 
     /**
+     * test for version.
+     */
+    @Test
+    void extension_version() {
+        project.asakusaVanillaBase.featureVersion = '__VERSION__'
+        assert project.asakusafw.vanilla.version == '__VERSION__'
+    }
+
+    /**
      * test for {@code tasks.vanillaCompileBatchapps}.
      */
     @Test


### PR DESCRIPTION
## Summary

This PR fixes for changes in asakusafw/asakusafw-sdk#109, which has been introduced `asakusafw.sdk.*` convention into Asakusa SDK Gradle plugin.

## Background, Problem or Goal of the patch

see asakusafw/asakusafw-sdk#109.

## Design of the fix, or a new feature

The following convention property is also now available:
* `asakusafw.vanilla.version`
  * Asakusa Vanilla libraries version.

## Related Issue, Pull Request or Code

see asakusafw/asakusafw-sdk#109.

## Wanted reviewer

@akirakw 