### PR TITLE
Rewrite input list buffers of co-group like operators.

### DIFF
--- a/dag/compiler/codegen/src/main/java/com/asakusafw/dag/compiler/codegen/CoGroupInputAdapterGenerator.java
+++ b/dag/compiler/codegen/src/main/java/com/asakusafw/dag/compiler/codegen/CoGroupInputAdapterGenerator.java
@@ -51,7 +51,7 @@ public class CoGroupInputAdapterGenerator {
                 v.visitVarInsn(Opcodes.ALOAD, 0);
                 getConst(v, spec.id);
                 getConst(v, typeOf(supplier));
-                getEnumConstant(v, getBufferType(spec));
+                getEnumConstant(v, spec.bufferType);
                 v.visitMethodInsn(
                         Opcodes.INVOKEVIRTUAL,
                         target.getInternalName(), "bind", //$NON-NLS-1$
@@ -67,13 +67,10 @@ public class CoGroupInputAdapterGenerator {
         return new ClassData(target, writer::toByteArray);
     }
 
-    private static CoGroupInputAdapter.BufferType getBufferType(Spec spec) {
-        return spec.fileListBuffer ? CoGroupInputAdapter.BufferType.FILE : CoGroupInputAdapter.BufferType.HEAP;
-    }
-
     /**
      * Represents an input spec for co-group-kind vertices.
      * @since 0.4.0
+     * @version 0.4.1
      */
     public static class Spec {
 
@@ -81,20 +78,21 @@ public class CoGroupInputAdapterGenerator {
 
         final TypeDescription dataType;
 
-        final boolean fileListBuffer;
+        final CoGroupInputAdapter.BufferType bufferType;
 
         /**
          * Creates a new instance.
          * @param id the input ID
          * @param dataType the input data type
-         * @param fileListBuffer {@code true} to use file list buffer
+         * @param bufferType the buffer type
          */
-        public Spec(String id, TypeDescription dataType, boolean fileListBuffer) {
+        public Spec(String id, TypeDescription dataType, CoGroupInputAdapter.BufferType bufferType) {
             Arguments.requireNonNull(id);
             Arguments.requireNonNull(dataType);
+            Arguments.requireNonNull(bufferType);
             this.id = id;
             this.dataType = dataType;
-            this.fileListBuffer = fileListBuffer;
+            this.bufferType = bufferType;
         }
     }
 }

--- a/dag/compiler/codegen/src/test/java/com/asakusafw/dag/compiler/codegen/CoGroupInputAdapterGeneratorTest.java
+++ b/dag/compiler/codegen/src/test/java/com/asakusafw/dag/compiler/codegen/CoGroupInputAdapterGeneratorTest.java
@@ -126,7 +126,8 @@ public class CoGroupInputAdapterGeneratorTest extends ClassGeneratorTestRoot {
     private List<List<List<String>>> check(Map<String, SortedMap<String, List<MockDataModel>>> map) {
         ClassGeneratorContext gc = context();
         ClassDescription generated = add(c -> new CoGroupInputAdapterGenerator().generate(
-                gc, Lang.project(map.keySet(), s -> new Spec(s, typeOf(MockDataModel.class), false)), c));
+                gc, Lang.project(map.keySet(), s -> new Spec(
+                        s, typeOf(MockDataModel.class), CoGroupInputAdapter.BufferType.HEAP)), c));
 
         MockTaskProcessorContext tc = new MockTaskProcessorContext("t");
         map.forEach((in, v) -> tc.withInput(in, () -> new CollectionGroupReader(v)));

--- a/dag/runtime/runtime/src/main/java/com/asakusafw/dag/runtime/data/DataAdapter.java
+++ b/dag/runtime/runtime/src/main/java/com/asakusafw/dag/runtime/data/DataAdapter.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dag.runtime.data;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+/**
+ * An abstract super interface of data adapters.
+ * @param <T> the data type
+ * @since 0.4.1
+ */
+public interface DataAdapter<T> {
+
+    /**
+     * Creates a new data object.
+     * @return the created object
+     */
+    T create();
+
+    /**
+     * Copies the given object into the another object.
+     * @param source the source object
+     * @param destination the destination object
+     */
+    void copy(T source, T destination);
+
+    /**
+     * Writes the given object into the output.
+     * @param source the source object
+     * @param output the target output
+     * @throws IOException if I/O error was occurred while writing the object
+     */
+    void write(T source, DataOutput output) throws IOException;
+
+    /**
+     * Reads an object from the given input.
+     * @param input the source input
+     * @param destination the destination object
+     * @throws IOException if I/O error was occurred while reading the object
+     */
+    void read(DataInput input, T destination) throws IOException;
+}

--- a/dag/runtime/runtime/src/main/java/com/asakusafw/dag/runtime/data/HeapListBuilder.java
+++ b/dag/runtime/runtime/src/main/java/com/asakusafw/dag/runtime/data/HeapListBuilder.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dag.runtime.data;
+
+import java.io.IOException;
+import java.util.AbstractList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.RandomAccess;
+
+import com.asakusafw.dag.api.common.ObjectCursor;
+
+/**
+ * A {@link ListBuilder} which provides array backed lists.
+ * @param <T> the element type
+ * @since 0.4.1
+ */
+public class HeapListBuilder<T> implements ListBuilder<T> {
+
+    private static final int MIN_ARRAY_SIZE = 256;
+
+    static final Object[] EMPTY = new Object[0];
+
+    private final Entity<T> entity = new Entity<>();
+
+    private final DataAdapter<T> adapter;
+
+    /**
+     * Creates a new instance.
+     * @param adapter the data adapter
+     */
+    public HeapListBuilder(DataAdapter<T> adapter) {
+        this.adapter = adapter;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<T> build(ObjectCursor cursor) throws IOException, InterruptedException {
+        DataAdapter<T> da = adapter;
+        T[] elements = entity.elements;
+        int index = 0;
+        while (cursor.nextObject()) {
+            if (index >= elements.length) {
+                elements = Arrays.copyOf(elements, Math.max(elements.length * 2, MIN_ARRAY_SIZE));
+            }
+            T object = (T) cursor.getObject();
+            T destination = elements[index];
+            if (destination == null) {
+                destination = da.create();
+                elements[index] = destination;
+            }
+            da.copy(object, destination);
+            index++;
+        }
+        entity.elements = elements;
+        entity.size = index;
+        return entity;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void close() throws IOException, InterruptedException {
+        entity.elements = (T[]) EMPTY;
+        entity.size = 0;
+    }
+
+    @SuppressWarnings("unchecked")
+    static final class Entity<T> extends AbstractList<T> implements RandomAccess {
+
+        T[] elements = (T[]) EMPTY;
+
+        int size = 0;
+
+        @Override
+        public T get(int index) {
+            T[] es = elements;
+            if (index < 0 || index >= size) {
+                throw new IndexOutOfBoundsException();
+            }
+            return es[index];
+        }
+
+        @Override
+        public int size() {
+            return size;
+        }
+    }
+}

--- a/dag/runtime/runtime/src/main/java/com/asakusafw/dag/runtime/data/ListBuilder.java
+++ b/dag/runtime/runtime/src/main/java/com/asakusafw/dag/runtime/data/ListBuilder.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dag.runtime.data;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.asakusafw.dag.api.common.ObjectCursor;
+import com.asakusafw.lang.utils.common.InterruptibleIo;
+
+/**
+ * Provides list.
+ * @param <T> the data type
+ * @since 0.4.1
+ */
+public interface ListBuilder<T> extends InterruptibleIo {
+
+    /**
+     * Builds a list from the given {@link ObjectCursor}.
+     * This operation will change the previously returned list.
+     * @param cursor the source cursor
+     * @return the list
+     * @throws IOException if I/O error was occurred while building a list
+     * @throws InterruptedException if interrupted while building a list
+     */
+    List<T> build(ObjectCursor cursor) throws IOException, InterruptedException;
+}

--- a/dag/runtime/runtime/src/main/java/com/asakusafw/dag/runtime/data/SpillListBuilder.java
+++ b/dag/runtime/runtime/src/main/java/com/asakusafw/dag/runtime/data/SpillListBuilder.java
@@ -1,0 +1,238 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dag.runtime.data;
+
+import java.io.Closeable;
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.AbstractList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.dag.api.common.ObjectCursor;
+import com.asakusafw.lang.utils.buffer.nio.NioDataBuffer;
+import com.asakusafw.lang.utils.buffer.nio.ResizableNioDataBuffer;
+
+/**
+ * A {@link ListBuilder} which provides temporary file backed lists.
+ * @param <T> the element type
+ * @since 0.4.1
+ */
+public class SpillListBuilder<T> implements ListBuilder<T> {
+
+    private static final int DEFAULT_CACHE_SIZE = 256;
+
+    static final Logger LOG = LoggerFactory.getLogger(SpillListBuilder.class);
+
+    private Entity<T> entity;
+
+    /**
+     * Creates a new instance.
+     * @param adapter the data adapter
+     */
+    public SpillListBuilder(DataAdapter<T> adapter) {
+        this(adapter, DEFAULT_CACHE_SIZE);
+    }
+
+    /**
+     * Creates a new instance.
+     * @param adapter the data adapter
+     * @param cacheSize the number of objects should be cached on Java heap
+     */
+    public SpillListBuilder(DataAdapter<T> adapter, int cacheSize) {
+        this.entity = new Entity<>(adapter, cacheSize);
+    }
+
+    @Override
+    public List<T> build(ObjectCursor cursor) throws IOException, InterruptedException {
+        entity.reset(cursor);
+        return entity;
+    }
+
+    @Override
+    public void close() throws IOException, InterruptedException {
+        Arrays.fill(entity.elements, null);
+        entity.store.close();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static class Entity<T> extends AbstractList<T> {
+
+        final DataAdapter<T> adapter;
+
+        final Store<T> store;
+
+        final T[] elements;
+
+        int currentPageIndex;
+
+        int sizeInList;
+
+        Entity(DataAdapter<T> adapter, int pageSize) {
+            this.store = new Store<>();
+            this.adapter = adapter;
+            this.elements = (T[]) new Object[pageSize];
+            this.currentPageIndex = 0;
+            this.sizeInList = 0;
+        }
+
+        void reset(ObjectCursor cursor) throws IOException, InterruptedException {
+            DataAdapter<T> da = adapter;
+            T[] es = this.elements;
+            int offset = 0;
+            int pageOffset = 0;
+            while (cursor.nextObject()) {
+                if (offset >= es.length) {
+                    // escape into buffer
+                    store.putPage(da, pageOffset, es, offset);
+                    offset = 0;
+                    pageOffset++;
+                }
+                T object = (T) cursor.getObject();
+                T destination = es[offset];
+                if (destination == null) {
+                    destination = da.create();
+                    es[offset] = destination;
+                }
+                da.copy(object, destination);
+                offset++;
+            }
+            if (pageOffset != 0) {
+                assert offset > 0;
+                store.putPage(da, pageOffset, es, offset);
+            }
+            sizeInList = pageOffset * es.length + offset;
+            currentPageIndex = pageOffset;
+        }
+
+        @Override
+        public T get(int index) {
+            if (index < 0 || index >= sizeInList) {
+                throw new IndexOutOfBoundsException();
+            }
+            int windowSize = elements.length;
+            int pageIndex = index / windowSize;
+            int offsetInPage = index % windowSize;
+            if (currentPageIndex != pageIndex) {
+                int count = Math.min(sizeInList - pageIndex * windowSize, windowSize);
+                try {
+                    store.getPage(adapter, pageIndex, elements, count);
+                } catch (IOException e) {
+                    throw new IllegalStateException(e);
+                }
+                currentPageIndex = pageIndex;
+            }
+            return elements[offsetInPage];
+        }
+
+        @Override
+        public int size() {
+            return sizeInList;
+        }
+    }
+
+    private static class Store<T> implements Closeable {
+
+        private static final long[] EMPTY_OFFSETS = new long[0];
+
+        Path path;
+
+        FileChannel channel;
+
+        private long[] offsets = EMPTY_OFFSETS;
+
+        private final ResizableNioDataBuffer buffer = new ResizableNioDataBuffer();
+
+        Store() {
+            return;
+        }
+
+        void putPage(DataAdapter<T> adapter, int index, T[] elements, int count) throws IOException {
+            if (path == null) {
+                path = Files.createTempFile("spill-", ".bin");
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("generating list spill: {}", path);
+                }
+                channel = FileChannel.open(path,
+                        StandardOpenOption.READ, StandardOpenOption.WRITE,
+                        StandardOpenOption.DELETE_ON_CLOSE);
+                offsets = new long[256];
+            }
+            if (index + 1 >= offsets.length) {
+                offsets = Arrays.copyOf(offsets, offsets.length * 2);
+            }
+            buffer.contents.clear();
+            for (int i = 0; i < count; i++) {
+                adapter.write(elements[i], buffer);
+            }
+            ByteBuffer buf = buffer.contents;
+            buf.flip();
+            long offset = offsets[index];
+            long end = offset + buf.limit();
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(String.format("writing list spill: %s#%,d@%,d+%,d", path, index, offset, buf.remaining())); //$NON-NLS-1$
+            }
+            while (buf.hasRemaining()) {
+                offset += channel.write(buf, offset);
+            }
+            offsets[index + 1] = end;
+        }
+
+        void getPage(DataAdapter<T> adapter, int index, T[] elements, int count) throws IOException {
+            long offset = offsets[index];
+            long end = offsets[index + 1];
+            int length = (int) (end - offset);
+
+            ByteBuffer buf = buffer.contents;
+            assert length <= buf.capacity();
+            buf.clear().limit(length);
+
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(String.format("reading list spill: %s#%,d@%,d+%,d", path, index, offset, buf.remaining())); //$NON-NLS-1$
+            }
+            while (buf.hasRemaining()) {
+                int read = channel.read(buf, offset);
+                if (read < 0) {
+                    throw new EOFException();
+                }
+                offset += read;
+            }
+            buf.flip();
+            for (int i = 0; i < count; i++) {
+                adapter.read(buffer, elements[i]);
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (channel != null) {
+                offsets = EMPTY_OFFSETS;
+                buffer.contents = NioDataBuffer.EMPTY_BUFFER;
+                channel.close();
+                channel = null;
+                path = null;
+            }
+        }
+    }
+}

--- a/dag/runtime/runtime/src/main/java/com/asakusafw/dag/runtime/data/package-info.java
+++ b/dag/runtime/runtime/src/main/java/com/asakusafw/dag/runtime/data/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Data structures.
+ */
+package com.asakusafw.dag.runtime.data;

--- a/dag/runtime/runtime/src/main/java/com/asakusafw/dag/runtime/io/BasicDataAdapter.java
+++ b/dag/runtime/runtime/src/main/java/com/asakusafw/dag/runtime/io/BasicDataAdapter.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dag.runtime.io;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.function.Supplier;
+
+import org.apache.hadoop.io.Writable;
+
+import com.asakusafw.dag.runtime.data.DataAdapter;
+import com.asakusafw.runtime.model.DataModel;
+
+/**
+ * A basic implementation of {@link DataAdapter}.
+ * @param <T> the data type
+ * @since 0.4.1
+ */
+public class BasicDataAdapter<T extends DataModel<T> & Writable> implements DataAdapter<T> {
+
+    private final Supplier<? extends T> supplier;
+
+    /**
+     * Creates a new instance.
+     * @param supplier the data model object supplier
+     */
+    public BasicDataAdapter(Supplier<? extends T> supplier) {
+        this.supplier = supplier;
+    }
+
+    /**
+     * Creates a new instance.
+     * @param dataType the data model type
+     */
+    public BasicDataAdapter(Class<? extends T> dataType) {
+        this.supplier = () -> {
+            try {
+                return dataType.newInstance();
+            } catch (Exception e) {
+                throw new IllegalStateException(e);
+            }
+        };
+    }
+
+    @Override
+    public T create() {
+        return supplier.get();
+    }
+
+    @Override
+    public void copy(T source, T destination) {
+        destination.copyFrom(source);
+    }
+
+    @Override
+    public void write(T source, DataOutput output) throws IOException {
+        source.write(output);
+    }
+
+    @Override
+    public void read(DataInput input, T destination) throws IOException {
+        destination.readFields(input);
+    }
+}

--- a/dag/runtime/runtime/src/test/java/com/asakusafw/dag/runtime/data/HeapListBuilderTest.java
+++ b/dag/runtime/runtime/src/test/java/com/asakusafw/dag/runtime/data/HeapListBuilderTest.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dag.runtime.data;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.RandomAccess;
+
+import org.junit.Test;
+
+import com.asakusafw.runtime.value.IntOption;
+
+/**
+ * Test for {@link HeapListBuilder}.
+ */
+public class HeapListBuilderTest {
+
+    /**
+     * simple case.
+     * @throws Exception if failed
+     */
+    @Test
+    public void simple() throws Exception {
+        try (HeapListBuilder<IntOption> builder = new HeapListBuilder<>(new IntOptionAdapter())) {
+            int begin = 0;
+            int end = 1;
+            int size = end - begin;
+            List<IntOption> list = builder.build(IntOptionAdapter.range(begin, end));
+            assertThat(list, instanceOf(RandomAccess.class));
+            assertThat(list.size(), is(size));
+            for (int i = 0, n = end - begin; i < n; i++) {
+                IntOption value = list.get(i);
+                assertThat(value, is(new IntOption(i + begin)));
+            }
+        }
+    }
+
+    /**
+     * w/ multiple records.
+     * @throws Exception if failed
+     */
+    @Test
+    public void multiple() throws Exception {
+        try (HeapListBuilder<IntOption> builder = new HeapListBuilder<>(new IntOptionAdapter())) {
+            int begin = 0;
+            int end = 10;
+            int size = end - begin;
+            List<IntOption> list = builder.build(IntOptionAdapter.range(begin, end));
+            assertThat(list.size(), is(size));
+            for (int i = 0, n = end - begin; i < n; i++) {
+                IntOption value = list.get(i);
+                assertThat(value, is(new IntOption(i + begin)));
+            }
+        }
+    }
+
+    /**
+     * w/ multiple records.
+     * @throws Exception if failed
+     */
+    @Test
+    public void large() throws Exception {
+        try (HeapListBuilder<IntOption> builder = new HeapListBuilder<>(new IntOptionAdapter())) {
+            int begin = 0;
+            int end = 1_000_000;
+            int size = end - begin;
+            List<IntOption> list = builder.build(IntOptionAdapter.range(begin, end));
+            assertThat(list.size(), is(size));
+            for (int i = 0, n = end - begin; i < n; i++) {
+                IntOption value = list.get(i);
+                assertEquals(i + begin, value.get());
+            }
+        }
+    }
+
+    /**
+     * w/ multiple records.
+     * @throws Exception if failed
+     */
+    @Test
+    public void reuse() throws Exception {
+        try (HeapListBuilder<IntOption> builder = new HeapListBuilder<>(new IntOptionAdapter())) {
+            int begin = 0;
+            int end = 1_000_000;
+            int size = end - begin;
+            List<IntOption> list = builder.build(IntOptionAdapter.range(begin, end));
+            assertThat(list.size(), is(size));
+            for (int i = 0, n = end - begin; i < n; i++) {
+                IntOption value = list.get(i);
+                assertEquals(i + begin, value.get());
+            }
+        }
+        try (HeapListBuilder<IntOption> builder = new HeapListBuilder<>(new IntOptionAdapter())) {
+            int begin = 2_000_000;
+            int end = 3_000_000;
+            int size = end - begin;
+            List<IntOption> list = builder.build(IntOptionAdapter.range(begin, end));
+            assertThat(list.size(), is(size));
+            for (int i = 0, n = end - begin; i < n; i++) {
+                IntOption value = list.get(i);
+                assertEquals(i + begin, value.get());
+            }
+        }
+    }
+
+    /**
+     * w/ for-each.
+     * @throws Exception if failed
+     */
+    @Test
+    public void forEach() throws Exception {
+        try (HeapListBuilder<IntOption> builder = new HeapListBuilder<>(new IntOptionAdapter())) {
+            int begin = 0;
+            int end = 10;
+            int size = end - begin;
+            List<IntOption> list = builder.build(IntOptionAdapter.range(begin, end));
+            assertThat(list.size(), is(size));
+            int index = begin;
+            for (IntOption value : list) {
+                assertThat(value, is(new IntOption(index++)));
+            }
+        }
+    }
+
+    /**
+     * w/ for-each.
+     * @throws Exception if failed
+     */
+    @Test
+    public void forEach_replay() throws Exception {
+        try (HeapListBuilder<IntOption> builder = new HeapListBuilder<>(new IntOptionAdapter())) {
+            int begin = 0;
+            int end = 10;
+            int size = end - begin;
+            List<IntOption> list = builder.build(IntOptionAdapter.range(begin, end));
+            assertThat(list.size(), is(size));
+            int index = begin;
+            for (IntOption value : list) {
+                assertThat(value, is(new IntOption(index++)));
+            }
+            index = begin;
+            for (IntOption value : list) {
+                assertThat(value, is(new IntOption(index++)));
+            }
+            index = begin;
+            for (IntOption value : list) {
+                assertThat(value, is(new IntOption(index++)));
+            }
+        }
+    }
+
+    /**
+     * w/ out of lower bounds.
+     * @throws Exception if failed
+     */
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void bounds_lower() throws Exception {
+        try (HeapListBuilder<IntOption> builder = new HeapListBuilder<>(new IntOptionAdapter())) {
+            builder.build(IntOptionAdapter.range(0, 10)).get(-1);
+        }
+    }
+
+    /**
+     * w/ out of upper bounds.
+     * @throws Exception if failed
+     */
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void bounds_upper() throws Exception {
+        try (HeapListBuilder<IntOption> builder = new HeapListBuilder<>(new IntOptionAdapter())) {
+            builder.build(IntOptionAdapter.range(0, 10)).get(10);
+        }
+    }
+}

--- a/dag/runtime/runtime/src/test/java/com/asakusafw/dag/runtime/data/IntOptionAdapter.java
+++ b/dag/runtime/runtime/src/test/java/com/asakusafw/dag/runtime/data/IntOptionAdapter.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dag.runtime.data;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import com.asakusafw.dag.api.common.ObjectCursor;
+import com.asakusafw.runtime.value.IntOption;
+
+class IntOptionAdapter implements DataAdapter<IntOption> {
+
+    @Override
+    public IntOption create() {
+        return new IntOption();
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public void copy(IntOption source, IntOption destination) {
+        destination.copyFrom(source);
+    }
+
+    @Override
+    public void write(IntOption source, DataOutput output) throws IOException {
+        source.write(output);
+    }
+
+    @Override
+    public void read(DataInput input, IntOption destination) throws IOException {
+        destination.readFields(input);
+    }
+
+    @SuppressWarnings("deprecation")
+    static ObjectCursor range(int begin, int end) {
+        return new ObjectCursor() {
+            final IntOption value = new IntOption();
+            int current = begin;
+            @Override
+            public boolean nextObject() throws IOException, InterruptedException {
+                if (current < end) {
+                    value.modify(current++);
+                    return true;
+                }
+                return false;
+            }
+            @Override
+            public Object getObject() throws IOException, InterruptedException {
+                return value;
+            }
+        };
+    }
+}

--- a/dag/runtime/runtime/src/test/java/com/asakusafw/dag/runtime/data/SpillListBuilderTest.java
+++ b/dag/runtime/runtime/src/test/java/com/asakusafw/dag/runtime/data/SpillListBuilderTest.java
@@ -1,0 +1,209 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dag.runtime.data;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.asakusafw.runtime.value.IntOption;
+
+/**
+ * Test for {@link SpillListBuilder}.
+ */
+public class SpillListBuilderTest {
+
+    /**
+     * simple case.
+     * @throws Exception if failed
+     */
+    @Test
+    public void simple() throws Exception {
+        try (SpillListBuilder<IntOption> builder = new SpillListBuilder<>(new IntOptionAdapter())) {
+            int begin = 0;
+            int end = 1;
+            int size = end - begin;
+            List<IntOption> list = builder.build(IntOptionAdapter.range(begin, end));
+            assertThat(list.size(), is(size));
+            for (int i = 0, n = end - begin; i < n; i++) {
+                IntOption value = list.get(i);
+                assertThat(value, is(new IntOption(i + begin)));
+            }
+        }
+    }
+
+    /**
+     * w/ multiple records.
+     * @throws Exception if failed
+     */
+    @Test
+    public void multiple() throws Exception {
+        try (SpillListBuilder<IntOption> builder = new SpillListBuilder<>(new IntOptionAdapter())) {
+            int begin = 0;
+            int end = 10;
+            int size = end - begin;
+            List<IntOption> list = builder.build(IntOptionAdapter.range(begin, end));
+            assertThat(list.size(), is(size));
+            for (int i = 0, n = end - begin; i < n; i++) {
+                IntOption value = list.get(i);
+                assertThat(value, is(new IntOption(i + begin)));
+            }
+        }
+    }
+
+    /**
+     * w/ multiple records.
+     * @throws Exception if failed
+     */
+    @Test
+    public void large() throws Exception {
+        try (SpillListBuilder<IntOption> builder = new SpillListBuilder<>(new IntOptionAdapter())) {
+            int begin = 0;
+            int end = 1_000_000;
+            int size = end - begin;
+            List<IntOption> list = builder.build(IntOptionAdapter.range(begin, end));
+            assertThat(list.size(), is(size));
+            for (int i = 0, n = end - begin; i < n; i++) {
+                IntOption value = list.get(i);
+                assertEquals(i + begin, value.get());
+            }
+        }
+    }
+
+    /**
+     * w/ multiple records.
+     * @throws Exception if failed
+     */
+    @Test
+    public void huge() throws Exception {
+        try (SpillListBuilder<IntOption> builder = new SpillListBuilder<>(new IntOptionAdapter())) {
+            int begin = 0;
+            int end = 100_000_000;
+            int size = end - begin;
+            long t0 = System.currentTimeMillis();
+            List<IntOption> list = builder.build(IntOptionAdapter.range(begin, end));
+            assertThat(list.size(), is(size));
+            long t1 = System.currentTimeMillis();
+            for (int i = 0, n = end - begin; i < n; i++) {
+                IntOption value = list.get(i);
+                assertEquals(i + begin, value.get());
+            }
+            long t2 = System.currentTimeMillis();
+            System.out.printf("spill - write: %,dms, read: %,dms%n", t1 - t0, t2 - t1);
+        }
+    }
+
+    /**
+     * w/ multiple records.
+     * @throws Exception if failed
+     */
+    @Test
+    public void reuse() throws Exception {
+        try (SpillListBuilder<IntOption> builder = new SpillListBuilder<>(new IntOptionAdapter())) {
+            int begin = 0;
+            int end = 1_000_000;
+            int size = end - begin;
+            List<IntOption> list = builder.build(IntOptionAdapter.range(begin, end));
+            assertThat(list.size(), is(size));
+            for (int i = 0, n = end - begin; i < n; i++) {
+                IntOption value = list.get(i);
+                assertEquals(i + begin, value.get());
+            }
+        }
+        try (SpillListBuilder<IntOption> builder = new SpillListBuilder<>(new IntOptionAdapter())) {
+            int begin = 2_000_000;
+            int end = 3_000_000;
+            int size = end - begin;
+            List<IntOption> list = builder.build(IntOptionAdapter.range(begin, end));
+            assertThat(list.size(), is(size));
+            for (int i = 0, n = end - begin; i < n; i++) {
+                IntOption value = list.get(i);
+                assertEquals(i + begin, value.get());
+            }
+        }
+    }
+
+    /**
+     * w/ for-each.
+     * @throws Exception if failed
+     */
+    @Test
+    public void forEach() throws Exception {
+        try (SpillListBuilder<IntOption> builder = new SpillListBuilder<>(new IntOptionAdapter())) {
+            int begin = 0;
+            int end = 10;
+            int size = end - begin;
+            List<IntOption> list = builder.build(IntOptionAdapter.range(begin, end));
+            assertThat(list.size(), is(size));
+            int index = begin;
+            for (IntOption value : list) {
+                assertThat(value, is(new IntOption(index++)));
+            }
+        }
+    }
+
+    /**
+     * w/ for-each.
+     * @throws Exception if failed
+     */
+    @Test
+    public void forEach_replay() throws Exception {
+        try (SpillListBuilder<IntOption> builder = new SpillListBuilder<>(new IntOptionAdapter())) {
+            int begin = 0;
+            int end = 10;
+            int size = end - begin;
+            List<IntOption> list = builder.build(IntOptionAdapter.range(begin, end));
+            assertThat(list.size(), is(size));
+            int index = begin;
+            for (IntOption value : list) {
+                assertThat(value, is(new IntOption(index++)));
+            }
+            index = begin;
+            for (IntOption value : list) {
+                assertThat(value, is(new IntOption(index++)));
+            }
+            index = begin;
+            for (IntOption value : list) {
+                assertThat(value, is(new IntOption(index++)));
+            }
+        }
+    }
+
+    /**
+     * w/ out of lower bounds.
+     * @throws Exception if failed
+     */
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void bounds_lower() throws Exception {
+        try (SpillListBuilder<IntOption> builder = new SpillListBuilder<>(new IntOptionAdapter())) {
+            builder.build(IntOptionAdapter.range(0, 10)).get(-1);
+        }
+    }
+
+    /**
+     * w/ out of upper bounds.
+     * @throws Exception if failed
+     */
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void bounds_upper() throws Exception {
+        try (SpillListBuilder<IntOption> builder = new SpillListBuilder<>(new IntOptionAdapter())) {
+            builder.build(IntOptionAdapter.range(0, 10)).get(10);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces new implementations of co-group like operator input buffer.

## Background, Problem or Goal of the patch

The latest implementation, we use `ListBuffer` family for the inputs, which includes:
* `ArrayListBuffer` - using backing array
* `FileMapListBuffer` - using backing file

## Design of the fix, or a new feature

The new implementation, we introduce `ListBuilder` family, which includes:
* `HeapListBuffer` - using backing array, which will replace `ArrayListBuffer`
* `SpillListBuffer` - using backing file, which will replace `FileMapListBuffer`

We especially improve performance of `SpillListBuffer` by using NIO (direct `ByteBuffer` and `FileChannel`), whereas the old implementation has used `RandomAccessFile` with byte array buffers.

Currently, this feature is available only for Asakusa {on M3BP, Vanilla}.

## Related Issue, Pull Request or Code

* #97 

## Wanted reviewer

@akirakw 