### PR TITLE
Fix convert operator behavior.

### DIFF
--- a/dag/compiler/builtin/src/main/java/com/asakusafw/dag/compiler/builtin/ConvertOperatorGenerator.java
+++ b/dag/compiler/builtin/src/main/java/com/asakusafw/dag/compiler/builtin/ConvertOperatorGenerator.java
@@ -80,11 +80,6 @@ public class ConvertOperatorGenerator extends UserOperatorNodeGenerator {
             LocalVarRef data = cast(method, 1, input.getDataType());
 
             self.load(method);
-            getField(method, map.get(copy));
-            data.load(method);
-            invokeResultAdd(method);
-
-            self.load(method);
             getField(method, map.get(output));
 
             List<ValueRef> arguments = new ArrayList<>();
@@ -93,6 +88,12 @@ public class ConvertOperatorGenerator extends UserOperatorNodeGenerator {
             arguments.addAll(Lang.project(operator.getArguments(), e -> map.get(e)));
             invoke(method, context, operator, arguments);
 
+            invokeResultAdd(method);
+
+            // must invoke about "original" after "converted" was processed
+            self.load(method);
+            getField(method, map.get(copy));
+            data.load(method);
             invokeResultAdd(method);
         });
         return new ClassData(target, writer::toByteArray);

--- a/dag/compiler/builtin/src/test/java/com/asakusafw/dag/compiler/builtin/ConvertOperatorGeneratorTest.java
+++ b/dag/compiler/builtin/src/test/java/com/asakusafw/dag/compiler/builtin/ConvertOperatorGeneratorTest.java
@@ -72,6 +72,29 @@ public class ConvertOperatorGeneratorTest extends OperatorNodeGeneratorTestRoot 
     }
 
     /**
+     * the original object was broken.
+     */
+    @Test
+    public void broken_original() {
+        UserOperator operator = load("simple").build();
+        NodeInfo info = generate(operator);
+        MockResult<MockDataModel> orig = new MockResult<MockDataModel>() {
+            @Override
+            protected MockDataModel bless(MockDataModel result) {
+                result.setValue(result.getValue() + "BROKEN");
+                return new MockDataModel(result);
+            }
+        };
+        MockResult<MockValueModel> results = new MockResult<>();
+        loading(info, c -> {
+            Result<Object> r = c.newInstance(orig, results);
+            r.add(new MockDataModel("Hello"));
+        });
+        assertThat(Lang.project(orig.getResults(), e -> e.getValue()), contains("HelloBROKEN"));
+        assertThat(Lang.project(results.getResults(), e -> e.getValue()), contains("Hello!"));
+    }
+
+    /**
      * cache - identical.
      */
     @Test


### PR DESCRIPTION
## Summary

This PR fixes `@Convert` operator behavior.

## Background, Problem or Goal of the patch

The latest implementation, `Convert.converted` will return wrong data when a succeeding operators of `Convert.original` modifies its input object.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 