### PR TITLE
Fix duplicate asakusaVersion output

### DIFF
--- a/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaSdkPlugin.groovy
+++ b/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaSdkPlugin.groovy
@@ -98,7 +98,6 @@ class AsakusaVanillaSdkPlugin implements Plugin<Project> {
             project.tasks.compileBatchapp.dependsOn task
             project.tasks.jarBatchapp.from { task.outputDirectory }
         }
-        extendVersionsTask()
         PluginUtils.afterEvaluate(project) {
             AsakusaCompileTask task = project.tasks.getByName(TASK_COMPILE)
             Map<String, String> map = [:]
@@ -110,12 +109,6 @@ class AsakusaVanillaSdkPlugin implements Plugin<Project> {
                 File f = project.file(sdk.logbackConf)
                 task.systemProperties.put('logback.configurationFile', f.absolutePath)
             }
-        }
-    }
-
-    private void extendVersionsTask() {
-        project.tasks.getByName(AsakusafwBasePlugin.TASK_VERSIONS) << {
-            logger.lifecycle "Vanilla: ${AsakusaVanillaBasePlugin.get(project).featureVersion}"
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes duplicate version outputs when executing `asakusaVersion` task with `asakusa-vanilla` Gradle Plugin.

## Background, Problem or Goal of the patch
This is caused by duplication of asakusaVersion extension in AsakusaVanillaSdkPlugin.groovy and AsakusaVanillaBasePlugin.groovy.

## Design of the fix, or a new feature
This PR removes extendVersionsTask from AsakusaVanillaSdkPlugin.

## Related Issue, Pull Request or Code
N/A.

## Wanted reviewer
@ashigeru 