### PR TITLE
Avoid using deprecated asakusafwVersion properties in Gradle plug-ins

### DIFF
--- a/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaOrganizerPlugin.groovy
+++ b/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaOrganizerPlugin.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.Task
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerPlugin
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerPluginConvention
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerProfile
+import com.asakusafw.gradle.plugins.internal.PluginUtils
 import com.asakusafw.vanilla.gradle.plugins.AsakusafwOrganizerVanillaExtension
 
 /**
@@ -57,12 +58,14 @@ class AsakusaVanillaOrganizerPlugin implements Plugin<Project> {
     }
 
     private void configureConvention() {
+        AsakusaVanillaBaseExtension base = AsakusaVanillaBasePlugin.get(project)
         AsakusafwOrganizerPluginConvention convention = project.asakusafwOrganizer
-        convention.extensions.create('vanilla', AsakusafwOrganizerVanillaExtension)
-        convention.vanilla.conventionMapping.with {
+        AsakusafwOrganizerVanillaExtension extension = convention.extensions.create('vanilla', AsakusafwOrganizerVanillaExtension)
+        extension.conventionMapping.with {
             enabled = { true }
             useSystemHadoop = { false }
         }
+        PluginUtils.injectVersionProperty(extension, { base.featureVersion })
     }
 
     private void configureProfiles() {
@@ -73,12 +76,14 @@ class AsakusaVanillaOrganizerPlugin implements Plugin<Project> {
     }
 
     private void configureProfile(AsakusafwOrganizerProfile profile) {
+        AsakusaVanillaBaseExtension base = AsakusaVanillaBasePlugin.get(project)
         AsakusafwOrganizerVanillaExtension extension = profile.extensions.create('vanilla', AsakusafwOrganizerVanillaExtension)
         AsakusafwOrganizerVanillaExtension parent = project.asakusafwOrganizer.vanilla
         extension.conventionMapping.with {
             enabled = { parent.enabled }
             useSystemHadoop = { parent.useSystemHadoop }
         }
+        PluginUtils.injectVersionProperty(extension, { base.featureVersion })
         AsakusaVanillaOrganizer organizer = new AsakusaVanillaOrganizer(project, profile, extension)
         organizer.configureProfile()
         organizers << organizer

--- a/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaSdkBasePlugin.groovy
+++ b/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaSdkBasePlugin.groovy
@@ -79,8 +79,7 @@ class AsakusaVanillaSdkBasePlugin implements Plugin<Project> {
         }
         PluginUtils.afterEvaluate(project) {
             AsakusaVanillaBaseExtension base = AsakusaVanillaBasePlugin.get(project)
-            AsakusafwPluginConvention sdk = AsakusaSdkPlugin.get(project)
-            AsakusafwSdkExtension features = sdk.sdk
+            AsakusafwSdkExtension features = AsakusaSdkPlugin.get(project).sdk
             project.dependencies {
                 if (features.core) {
                     asakusaVanillaCommon "com.asakusafw.vanilla.compiler:asakusa-vanilla-compiler-core:${base.featureVersion}"
@@ -88,19 +87,19 @@ class AsakusaVanillaSdkBasePlugin implements Plugin<Project> {
                     asakusaVanillaCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-redirector:${base.featureVersion}"
                     asakusaVanillaCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-yaess:${base.featureVersion}"
                     asakusaVanillaCommon "com.asakusafw.lang.compiler:asakusa-compiler-cli:${base.featureVersion}"
-                    asakusaVanillaCommon "com.asakusafw:simple-graph:${sdk.asakusafwVersion}"
-                    asakusaVanillaCommon "com.asakusafw:java-dom:${sdk.asakusafwVersion}"
-                    asakusaVanillaCompiler "com.asakusafw:asakusa-dsl-vocabulary:${sdk.asakusafwVersion}"
-                    asakusaVanillaCompiler "com.asakusafw:asakusa-runtime:${sdk.asakusafwVersion}"
-                    asakusaVanillaCompiler "com.asakusafw:asakusa-yaess-core:${sdk.asakusafwVersion}"
+                    asakusaVanillaCommon "com.asakusafw:simple-graph:${base.coreVersion}"
+                    asakusaVanillaCommon "com.asakusafw:java-dom:${base.coreVersion}"
+                    asakusaVanillaCompiler "com.asakusafw:asakusa-dsl-vocabulary:${base.coreVersion}"
+                    asakusaVanillaCompiler "com.asakusafw:asakusa-runtime:${base.coreVersion}"
+                    asakusaVanillaCompiler "com.asakusafw:asakusa-yaess-core:${base.coreVersion}"
 
                     if (features.directio) {
                         asakusaVanillaCommon "com.asakusafw.dag.compiler:asakusa-dag-compiler-extension-directio:${base.featureVersion}"
-                        asakusaVanillaCompiler "com.asakusafw:asakusa-directio-vocabulary:${sdk.asakusafwVersion}"
+                        asakusaVanillaCompiler "com.asakusafw:asakusa-directio-vocabulary:${base.coreVersion}"
                     }
                     if (features.windgate) {
                         asakusaVanillaCommon "com.asakusafw.dag.compiler:asakusa-dag-compiler-extension-windgate:${base.featureVersion}"
-                        asakusaVanillaCompiler "com.asakusafw:asakusa-windgate-vocabulary:${sdk.asakusafwVersion}"
+                        asakusaVanillaCompiler "com.asakusafw:asakusa-windgate-vocabulary:${base.coreVersion}"
                     }
                     if (features.hive) {
                         asakusaVanillaCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-hive:${base.featureVersion}"
@@ -110,7 +109,7 @@ class AsakusaVanillaSdkBasePlugin implements Plugin<Project> {
                     asakusaVanillaTestkit "com.asakusafw.vanilla.runtime:asakusa-vanilla-assembly:${base.featureVersion}"
                     asakusaVanillaTestkit "com.asakusafw.vanilla.testkit:asakusa-vanilla-test-adapter:${base.featureVersion}"
                     asakusaVanillaTestkit "com.asakusafw.vanilla.testkit:asakusa-vanilla-test-inprocess:${base.featureVersion}"
-                    asakusaVanillaTestkit "com.asakusafw:asakusa-test-inprocess:${sdk.asakusafwVersion}"
+                    asakusaVanillaTestkit "com.asakusafw:asakusa-test-inprocess:${base.coreVersion}"
                 }
             }
         }

--- a/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaSdkBasePlugin.groovy
+++ b/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaSdkBasePlugin.groovy
@@ -18,22 +18,18 @@ package com.asakusafw.vanilla.gradle.plugins.internal
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-import com.asakusafw.gradle.plugins.AsakusafwCompilerExtension
-import com.asakusafw.gradle.plugins.AsakusafwPluginConvention
 import com.asakusafw.gradle.plugins.AsakusafwSdkExtension
 import com.asakusafw.gradle.plugins.internal.AsakusaSdkPlugin
 import com.asakusafw.gradle.plugins.internal.PluginUtils
 
 /**
  * A base plug-in of {@link AsakusaVanillaSdkPlugin}.
- * This only organizes conventions and dependencies.
+ * This only organizes dependencies and testkits.
  * @since 0.4.0
  */
 class AsakusaVanillaSdkBasePlugin implements Plugin<Project> {
 
     private Project project
-
-    private AsakusafwCompilerExtension extension
 
     @Override
     void apply(Project project) {
@@ -41,23 +37,14 @@ class AsakusaVanillaSdkBasePlugin implements Plugin<Project> {
 
         project.apply plugin: AsakusaSdkPlugin
         project.apply plugin: AsakusaVanillaBasePlugin
-        this.extension = AsakusaSdkPlugin.get(project).extensions.create('vanilla', AsakusafwCompilerExtension)
 
-        configureExtension()
+        configureTestkit()
         configureConfigurations()
     }
 
-    private void configureExtension() {
-        AsakusaVanillaBaseExtension base = AsakusaVanillaBasePlugin.get(project)
-        AsakusafwPluginConvention sdk = AsakusaSdkPlugin.get(project)
-        extension.conventionMapping.with {
-            outputDirectory = { project.relativePath(new File(project.buildDir, 'vanilla-batchapps')) }
-            batchIdPrefix = { (String) 'vanilla.' }
-            failOnError = { true }
-        }
-        extension.compilerProperties.put('javac.version', { sdk.javac.sourceCompatibility.toString() })
-        PluginUtils.injectVersionProperty(extension, { base.featureVersion })
-        sdk.sdk.availableTestkits << new AsakusaVanillaTestkit()
+    private void configureTestkit() {
+        AsakusafwSdkExtension sdk = AsakusaSdkPlugin.get(project).sdk
+        sdk.availableTestkits << new AsakusaVanillaTestkit()
     }
 
     private void configureConfigurations() {
@@ -113,20 +100,5 @@ class AsakusaVanillaSdkBasePlugin implements Plugin<Project> {
                 }
             }
         }
-    }
-
-    /**
-     * Returns the extension object of this plug-in.
-     * The plug-in will be applied automatically.
-     * @param project the target project
-     * @return the related extension
-     */
-    static AsakusafwCompilerExtension get(Project project) {
-        project.apply plugin: AsakusaVanillaSdkBasePlugin
-        AsakusaVanillaSdkBasePlugin plugin = project.plugins.getPlugin(AsakusaVanillaSdkBasePlugin)
-        if (plugin == null) {
-            throw new IllegalStateException('AsakusaVanillaSdkBasePlugin has not been applied')
-        }
-        return plugin.extension
     }
 }

