### PR TITLE
Remove `Task.leftShift()` in Gradle plug-ins.

### DIFF
--- a/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaBasePlugin.groovy
+++ b/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaBasePlugin.groovy
@@ -120,7 +120,7 @@ class AsakusaVanillaBasePlugin implements Plugin<Project> {
     }
 
     private void extendVersionsTask() {
-        project.tasks.getByName(AsakusafwBasePlugin.TASK_VERSIONS) << {
+        project.tasks.getByName(AsakusafwBasePlugin.TASK_VERSIONS).doLast {
             logger.lifecycle "Asakusa Vanilla: ${extension.featureVersion}"
         }
     }


### PR DESCRIPTION
## Summary

This PR replaces `Task.leftShift()` with `Task.doLast()` in Gradle plug-ins (`./vanilla/gradle`).

## Background, Problem or Goal of the patch

`Task.leftShift()` will have become deprecated from Gradle `3.2`.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 