### PR TITLE
assemble task should not build vanilla apps in default.

### DIFF
--- a/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaOrganizerPlugin.groovy
+++ b/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaOrganizerPlugin.groovy
@@ -62,7 +62,7 @@ class AsakusaVanillaOrganizerPlugin implements Plugin<Project> {
         AsakusafwOrganizerPluginConvention convention = project.asakusafwOrganizer
         AsakusafwOrganizerVanillaExtension extension = convention.extensions.create('vanilla', AsakusafwOrganizerVanillaExtension)
         extension.conventionMapping.with {
-            enabled = { true }
+            enabled = { false }
             useSystemHadoop = { false }
         }
         PluginUtils.injectVersionProperty(extension, { base.featureVersion })

--- a/vanilla/gradle/src/test/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaOrganizerPluginTest.groovy
+++ b/vanilla/gradle/src/test/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaOrganizerPluginTest.groovy
@@ -63,16 +63,16 @@ class AsakusaVanillaOrganizerPluginTest {
         AsakusafwOrganizerVanillaExtension extension = root.vanilla
         assert extension != null
 
-        assert extension.enabled == true
+        assert extension.enabled == false
         assert extension.useSystemHadoop == false
 
-        assert root.profiles.dev.vanilla.enabled == true
-        assert root.profiles.prod.vanilla.enabled == true
+        assert root.profiles.dev.vanilla.enabled == false
+        assert root.profiles.prod.vanilla.enabled == false
 
         root.profiles.testing {
             // ok
         }
-        assert root.profiles.testing.vanilla.enabled == true
+        assert root.profiles.testing.vanilla.enabled == false
     }
 
     /**
@@ -95,21 +95,20 @@ class AsakusaVanillaOrganizerPluginTest {
         AsakusafwOrganizerPluginConvention root = project.asakusafwOrganizer
         AsakusafwOrganizerVanillaExtension extension = root.vanilla
 
-        extension.enabled = false
+        extension.enabled = true
 
-        assert root.profiles.dev.vanilla.enabled == false
-        assert root.profiles.prod.vanilla.enabled == false
-
-        root.profiles.prod.vanilla.enabled = true
-        assert extension.enabled == false
-        assert root.profiles.dev.vanilla.enabled == false
+        assert root.profiles.dev.vanilla.enabled == true
         assert root.profiles.prod.vanilla.enabled == true
 
+        root.profiles.prod.vanilla.enabled = false
+        assert extension.enabled == true
+        assert root.profiles.dev.vanilla.enabled == true
+        assert root.profiles.prod.vanilla.enabled == false
 
         root.profiles.testing {
             // ok
         }
-        assert root.profiles.testing.vanilla.enabled == false
+        assert root.profiles.testing.vanilla.enabled == true
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR disables building Asakusa vanilla apps when Gradle `assemble` task was invoked in default.

## Background, Problem or Goal of the patch

N/A.

## Design of the fix, or a new feature

To enable vanilla apps in `assemble`, please enable it explicitly:

```gradle
asakusafwOrganizer.vanilla.enabled true
```

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 