--- a/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaSdkPlugin.groovy
+++ b/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaSdkPlugin.groovy
@@ -47,9 +47,22 @@ class AsakusaVanillaSdkPlugin implements Plugin<Project> {
         this.project = project
 
         project.apply plugin: AsakusaVanillaSdkBasePlugin
-        this.extension = AsakusaVanillaSdkBasePlugin.get(project)
+        this.extension = AsakusaSdkPlugin.get(project).extensions.create('vanilla', AsakusafwCompilerExtension)
 
+        configureExtension()
         defineTasks()
+    }
+
+    private void configureExtension() {
+        AsakusaVanillaBaseExtension base = AsakusaVanillaBasePlugin.get(project)
+        AsakusafwPluginConvention sdk = AsakusaSdkPlugin.get(project)
+        extension.conventionMapping.with {
+            outputDirectory = { project.relativePath(new File(project.buildDir, 'vanilla-batchapps')) }
+            batchIdPrefix = { (String) 'vanilla.' }
+            failOnError = { true }
+        }
+        extension.compilerProperties.put('javac.version', { sdk.javac.sourceCompatibility.toString() })
+        PluginUtils.injectVersionProperty(extension, { base.featureVersion })
     }
 
     private void defineTasks() {

--- a/vanilla/gradle/src/test/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaOrganizerPluginTest.groovy
+++ b/vanilla/gradle/src/test/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaOrganizerPluginTest.groovy
@@ -76,6 +76,18 @@ class AsakusaVanillaOrganizerPluginTest {
     }
 
     /**
+     * Test for {@code project.asakusafwOrganizer.vanilla.version}.
+     */
+    @Test
+    void extension_version() {
+        project.asakusaVanillaBase.featureVersion = '__VERSION__'
+        assert project.asakusafwOrganizer.vanilla.version == '__VERSION__'
+        assert project.asakusafwOrganizer.profiles.dev.vanilla.version == '__VERSION__'
+        assert project.asakusafwOrganizer.profiles.prod.vanilla.version == '__VERSION__'
+        assert project.asakusafwOrganizer.profiles.other.vanilla.version == '__VERSION__'
+    }
+
+    /**
      * test for extension.
      */
     @Test


### PR DESCRIPTION
## Summary

This PR fixes for upstream changes in asakusafw/asakusafw-sdk#111, which has made `*.asakusafwVersion` properties deprecated.

## Background, Problem or Goal of the patch

see asakusafw/asakusafw-sdk#111.

## Design of the fix, or a new feature

The following convention properties are also now available:

* `asakusafwOrganizer.vanilla.version`
  * Asakusa Vanilla libraries version.
* `asakusafwOrganizer.profiles.<profile-name>.vanilla.version`
  * Asakusa Vanilla libraries version.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw-sdk#111

## Wanted reviewer

@akirakw 