### PR TITLE
Enable to configure window size of `InputBuffer.ESCAPE`.

### DIFF
--- a/dag/runtime/runtime/src/main/java/com/asakusafw/dag/runtime/skeleton/CoGroupInputAdapter.java
+++ b/dag/runtime/runtime/src/main/java/com/asakusafw/dag/runtime/skeleton/CoGroupInputAdapter.java
@@ -115,7 +115,7 @@ public class CoGroupInputAdapter implements InputAdapter<CoGroupOperation.Input>
             if (fileWindowSize <= 0) {
                 return new ArrayListBuffer<>();
             } else {
-                return new FileMapListBuffer<>();
+                return new FileMapListBuffer<>(fileWindowSize);
             }
         default:
             throw new AssertionError(bufferType);


### PR DESCRIPTION
## Summary

This PR enables to configure window size of `InputBuffer.ESCAPE`.

## Background, Problem or Goal of the patch

The configuration did not work well, and only can prevent from using `FileMapListBuffer`. Note that, the configuration is not documented and only for internal use.

## Design of the fix, or a new feature

* `com.asakusafw.dag.input.file.window.size`
  * the on-heap window size (in number of objects) for `InputBuffer.ESCAPE`
    * or `InputBuffer.ESCAPE` is disabled if `<= 0`
  * default: `256`

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 