### PR TITLE
Enable `@Once` and `@Spill` for co-group inputs.

### DIFF
--- a/compiler-project/analyzer/src/main/java/com/asakusafw/lang/compiler/analyzer/FlowGraphAnalyzer.java
+++ b/compiler-project/analyzer/src/main/java/com/asakusafw/lang/compiler/analyzer/FlowGraphAnalyzer.java
@@ -313,7 +313,8 @@ public final class FlowGraphAnalyzer {
             OperatorSource source,
             Operator.AbstractBuilder<?, ?> builder) {
         for (FlowElementPortDescription port : description.getInputPorts()) {
-            builder.input(port.getName(), typeOf(port.getDataType()), convert(port.getShuffleKey()));
+            builder.input(port.getName(), typeOf(port.getDataType()), c -> c
+                    .group(convert(port.getShuffleKey())));
         }
         for (FlowElementPortDescription port : description.getOutputPorts()) {
             builder.output(port.getName(), typeOf(port.getDataType()));

--- a/compiler-project/analyzer/src/main/java/com/asakusafw/lang/compiler/analyzer/builtin/CoGroupKindOperatorClassifier.java
+++ b/compiler-project/analyzer/src/main/java/com/asakusafw/lang/compiler/analyzer/builtin/CoGroupKindOperatorClassifier.java
@@ -16,9 +16,8 @@
 package com.asakusafw.lang.compiler.analyzer.builtin;
 
 import java.util.List;
-import java.util.Optional;
 
-import com.asakusafw.lang.compiler.model.description.AnnotationDescription;
+import com.asakusafw.lang.compiler.analyzer.util.GroupOperatorUtil;
 import com.asakusafw.lang.compiler.model.graph.Group;
 import com.asakusafw.lang.compiler.model.graph.Operator;
 import com.asakusafw.lang.compiler.model.graph.Operator.OperatorKind;
@@ -28,8 +27,6 @@ import com.asakusafw.lang.compiler.optimizer.OperatorCharacterizer;
 import com.asakusafw.lang.compiler.optimizer.basic.OperatorClass;
 import com.asakusafw.lang.compiler.optimizer.basic.OperatorClass.InputAttribute;
 import com.asakusafw.lang.compiler.optimizer.basic.OperatorClass.InputType;
-import com.asakusafw.vocabulary.attribute.BufferType;
-import com.asakusafw.vocabulary.flow.processor.InputBuffer;
 
 /**
  * Provides {@link OperatorClass} for generic <em>co-group kind</em> operators.
@@ -37,10 +34,6 @@ import com.asakusafw.vocabulary.flow.processor.InputBuffer;
  * @version 0.3.0
  */
 public class CoGroupKindOperatorClassifier implements OperatorCharacterizer<OperatorClass> {
-
-    private static final String KEY_INPUT_BUFFER_TYPE = "inputBuffer"; //$NON-NLS-1$
-
-    private static final InputBuffer DEFAULT_INPUT_BUFFER_TYPE = InputBuffer.EXPAND;
 
     @Override
     public OperatorClass extract(Context context, Operator operator) {
@@ -56,25 +49,22 @@ public class CoGroupKindOperatorClassifier implements OperatorCharacterizer<Oper
             throw new IllegalArgumentException();
         }
         OperatorClass.Builder builder = OperatorClass.builder(operator, InputType.GROUP);
-        BufferType defaultInputBufferType = isEscaped(operator.getAnnotation()) ? BufferType.STORED : BufferType.HEAP;
         for (OperatorInput input : inputs) {
             builder.with(input, InputAttribute.PRIMARY);
             if (isSorted(input)) {
                 builder.with(input, InputAttribute.SORTED);
             }
-            BufferType bufferType = Optional.ofNullable(input.getAttribute(BufferType.class))
-                    .orElse(defaultInputBufferType);
-            switch (bufferType) {
+            switch (GroupOperatorUtil.getBufferType(input)) {
             case HEAP:
                 break;
-            case STORED:
+            case SPILL:
                 builder.with(input, InputAttribute.ESCAPED);
                 break;
             case VOLATILE:
                 builder.with(input, InputAttribute.VOALTILE);
                 break;
             default:
-                throw new AssertionError(bufferType);
+                throw new AssertionError(input);
             }
         }
         return builder.build();
@@ -83,10 +73,5 @@ public class CoGroupKindOperatorClassifier implements OperatorCharacterizer<Oper
     private static boolean isSorted(OperatorInput input) {
         Group group = input.getGroup();
         return group != null && group.getOrdering().isEmpty() == false;
-    }
-
-    private static boolean isEscaped(AnnotationDescription annotation) {
-        InputBuffer value = Util.element(annotation, KEY_INPUT_BUFFER_TYPE, DEFAULT_INPUT_BUFFER_TYPE);
-        return value == InputBuffer.ESCAPE;
     }
 }

--- a/compiler-project/analyzer/src/main/java/com/asakusafw/lang/compiler/analyzer/util/GroupOperatorUtil.java
+++ b/compiler-project/analyzer/src/main/java/com/asakusafw/lang/compiler/analyzer/util/GroupOperatorUtil.java
@@ -17,41 +17,56 @@ package com.asakusafw.lang.compiler.analyzer.util;
 
 import java.text.MessageFormat;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.asakusafw.lang.compiler.model.description.AnnotationDescription;
 import com.asakusafw.lang.compiler.model.description.ClassDescription;
 import com.asakusafw.lang.compiler.model.description.Descriptions;
 import com.asakusafw.lang.compiler.model.description.EnumConstantDescription;
 import com.asakusafw.lang.compiler.model.description.ValueDescription;
-import com.asakusafw.lang.compiler.model.description.ValueDescription.ValueKind;
 import com.asakusafw.lang.compiler.model.graph.Operator;
 import com.asakusafw.lang.compiler.model.graph.Operator.OperatorKind;
+import com.asakusafw.lang.compiler.model.graph.OperatorInput;
 import com.asakusafw.lang.compiler.model.graph.UserOperator;
-import com.asakusafw.vocabulary.operator.Logging;
+import com.asakusafw.vocabulary.attribute.BufferType;
+import com.asakusafw.vocabulary.flow.processor.InputBuffer;
+import com.asakusafw.vocabulary.operator.CoGroup;
+import com.asakusafw.vocabulary.operator.GroupSort;
 
 /**
- * Utilities for <em>branch kind</em> operators.
+ * Utilities about operators which process input groups.
+ * @since 0.4.1
  */
-public final class LoggingOperatorUtil {
+public final class GroupOperatorUtil {
 
-    private static final String NAME_ELEMENT = "value"; //$NON-NLS-1$
+    static final Logger LOG = LoggerFactory.getLogger(GroupOperatorUtil.class);
+
+    private static final String NAME_INPUT_BUFFER = "inputBuffer"; //$NON-NLS-1$
+
+    private static final EnumConstantDescription INPUT_BUFFER_DEFAULT = EnumConstantDescription.of(InputBuffer.EXPAND);
+
+    private static final EnumConstantDescription INPUT_BUFFER_ESCAPE = EnumConstantDescription.of(InputBuffer.ESCAPE);
 
     private static final Set<ClassDescription> SUPPORTED;
     static {
         Set<ClassDescription> set = new HashSet<>();
-        set.add(Descriptions.classOf(Logging.class));
+        set.add(Descriptions.classOf(GroupSort.class));
+        set.add(Descriptions.classOf(CoGroup.class));
         SUPPORTED = set;
     }
 
-    private LoggingOperatorUtil() {
+    private GroupOperatorUtil() {
         return;
     }
 
     /**
-     * Returns whether the target operator is <em>logging operator kind</em> or not.
+     * Returns whether the target operator is <em>grouping operator kind</em> or not.
      * @param operator the target operator
-     * @return {@code true} if the target operator is <em>logging operator kind</em>, otherwise {@code false}
+     * @return {@code true} if the target operator is <em>grouping operator kind</em>, otherwise {@code false}
      */
     public static boolean isSupported(Operator operator) {
         if (operator.getOperatorKind() != OperatorKind.USER) {
@@ -63,35 +78,25 @@ public final class LoggingOperatorUtil {
     }
 
     /**
-     * Extracts log level in <em>branch kind</em> operator.
-     * @param classLoader the class loader to resolve target operator
-     * @param operator the target logging kind operator
-     * @return the log level
-     * @throws ReflectiveOperationException if failed to resolve operators
+     * Returns the buffer type of the given operator input.
+     * The operator must be a <em>grouping operator kind</em>.
+     * @param port the target input port
+     * @return the corresponded buffer type
      * @throws IllegalArgumentException if the target operator is not supported
      */
-    public static Logging.Level getLogLevel(
-            ClassLoader classLoader,
-            Operator operator) throws ReflectiveOperationException {
-        if (isSupported(operator) == false) {
+    public static BufferType getBufferType(OperatorInput port) {
+        if (isSupported(port.getOwner()) == false) {
             throw new IllegalArgumentException(MessageFormat.format(
                     "operator must be a kind of Logging: {0}",
-                    operator));
+                    port.getOwner()));
         }
-        UserOperator op = (UserOperator) operator;
-        AnnotationDescription annotation = op.getAnnotation();
-        ValueDescription level = annotation.getElements().get(NAME_ELEMENT);
-        if (level == null || level.getValueKind() != ValueKind.ENUM_CONSTANT) {
-            throw new IllegalStateException(MessageFormat.format(
-                    "Logging kind operator must have log level: {0}",
-                    op.getMethod()));
-        }
-        Object resolved = ((EnumConstantDescription) level).resolve(classLoader);
-        if ((resolved instanceof Logging.Level) == false) {
-            throw new IllegalStateException(MessageFormat.format(
-                    "log level of Logging kind operator must be instance of Logging.Level: {0}",
-                    resolved));
-        }
-        return (Logging.Level) resolved;
+        return Optional.ofNullable(port.getAttribute(BufferType.class))
+                .orElseGet(() -> isEscape((UserOperator) port.getOwner()) ? BufferType.SPILL : BufferType.HEAP);
+    }
+
+    private static boolean isEscape(UserOperator operator) {
+        AnnotationDescription annotation = operator.getAnnotation();
+        ValueDescription inputBuffer = annotation.getElements().getOrDefault(NAME_INPUT_BUFFER, INPUT_BUFFER_DEFAULT);
+        return inputBuffer.equals(INPUT_BUFFER_ESCAPE);
     }
 }

--- a/compiler-project/analyzer/src/test/java/com/asakusafw/lang/compiler/analyzer/FlowGraphAnalyzerTest.java
+++ b/compiler-project/analyzer/src/test/java/com/asakusafw/lang/compiler/analyzer/FlowGraphAnalyzerTest.java
@@ -35,17 +35,20 @@ import com.asakusafw.lang.compiler.model.graph.Groups;
 import com.asakusafw.lang.compiler.model.graph.OperatorConstraint;
 import com.asakusafw.lang.compiler.model.graph.UserOperator;
 import com.asakusafw.runtime.core.Result;
+import com.asakusafw.vocabulary.attribute.BufferType;
 import com.asakusafw.vocabulary.external.ExporterDescription;
 import com.asakusafw.vocabulary.external.ImporterDescription;
 import com.asakusafw.vocabulary.flow.FlowDescription;
 import com.asakusafw.vocabulary.flow.graph.FlowBoundary;
 import com.asakusafw.vocabulary.flow.graph.FlowElementDescription;
+import com.asakusafw.vocabulary.flow.graph.FlowElementPortDescription;
 import com.asakusafw.vocabulary.flow.graph.FlowGraph;
 import com.asakusafw.vocabulary.flow.graph.FlowPartDescription;
 import com.asakusafw.vocabulary.flow.graph.InputDescription;
 import com.asakusafw.vocabulary.flow.graph.ObservationCount;
 import com.asakusafw.vocabulary.flow.graph.OperatorDescription;
 import com.asakusafw.vocabulary.flow.graph.OutputDescription;
+import com.asakusafw.vocabulary.flow.graph.PortDirection;
 import com.asakusafw.vocabulary.flow.util.CoreOperators;
 import com.asakusafw.vocabulary.model.Key;
 import com.asakusafw.vocabulary.operator.CoGroup;
@@ -471,6 +474,45 @@ public class FlowGraphAnalyzerTest {
             .output("d0", "p");
 
         assertThat(inspector.get("o0").getAttribute(MockAttribute.class), is(new MockAttribute("OK")));
+    }
+
+    /**
+     * port w/ attribute.
+     */
+    @Test
+    public void port_attribute() {
+        FlowGraph g = new MockFlowGraph()
+            .add("s0", new InputDescription("p", String.class))
+            .add("o0", new OperatorDescription.Builder(CoGroup.class)
+                    .declare(Alias.class, Alias.class, "groupsort")
+                    .declareParameter(List.class)
+                    .declareParameter(Result.class)
+                    .addPort(new FlowElementPortDescription(
+                            "p", String.class,
+                            PortDirection.INPUT, null, Arrays.asList(BufferType.VOLATILE)))
+                    .addPort(new FlowElementPortDescription(
+                            "p", String.class,
+                            PortDirection.OUTPUT, null, Arrays.asList(BufferType.STORED)))
+                    .toDescription())
+            .add("d0", new OutputDescription("p", String.class))
+            .connect("s0", "o0")
+            .connect("o0", "d0")
+            .toGraph();
+
+        OperatorGraphInspector inspector = new OperatorGraphInspector(converter.analyze(g))
+            .input("s0", "p")
+            .operator("o0", Alias.class, "groupsort")
+            .output("d0", "p");
+
+        inspector
+            .operators(3)
+            .connections(2)
+            .connected("s0", "o0")
+            .connected("o0", "d0");
+
+        UserOperator operator = (UserOperator) inspector.get("o0");
+        assertThat(operator.getInputs().get(0).getAttribute(BufferType.class), is(BufferType.VOLATILE));
+        assertThat(operator.getOutputs().get(0).getAttribute(BufferType.class), is(BufferType.STORED));
     }
 
     /**

--- a/compiler-project/analyzer/src/test/java/com/asakusafw/lang/compiler/analyzer/FlowGraphAnalyzerTest.java
+++ b/compiler-project/analyzer/src/test/java/com/asakusafw/lang/compiler/analyzer/FlowGraphAnalyzerTest.java
@@ -492,7 +492,7 @@ public class FlowGraphAnalyzerTest {
                             PortDirection.INPUT, null, Arrays.asList(BufferType.VOLATILE)))
                     .addPort(new FlowElementPortDescription(
                             "p", String.class,
-                            PortDirection.OUTPUT, null, Arrays.asList(BufferType.STORED)))
+                            PortDirection.OUTPUT, null, Arrays.asList(BufferType.SPILL)))
                     .toDescription())
             .add("d0", new OutputDescription("p", String.class))
             .connect("s0", "o0")
@@ -512,7 +512,7 @@ public class FlowGraphAnalyzerTest {
 
         UserOperator operator = (UserOperator) inspector.get("o0");
         assertThat(operator.getInputs().get(0).getAttribute(BufferType.class), is(BufferType.VOLATILE));
-        assertThat(operator.getOutputs().get(0).getAttribute(BufferType.class), is(BufferType.STORED));
+        assertThat(operator.getOutputs().get(0).getAttribute(BufferType.class), is(BufferType.SPILL));
     }
 
     /**

--- a/compiler-project/analyzer/src/test/java/com/asakusafw/lang/compiler/analyzer/util/GroupOperatorUtilTest.java
+++ b/compiler-project/analyzer/src/test/java/com/asakusafw/lang/compiler/analyzer/util/GroupOperatorUtilTest.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.compiler.analyzer.util;
+
+import static com.asakusafw.lang.compiler.model.description.Descriptions.*;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.lang.annotation.Annotation;
+
+import org.junit.Test;
+
+import com.asakusafw.lang.compiler.model.graph.CoreOperator;
+import com.asakusafw.lang.compiler.model.graph.CoreOperator.CoreOperatorKind;
+import com.asakusafw.lang.compiler.model.graph.UserOperator;
+import com.asakusafw.lang.compiler.model.testing.OperatorExtractor;
+import com.asakusafw.vocabulary.attribute.BufferType;
+import com.asakusafw.vocabulary.flow.processor.InputBuffer;
+import com.asakusafw.vocabulary.operator.CoGroup;
+import com.asakusafw.vocabulary.operator.GroupSort;
+import com.asakusafw.vocabulary.operator.Update;
+
+/**
+ * Test for {@link GroupOperatorUtil}.
+ */
+public class GroupOperatorUtilTest {
+
+    /**
+     * simple case.
+     */
+    @Test
+    public void simple() {
+        UserOperator m0 = extract(GroupSort.class, Ops.class, "m0");
+        assertThat(GroupOperatorUtil.isSupported(m0), is(true));
+        assertThat(GroupOperatorUtil.getBufferType(m0.getInputs().get(0)), is(BufferType.HEAP));
+    }
+
+    /**
+     * check supports.
+     * @throws Exception if failed
+     */
+    @Test
+    public void support() throws Exception {
+        UserOperator m0 = extract(GroupSort.class, Ops.class, "m0");
+        UserOperator m1 = extract(CoGroup.class, Ops.class, "m1");
+        UserOperator m2 = extract(GroupSort.class, Ops.class, "m2");
+        UserOperator m3 = extract(CoGroup.class, Ops.class, "m3");
+        UserOperator m4 = extract(Update.class, Ops.class, "m4");
+        CoreOperator m5 = CoreOperator.builder(CoreOperatorKind.CHECKPOINT)
+                .input("in", typeOf(String.class))
+                .output("out", typeOf(String.class))
+                .build();
+
+        assertThat(GroupOperatorUtil.isSupported(m0), is(true));
+        assertThat(GroupOperatorUtil.isSupported(m1), is(true));
+        assertThat(GroupOperatorUtil.isSupported(m2), is(true));
+        assertThat(GroupOperatorUtil.isSupported(m3), is(true));
+        assertThat(GroupOperatorUtil.isSupported(m4), is(false));
+        assertThat(GroupOperatorUtil.isSupported(m5), is(false));
+    }
+
+    /**
+     * spill.
+     */
+    @Test
+    public void spill() {
+        UserOperator m0 = extract(GroupSort.class, Ops.class, "m0", BufferType.SPILL);
+        assertThat(GroupOperatorUtil.isSupported(m0), is(true));
+        assertThat(GroupOperatorUtil.getBufferType(m0.getInputs().get(0)), is(BufferType.SPILL));
+    }
+
+    /**
+     * once.
+     */
+    @Test
+    public void once() {
+        UserOperator m0 = extract(GroupSort.class, Ops.class, "m0", BufferType.VOLATILE);
+        assertThat(GroupOperatorUtil.isSupported(m0), is(true));
+        assertThat(GroupOperatorUtil.getBufferType(m0.getInputs().get(0)), is(BufferType.VOLATILE));
+    }
+
+    /**
+     * spill from operator annotation.
+     */
+    @Test
+    public void inherit_spill() {
+        UserOperator m0 = extract(GroupSort.class, Ops.class, "m2");
+        assertThat(GroupOperatorUtil.isSupported(m0), is(true));
+        assertThat(GroupOperatorUtil.getBufferType(m0.getInputs().get(0)), is(BufferType.SPILL));
+    }
+
+    /**
+     * unsupported operator.
+     * @throws Exception if failed
+     */
+    @Test(expected = RuntimeException.class)
+    public void invalid_unsupported() throws Exception {
+        CoreOperator operator = CoreOperator.builder(CoreOperatorKind.CHECKPOINT)
+                .input("in", typeOf(String.class))
+                .output("out", typeOf(String.class))
+                .build();
+        GroupOperatorUtil.getBufferType(operator.getInputs().get(0));
+    }
+
+    private static UserOperator extract(
+            Class<? extends Annotation> annotationType,
+            Class<?> operatorClass,
+            String methodName,
+            Enum<?>... attributes) {
+        return OperatorExtractor.extract(annotationType, operatorClass, methodName)
+                .input("in", typeOf(String.class), c -> {
+                    for (Enum<?> attr : attributes) {
+                        c.attribute(attr);
+                    }
+                })
+                .output("out", typeOf(String.class))
+                .build();
+    }
+
+    @SuppressWarnings("javadoc")
+    public static abstract class Ops {
+
+        @GroupSort
+        public abstract void m0();
+
+        @CoGroup
+        public abstract void m1();
+
+        @GroupSort(inputBuffer = InputBuffer.ESCAPE)
+        public abstract void m2();
+
+        @CoGroup(inputBuffer = InputBuffer.ESCAPE)
+        public abstract void m3();
+
+        @Update
+        public abstract void m4();
+    }
+}

--- a/compiler-project/analyzer/src/test/java/com/asakusafw/lang/compiler/analyzer/util/LoggingOperatorUtilTest.java
+++ b/compiler-project/analyzer/src/test/java/com/asakusafw/lang/compiler/analyzer/util/LoggingOperatorUtilTest.java
@@ -101,7 +101,7 @@ public class LoggingOperatorUtilTest {
                 .build());
     }
 
-    private UserOperator extract(
+    private static UserOperator extract(
             Class<? extends Annotation> annotationType,
             Class<?> operatorClass,
             String methodName) {

--- a/compiler-project/inspection/src/main/java/com/asakusafw/lang/compiler/inspection/DslDriver.java
+++ b/compiler-project/inspection/src/main/java/com/asakusafw/lang/compiler/inspection/DslDriver.java
@@ -36,6 +36,7 @@ import com.asakusafw.lang.compiler.model.graph.OperatorConstraint;
 import com.asakusafw.lang.compiler.model.graph.OperatorGraph;
 import com.asakusafw.lang.compiler.model.graph.OperatorInput;
 import com.asakusafw.lang.compiler.model.graph.OperatorOutput;
+import com.asakusafw.lang.compiler.model.graph.OperatorPort;
 import com.asakusafw.lang.compiler.model.graph.Operators;
 import com.asakusafw.lang.compiler.model.graph.UserOperator;
 import com.asakusafw.lang.compiler.model.info.ExternalInputInfo;
@@ -162,11 +163,13 @@ public class DslDriver {
             if (port.getGroup() != null) {
                 p.withProperty("group", port.getGroup().toString()); //$NON-NLS-1$
             }
+            inspectAttributes(p, port);
         }
         for (OperatorOutput port : object.getOutputs()) {
             InspectionNode.Port p = new InspectionNode.Port(id(port));
             node.withOutput(p);
             p.withProperty(PROPERTY_TYPE, port.getDataType().toString());
+            inspectAttributes(p, port);
         }
         for (OperatorArgument arg : object.getArguments()) {
             node.withProperty(String.format("arguments.%s", arg.getName()), arg.getValue().toString()); //$NON-NLS-1$
@@ -263,6 +266,13 @@ public class DslDriver {
             result.withProperty(getAttributeKey(type), getAttributeValue(attribute));
         }
         return result;
+    }
+
+    private void inspectAttributes(InspectionNode.Port port, OperatorPort object) {
+        for (Class<?> type : object.getAttributeTypes()) {
+            Object attribute = object.getAttribute(type);
+            port.withProperty(getAttributeKey(type), getAttributeValue(attribute));
+        }
     }
 
     private static class OperatorNamer {

--- a/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/graph/AttributeMap.java
+++ b/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/graph/AttributeMap.java
@@ -118,6 +118,20 @@ public final class AttributeMap {
 
         /**
          * Adds an attribute.
+         * @param value the attribute value
+         * @return this
+         */
+        public Builder add(Enum<?> value) {
+            Objects.requireNonNull(value);
+            if (entries == null) {
+                entries = new LinkedHashMap<>();
+            }
+            entries.put(value.getDeclaringClass(), value);
+            return this;
+        }
+
+        /**
+         * Adds an attribute.
          * @param <T> the attribute type
          * @param type the attribute type
          * @param object the attribute value

--- a/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/graph/AttributeMap.java
+++ b/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/graph/AttributeMap.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.compiler.model.graph;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Represents a map of attributes.
+ * @since 0.4.1
+ */
+public final class AttributeMap {
+
+    static final AttributeMap EMPTY = new AttributeMap(Collections.emptyMap());
+
+    private final Map<Class<?>, Object> entries;
+
+    private AttributeMap(Map<Class<?>, Object> entries) {
+        this.entries = shrink(entries);
+    }
+
+    private static Map<Class<?>, Object> shrink(Map<Class<?>, Object> map) {
+        switch (map.size()) {
+        case 0:
+            return Collections.emptyMap();
+        case 1:
+            Map.Entry<Class<?>, Object> entry = map.entrySet().iterator().next();
+            return Collections.singletonMap(entry.getKey(), entry.getValue());
+        default:
+            return map;
+        }
+    }
+
+    AttributeMap(Builder builder) {
+        this(builder.entries);
+    }
+
+    /**
+     * Returns the all attribute types which this map has.
+     * @return the all attribute types
+     */
+    public Set<Class<?>> getAttributeTypes() {
+        if (entries.isEmpty()) {
+            return Collections.emptySet();
+        }
+        return Collections.unmodifiableSet(entries.keySet());
+    }
+
+    /**
+     * Returns an attribute.
+     * @param <T> the attribute type
+     * @param type the attribute type
+     * @return the attribute value, or {@code null} if the map has no such an attribute
+     */
+    public <T> T getAttribute(Class<T> type) {
+        return type.cast(entries.get(type));
+    }
+
+    AttributeMap copy() {
+        if (entries.isEmpty()) {
+            return this;
+        }
+        Map<Class<?>, Object> copy = new LinkedHashMap<>();
+        copyTo(entries, copy);
+        return new AttributeMap(copy);
+    }
+
+    static void copyTo(Map<Class<?>, Object> from, Map<Class<?>, Object> to) {
+        for (Map.Entry<Class<?>, Object> entry : from.entrySet()) {
+            Class<?> key = entry.getKey();
+            Object value = entry.getValue();
+            if (value instanceof OperatorAttribute) {
+                value = ((OperatorAttribute) value).copy();
+                assert key.isInstance(value);
+            }
+            to.put(key, value);
+        }
+    }
+
+    @Override
+    public String toString() {
+        if (entries == null) {
+            return "{}"; //$NON-NLS-1$
+        }
+        return entries.entrySet().stream()
+                .sequential()
+                .map(e -> e.getKey().getSimpleName() + "=" + e.getValue()) //$NON-NLS-1$
+                .collect(Collectors.joining(
+                        ", ", //$NON-NLS-1$
+                        "{ ", //$NON-NLS-1$
+                        " }")); //$NON-NLS-1$
+    }
+
+    /**
+     * A builder of {@link AttributeMap}.
+     * @since 0.4.1
+     */
+    public static class Builder {
+
+        Map<Class<?>, Object> entries;
+
+        /**
+         * Adds an attribute.
+         * @param <T> the attribute type
+         * @param type the attribute type
+         * @param object the attribute value
+         * @return this
+         */
+        public <T> Builder add(Class<T> type, T object) {
+            Objects.requireNonNull(type);
+            Objects.requireNonNull(object);
+            if (entries == null) {
+                entries = new LinkedHashMap<>();
+            }
+            entries.put(type, object);
+            return this;
+        }
+
+        /**
+         * Builds {@link AttributeMap} and resets this builder.
+         * @return the built object
+         */
+        public AttributeMap build() {
+            if (entries == null) {
+                return AttributeMap.EMPTY;
+            }
+            AttributeMap result = new AttributeMap(this);
+            entries = null;
+            return result;
+        }
+    }
+}

--- a/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/graph/Operator.java
+++ b/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/graph/Operator.java
@@ -547,11 +547,10 @@ public abstract class Operator {
 
         /**
          * Adds an attribute to the building input.
-         * @param <T> the attribute type
          * @param value the attribute value
          * @return this
          */
-        <T extends Enum<T>> PortOptionBuilder attribute(T value);
+        PortOptionBuilder attribute(Enum<?> value);
 
         /**
          * Adds an attribute to the building input.
@@ -610,8 +609,9 @@ public abstract class Operator {
         }
 
         @Override
-        public <T extends Enum<T>> InputOptionBuilder attribute(T value) {
-            return attribute(value.getDeclaringClass(), value);
+        public InputOptionBuilder attribute(Enum<?> value) {
+            this.attributes.add(value);
+            return this;
         }
 
         @Override
@@ -634,14 +634,15 @@ public abstract class Operator {
         }
 
         @Override
-        public <T> OutputOptionBuilder attribute(Class<T> type, T value) {
-            this.attributes.add(type, value);
+        public OutputOptionBuilder attribute(Enum<?> value) {
+            this.attributes.add(value);
             return this;
         }
 
         @Override
-        public <T extends Enum<T>> OutputOptionBuilder attribute(T value) {
-            return attribute(value.getDeclaringClass(), value);
+        public <T> OutputOptionBuilder attribute(Class<T> type, T value) {
+            this.attributes.add(type, value);
+            return this;
         }
     }
 }

--- a/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/graph/Operator.java
+++ b/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/graph/Operator.java
@@ -540,10 +540,34 @@ public abstract class Operator {
     }
 
     /**
+     * An abstract option builder for {@link OperatorPort}.
+     * @since 0.4.1
+     */
+    public interface PortOptionBuilder {
+
+        /**
+         * Adds an attribute to the building input.
+         * @param <T> the attribute type
+         * @param value the attribute value
+         * @return this
+         */
+        <T extends Enum<T>> PortOptionBuilder attribute(T value);
+
+        /**
+         * Adds an attribute to the building input.
+         * @param <T> the attribute type
+         * @param type the attribute type
+         * @param value the attribute value
+         * @return this
+         */
+        <T> PortOptionBuilder attribute(Class<T> type, T value);
+    }
+
+    /**
      * A option builder for {@link OperatorInput}.
      * @since 0.4.1
      */
-    public static class InputOptionBuilder {
+    public static class InputOptionBuilder implements PortOptionBuilder {
 
         Group group;
 
@@ -585,23 +609,12 @@ public abstract class Operator {
             return this;
         }
 
-        /**
-         * Adds an attribute to the building input.
-         * @param <T> the attribute type
-         * @param value the attribute value
-         * @return this
-         */
+        @Override
         public <T extends Enum<T>> InputOptionBuilder attribute(T value) {
             return attribute(value.getDeclaringClass(), value);
         }
 
-        /**
-         * Adds an attribute to the building input.
-         * @param <T> the attribute type
-         * @param type the attribute type
-         * @param value the attribute value
-         * @return this
-         */
+        @Override
         public <T> InputOptionBuilder attribute(Class<T> type, T value) {
             this.attributes.add(type, value);
             return this;
@@ -612,7 +625,7 @@ public abstract class Operator {
      * A option builder for {@link OperatorOutput}.
      * @since 0.4.1
      */
-    public static class OutputOptionBuilder {
+    public static class OutputOptionBuilder implements PortOptionBuilder {
 
         final AttributeMap.Builder attributes = new AttributeMap.Builder();
 
@@ -620,24 +633,13 @@ public abstract class Operator {
             return;
         }
 
-        /**
-         * Adds an attribute to the building output.
-         * @param <T> the attribute type
-         * @param type the attribute type
-         * @param value the attribute value
-         * @return this
-         */
+        @Override
         public <T> OutputOptionBuilder attribute(Class<T> type, T value) {
             this.attributes.add(type, value);
             return this;
         }
 
-        /**
-         * Adds an attribute to the building output.
-         * @param <T> the attribute type
-         * @param value the attribute value
-         * @return this
-         */
+        @Override
         public <T extends Enum<T>> OutputOptionBuilder attribute(T value) {
             return attribute(value.getDeclaringClass(), value);
         }

--- a/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/graph/Operator.java
+++ b/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/graph/Operator.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 
 import com.asakusafw.lang.compiler.model.description.TypeDescription;
 import com.asakusafw.lang.compiler.model.description.ValueDescription;
@@ -101,34 +102,20 @@ public abstract class Operator {
         ((Operator) copy).originalSerialNumber = originalSerialNumber;
         for (OperatorProperty property : properties) {
             switch (property.getPropertyKind()) {
-            case INPUT: {
-                OperatorInput p = (OperatorInput) property;
-                copy.properties.add(new OperatorInput(copy, p.getName(), p.getDataType(), p.getGroup()));
+            case INPUT:
+                copy.properties.add(((OperatorInput) property).copy(copy));
                 break;
-            }
-            case OUTPUT: {
-                OperatorOutput p = (OperatorOutput) property;
-                copy.properties.add(new OperatorOutput(copy, p.getName(), p.getDataType()));
+            case OUTPUT:
+                copy.properties.add(((OperatorOutput) property).copy(copy));
                 break;
-            }
-            case ARGUMENT: {
-                OperatorArgument p = (OperatorArgument) property;
-                copy.properties.add(new OperatorArgument(p.getName(), p.getValue()));
+            case ARGUMENT:
+                copy.properties.add(property);
                 break;
-            }
             default:
                 throw new AssertionError(property);
             }
         }
-        for (Map.Entry<Class<?>, Object> entry : attributes.entrySet()) {
-            Class<?> key = entry.getKey();
-            Object value = entry.getValue();
-            if (value instanceof OperatorAttribute) {
-                value = ((OperatorAttribute) value).copy();
-                assert key.isInstance(value);
-            }
-            copy.attributes.put(key, value);
-        }
+        AttributeMap.copyTo(attributes, copy.attributes);
         copy.constraints.addAll(constraints);
         return copy;
     }
@@ -369,7 +356,7 @@ public abstract class Operator {
      * @param <TOperator> the operator type
      * @param <TSelf> the actual builder type
      * @since 0.1.0
-     * @version 0.3.0
+     * @version 0.4.1
      */
     public abstract static class AbstractBuilder<TOperator extends Operator, TSelf>
             extends BuilderBase<TOperator, TSelf> {
@@ -383,6 +370,79 @@ public abstract class Operator {
         }
 
         /**
+         * Adds a clone of the given input port to the building operator.
+         * @param port the original input
+         * @return this
+         * @since 0.4.1
+         */
+        public TSelf input(OperatorInput port) {
+            TOperator owner = getOwner();
+            owner.properties.add(port.copy(owner));
+            return getSelf();
+        }
+
+        /**
+         * Adds a clone of the given output port to the building operator.
+         * @param port the original output
+         * @return this
+         * @since 0.4.1
+         */
+        public TSelf output(OperatorOutput port) {
+            TOperator owner = getOwner();
+            owner.properties.add(port.copy(owner));
+            return getSelf();
+        }
+
+        /**
+         * Adds a clone of the given argument to the building operator.
+         * @param argument the original argument
+         * @return this
+         * @since 0.4.1
+         */
+        public TSelf argument(OperatorArgument argument) {
+            TOperator owner = getOwner();
+            owner.properties.add(argument);
+            return getSelf();
+        }
+
+        /**
+         * Adds an input port to the building operator.
+         * @param name the port name
+         * @param dataType the data type on the port
+         * @param configurator configurator of the building inputs
+         * @return this
+         * @since 0.4.1
+         */
+        public TSelf input(String name, TypeDescription dataType, Consumer<InputOptionBuilder> configurator) {
+            InputOptionBuilder sub = new InputOptionBuilder();
+            configurator.accept(sub);
+            TOperator owner = getOwner();
+            OperatorInput port = new OperatorInput(owner, name, dataType, sub.group, sub.attributes.build());
+            owner.properties.add(port);
+            for (OperatorOutput upstream : sub.upstreams) {
+                port.connect(upstream);
+            }
+            return getSelf();
+        }
+
+        /**
+         * Adds an input port to the building operator.
+         * @param name the port name
+         * @param dataType the data type on the port
+         * @param configurator configurator of the building inputs
+         * @return this
+         * @since 0.4.1
+         */
+        public TSelf output(String name, TypeDescription dataType, Consumer<OutputOptionBuilder> configurator) {
+            OutputOptionBuilder sub = new OutputOptionBuilder();
+            configurator.accept(sub);
+            TOperator owner = getOwner();
+            OperatorOutput port = new OperatorOutput(owner, name, dataType, sub.attributes.build());
+            owner.properties.add(port);
+            return getSelf();
+        }
+
+        /**
          * Adds an input port to the building operator.
          * @param name the port name
          * @param dataType the data type on the port
@@ -390,7 +450,7 @@ public abstract class Operator {
          * @return this
          */
         public TSelf input(String name, TypeDescription dataType, OperatorOutput... upstreams) {
-            return input(name, dataType, (Group) null, upstreams);
+            return input(name, dataType, c -> c.upstreams(upstreams));
         }
 
         /**
@@ -403,13 +463,7 @@ public abstract class Operator {
          * @see Groups
          */
         public TSelf input(String name, TypeDescription dataType, Group group, OperatorOutput... upstreams) {
-            TOperator owner = getOwner();
-            OperatorInput port = new OperatorInput(owner, name, dataType, group);
-            owner.properties.add(port);
-            for (OperatorOutput upstream : upstreams) {
-                port.connect(upstream);
-            }
-            return getSelf();
+            return input(name, dataType, c -> c.group(group).upstreams(upstreams));
         }
 
         /**
@@ -420,7 +474,8 @@ public abstract class Operator {
          * @return this
          */
         public TSelf input(String name, OperatorOutput upstream, OperatorOutput... upstreams) {
-            return input(name, (Group) null, upstream, upstreams);
+            TypeDescription dataType = upstream.getDataType();
+            return input(name, dataType, c -> c.upstream(upstream).upstreams(upstreams));
         }
 
         /**
@@ -433,10 +488,8 @@ public abstract class Operator {
          * @see Groups
          */
         public TSelf input(String name, Group group, OperatorOutput upstream, OperatorOutput... upstreams) {
-            OperatorOutput[] joint = new OperatorOutput[upstreams.length + 1];
-            joint[0] = upstream;
-            System.arraycopy(upstreams, 0, joint, 1, upstreams.length);
-            return input(name, upstream.getDataType(), group, joint);
+            TypeDescription dataType = upstream.getDataType();
+            return input(name, dataType, c -> c.group(group).upstream(upstream).upstreams(upstreams));
         }
 
         /**
@@ -446,9 +499,9 @@ public abstract class Operator {
          * @return this
          */
         public TSelf output(String name, TypeDescription dataType) {
-            TOperator owner = getOwner();
-            owner.properties.add(new OperatorOutput(owner, name, dataType));
-            return getSelf();
+            return output(name, dataType, c -> {
+                return;
+            });
         }
 
         /**
@@ -483,6 +536,110 @@ public abstract class Operator {
             TOperator owner = getOwner();
             Collections.addAll(owner.constraints, constraints);
             return getSelf();
+        }
+    }
+
+    /**
+     * A option builder for {@link OperatorInput}.
+     * @since 0.4.1
+     */
+    public static class InputOptionBuilder {
+
+        Group group;
+
+        final List<OperatorOutput> upstreams = new ArrayList<>();
+
+        final AttributeMap.Builder attributes = new AttributeMap.Builder();
+
+        InputOptionBuilder() {
+            return;
+        }
+
+        /**
+         * Sets the grouping information.
+         * @param grouping grouping information
+         * @return this
+         */
+        public InputOptionBuilder group(Group grouping) {
+            this.group = grouping;
+            return this;
+        }
+
+        /**
+         * Adds an upstream of the building input.
+         * @param upstream the upstream port
+         * @return this
+         */
+        public InputOptionBuilder upstream(OperatorOutput upstream) {
+            this.upstreams.add(upstream);
+            return this;
+        }
+
+        /**
+         * Adds upstreams of the building input.
+         * @param upstreamArray the upstream port
+         * @return this
+         */
+        public InputOptionBuilder upstreams(OperatorOutput... upstreamArray) {
+            Collections.addAll(this.upstreams, upstreamArray);
+            return this;
+        }
+
+        /**
+         * Adds an attribute to the building input.
+         * @param <T> the attribute type
+         * @param value the attribute value
+         * @return this
+         */
+        public <T extends Enum<T>> InputOptionBuilder attribute(T value) {
+            return attribute(value.getDeclaringClass(), value);
+        }
+
+        /**
+         * Adds an attribute to the building input.
+         * @param <T> the attribute type
+         * @param type the attribute type
+         * @param value the attribute value
+         * @return this
+         */
+        public <T> InputOptionBuilder attribute(Class<T> type, T value) {
+            this.attributes.add(type, value);
+            return this;
+        }
+    }
+
+    /**
+     * A option builder for {@link OperatorOutput}.
+     * @since 0.4.1
+     */
+    public static class OutputOptionBuilder {
+
+        final AttributeMap.Builder attributes = new AttributeMap.Builder();
+
+        OutputOptionBuilder() {
+            return;
+        }
+
+        /**
+         * Adds an attribute to the building output.
+         * @param <T> the attribute type
+         * @param type the attribute type
+         * @param value the attribute value
+         * @return this
+         */
+        public <T> OutputOptionBuilder attribute(Class<T> type, T value) {
+            this.attributes.add(type, value);
+            return this;
+        }
+
+        /**
+         * Adds an attribute to the building output.
+         * @param <T> the attribute type
+         * @param value the attribute value
+         * @return this
+         */
+        public <T extends Enum<T>> OutputOptionBuilder attribute(T value) {
+            return attribute(value.getDeclaringClass(), value);
         }
     }
 }

--- a/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/graph/OperatorInput.java
+++ b/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/graph/OperatorInput.java
@@ -26,6 +26,8 @@ import com.asakusafw.lang.compiler.model.description.TypeDescription;
 
 /**
  * Represents an operator input port.
+ * @since 0.1.0
+ * @version 0.4.1
  */
 public class OperatorInput implements OperatorPort {
 
@@ -37,17 +39,9 @@ public class OperatorInput implements OperatorPort {
 
     private final Group group;
 
-    private final Set<OperatorOutput> opposites = new HashSet<>();
+    private final AttributeMap attributes;
 
-    /**
-     * Creates a new instance.
-     * @param owner the owner of this port
-     * @param name the port name
-     * @param dataType the data type
-     */
-    public OperatorInput(Operator owner, String name, TypeDescription dataType) {
-        this(owner, name, dataType, null);
-    }
+    private final Set<OperatorOutput> opposites = new HashSet<>();
 
     /**
      * Creates a new instance.
@@ -57,10 +51,24 @@ public class OperatorInput implements OperatorPort {
      * @param group the grouping instruction (nullable)
      */
     public OperatorInput(Operator owner, String name, TypeDescription dataType, Group group) {
+        this(owner, name, dataType, group, AttributeMap.EMPTY);
+    }
+
+    /**
+     * Creates a new instance.
+     * @param owner the owner of this port
+     * @param name the port name
+     * @param dataType the data type
+     * @param group the grouping instruction (nullable)
+     * @param attributes the port attributes
+     * @since 0.4.1
+     */
+    public OperatorInput(Operator owner, String name, TypeDescription dataType, Group group, AttributeMap attributes) {
         this.owner = owner;
         this.name = name;
         this.dataType = dataType;
         this.group = group;
+        this.attributes = attributes;
     }
 
     @Override
@@ -85,10 +93,20 @@ public class OperatorInput implements OperatorPort {
 
     /**
      * Returns the dataset grouping instruction.
-     * @return the dataset grouping instruction, or {@code null} if grouing is not required
+     * @return the dataset grouping instruction, or {@code null} if grouping is not required
      */
     public Group getGroup() {
         return group;
+    }
+
+    @Override
+    public Set<Class<?>> getAttributeTypes() {
+        return attributes.getAttributeTypes();
+    }
+
+    @Override
+    public <T> T getAttribute(Class<T> attributeType) {
+        return attributes.getAttribute(attributeType);
     }
 
     /**
@@ -153,6 +171,10 @@ public class OperatorInput implements OperatorPort {
     @Override
     public Collection<OperatorOutput> getOpposites() {
         return Collections.unmodifiableList(new ArrayList<>(opposites));
+    }
+
+    OperatorInput copy(Operator newOwner) {
+        return new OperatorInput(newOwner, name, dataType, group, attributes.copy());
     }
 
     @Override

--- a/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/graph/OperatorOutput.java
+++ b/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/graph/OperatorOutput.java
@@ -26,6 +26,8 @@ import com.asakusafw.lang.compiler.model.description.TypeDescription;
 
 /**
  * Represents an operator output port.
+ * @since 0.1.0
+ * @version 0.4.1
  */
 public class OperatorOutput implements OperatorPort {
 
@@ -34,6 +36,8 @@ public class OperatorOutput implements OperatorPort {
     private final String name;
 
     private final TypeDescription dataType;
+
+    private final AttributeMap attributes;
 
     private final Set<OperatorInput> opposites = new HashSet<>();
 
@@ -44,9 +48,22 @@ public class OperatorOutput implements OperatorPort {
      * @param dataType the data type
      */
     public OperatorOutput(Operator owner, String name, TypeDescription dataType) {
+        this(owner, name, dataType, AttributeMap.EMPTY);
+    }
+
+    /**
+     * Creates a new instance.
+     * @param owner the owner of this port
+     * @param name the port name
+     * @param dataType the data type
+     * @param attributes the port attributes
+     * @since 0.4.1
+     */
+    public OperatorOutput(Operator owner, String name, TypeDescription dataType, AttributeMap attributes) {
         this.owner = owner;
         this.name = name;
         this.dataType = dataType;
+        this.attributes = attributes;
     }
 
     @Override
@@ -67,6 +84,16 @@ public class OperatorOutput implements OperatorPort {
     @Override
     public TypeDescription getDataType() {
         return dataType;
+    }
+
+    @Override
+    public Set<Class<?>> getAttributeTypes() {
+        return attributes.getAttributeTypes();
+    }
+
+    @Override
+    public <T> T getAttribute(Class<T> attributeType) {
+        return attributes.getAttribute(attributeType);
     }
 
     /**
@@ -130,6 +157,10 @@ public class OperatorOutput implements OperatorPort {
     @Override
     public Collection<OperatorInput> getOpposites() {
         return Collections.unmodifiableList(new ArrayList<>(opposites));
+    }
+
+    OperatorOutput copy(Operator newOwner) {
+        return new OperatorOutput(newOwner, name, dataType, attributes.copy());
     }
 
     @Override

--- a/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/graph/OperatorPort.java
+++ b/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/graph/OperatorPort.java
@@ -16,11 +16,14 @@
 package com.asakusafw.lang.compiler.model.graph;
 
 import java.util.Collection;
+import java.util.Set;
 
 import com.asakusafw.lang.compiler.model.description.TypeDescription;
 
 /**
  * Represents an I/O port of operator.
+ * @since 0.1.0
+ * @version 0.4.1
  */
 public interface OperatorPort extends OperatorProperty {
 
@@ -42,6 +45,22 @@ public interface OperatorPort extends OperatorProperty {
      * @return the data type
      */
     TypeDescription getDataType();
+
+    /**
+     * Returns the all attribute types which this port has.
+     * @return the all attribute types
+     * @since 0.4.1
+     */
+    Set<Class<?>> getAttributeTypes();
+
+    /**
+     * Returns an attribute.
+     * @param <T> the attribute type
+     * @param attributeType the attribute type
+     * @return the attribute value, or {@code null} if the port has no such an attribute
+     * @since 0.4.1
+     */
+    <T> T getAttribute(Class<T> attributeType);
 
     /**
      * Disconnects from all opposite ports.

--- a/compiler-project/optimizer/src/main/java/com/asakusafw/lang/compiler/optimizer/basic/OperatorClass.java
+++ b/compiler-project/optimizer/src/main/java/com/asakusafw/lang/compiler/optimizer/basic/OperatorClass.java
@@ -191,6 +191,8 @@ public class OperatorClass implements OperatorCharacteristics {
 
     /**
      * Represents an attribute for {@link OperatorInput}.
+     * @since 0.1.0
+     * @version 0.4.1
      */
     public enum InputAttribute {
 
@@ -208,6 +210,12 @@ public class OperatorClass implements OperatorCharacteristics {
          * Each input group may be escaped from heap memory.
          */
         ESCAPED,
+
+        /**
+         * Each input group must be read up to once.
+         * @since 0.4.1
+         */
+        VOALTILE,
 
         /**
          * Each input group will be aggregated.

--- a/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/Planning.java
+++ b/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/Planning.java
@@ -161,7 +161,7 @@ public final class Planning {
             }
             OperatorInput orig = port.getOperatorPort();
             ExternalOutput.Builder builder = ExternalOutput.builder(port.getName(), port.getInfo())
-                    .input(orig.getName(), orig.getDataType(), orig.getGroup())
+                    .input(orig)
                     .output(ExternalOutput.PORT_NAME, orig.getDataType()) // virtual
                     .constraint(port.getConstraints())
                     .constraint(OperatorConstraint.AT_LEAST_ONCE);

--- a/dag/compiler/builtin/src/main/java/com/asakusafw/dag/compiler/builtin/CoGroupOperatorGenerator.java
+++ b/dag/compiler/builtin/src/main/java/com/asakusafw/dag/compiler/builtin/CoGroupOperatorGenerator.java
@@ -31,6 +31,7 @@ import com.asakusafw.dag.compiler.codegen.AsmUtil.ValueRef;
 import com.asakusafw.dag.compiler.model.ClassData;
 import com.asakusafw.dag.compiler.model.graph.VertexElement;
 import com.asakusafw.dag.runtime.adapter.CoGroupOperation;
+import com.asakusafw.lang.compiler.analyzer.util.GroupOperatorUtil;
 import com.asakusafw.lang.compiler.model.description.ClassDescription;
 import com.asakusafw.lang.compiler.model.description.Descriptions;
 import com.asakusafw.lang.compiler.model.graph.OperatorInput;
@@ -95,7 +96,7 @@ public class CoGroupOperatorGenerator extends UserOperatorNodeGenerator {
     }
 
     private static boolean isReadOnce(OperatorInput port) {
-        BufferType type = port.getAttribute(BufferType.class);
+        BufferType type = GroupOperatorUtil.getBufferType(port);
         return type == BufferType.VOLATILE;
     }
 }

--- a/dag/compiler/builtin/src/main/java/com/asakusafw/dag/compiler/builtin/Util.java
+++ b/dag/compiler/builtin/src/main/java/com/asakusafw/dag/compiler/builtin/Util.java
@@ -168,6 +168,18 @@ final class Util {
                 false);
     }
 
+    static void getGroupIterable(MethodVisitor method, Context context, OperatorInput input) {
+        method.visitVarInsn(Opcodes.ALOAD, 1);
+        getInt(method, context.getGroupIndex(input));
+        method.visitMethodInsn(
+                Opcodes.INVOKESTATIC,
+                AsmUtil.typeOf(CoGroupOperationUtil.class).getInternalName(),
+                "getIterable",
+                Type.getMethodDescriptor(AsmUtil.typeOf(Iterable.class),
+                        AsmUtil.typeOf(CoGroupOperation.Input.class), Type.INT_TYPE),
+                false);
+    }
+
     static void invoke(MethodVisitor method, Context context, UserOperator operator, List<ValueRef> arguments) {
         for (ValueRef var : arguments) {
             var.load(method);

--- a/dag/compiler/model/src/main/java/com/asakusafw/dag/compiler/model/plan/InputSpec.java
+++ b/dag/compiler/model/src/main/java/com/asakusafw/dag/compiler/model/plan/InputSpec.java
@@ -173,6 +173,7 @@ public class InputSpec implements ElementSpec<SubPlan.Input> {
     /**
      * Represents an operation type.
      * @since 0.4.0
+     * @version 0.4.1
      */
     public enum InputOption {
 
@@ -185,5 +186,11 @@ public class InputSpec implements ElementSpec<SubPlan.Input> {
          * Uses file list buffer.
          */
         SPILL_OUT,
+
+        /**
+         * Only can read once.
+         * @since 0.4.1
+         */
+        READ_ONCE,
     }
 }

--- a/dag/compiler/plan/src/main/java/com/asakusafw/dag/compiler/planner/SubPlanAnalyzer.java
+++ b/dag/compiler/plan/src/main/java/com/asakusafw/dag/compiler/planner/SubPlanAnalyzer.java
@@ -267,6 +267,9 @@ public final class SubPlanAnalyzer {
         if (isSpillOut(input)) {
             results.add(InputOption.SPILL_OUT);
         }
+        if (isReadOnce(input)) {
+            results.add(InputOption.READ_ONCE);
+        }
         return results;
     }
 
@@ -279,6 +282,17 @@ public final class SubPlanAnalyzer {
             }
         }
         return false;
+    }
+
+    private boolean isReadOnce(SubPlan.Input input) {
+        for (OperatorInput consumer : input.getOperator().getOutput().getOpposites()) {
+            OperatorClass info = getOperatorClass(consumer.getOwner());
+            OperatorInput resolved = info.getOperator().findInput(consumer.getName());
+            if (info.getAttributes(resolved).contains(InputAttribute.VOALTILE) == false) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private TypeDescription computeInputDataType(SubPlan.Input input, InputType type) {

--- a/dag/runtime/runtime/src/main/java/com/asakusafw/dag/runtime/adapter/CoGroupOperation.java
+++ b/dag/runtime/runtime/src/main/java/com/asakusafw/dag/runtime/adapter/CoGroupOperation.java
@@ -16,6 +16,7 @@
 package com.asakusafw.dag.runtime.adapter;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.List;
 
 import com.asakusafw.dag.api.common.ObjectCursor;
@@ -57,10 +58,29 @@ public interface CoGroupOperation extends Operation<CoGroupOperation.Input> {
      * Provides the element in each group.
      * @param <T> the element type
      * @since 0.4.0
+     * @version 0.4.1
      */
-    public interface Cursor<T> extends ObjectCursor {
+    public interface Cursor<T> extends ObjectCursor, Iterator<T> {
 
         @Override
         T getObject() throws IOException, InterruptedException;
+
+        @Override
+        default boolean hasNext() {
+            try {
+                return nextObject();
+            } catch (IOException | InterruptedException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+
+        @Override
+        default T next() {
+            try {
+                return getObject();
+            } catch (IOException | InterruptedException e) {
+                throw new IllegalStateException(e);
+            }
+        }
     }
 }

--- a/dag/runtime/runtime/src/main/java/com/asakusafw/dag/runtime/skeleton/CoGroupOperationUtil.java
+++ b/dag/runtime/runtime/src/main/java/com/asakusafw/dag/runtime/skeleton/CoGroupOperationUtil.java
@@ -17,6 +17,7 @@ package com.asakusafw.dag.runtime.skeleton;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 
 import com.asakusafw.dag.api.common.ObjectCursor;
@@ -28,6 +29,7 @@ import com.asakusafw.lang.utils.common.Arguments;
 /**
  * Utilities for {@link CoGroupOperation}.
  * @since 0.4.0
+ * @version 0.4.1
  */
 public final class CoGroupOperationUtil {
 
@@ -107,5 +109,41 @@ public final class CoGroupOperationUtil {
             return Collections.emptyList();
         }
         return input.getList(index);
+    }
+
+    /**
+     * Returns a co-group element.
+     * @param <T> the element type
+     * @param input the input
+     * @param index the group index (0-origin)
+     * @return the group elements, or an empty list if {@code index} is {@code -1}
+     * @throws IOException if I/O error was occurred while reading the input
+     * @throws InterruptedException if interrupted while reading the input
+     * @since 0.4.1
+     */
+    public static <T> Iterable<T> getIterable(Input input, int index) throws IOException, InterruptedException {
+        if (index < 0) {
+            return Collections.emptyList();
+        }
+        return new OnceIterable<>(input.getCursor(index));
+    }
+
+    private static final class OnceIterable<T> implements Iterable<T> {
+
+        private Iterator<T> iterator;
+
+        OnceIterable(Iterator<T> iterator) {
+            this.iterator = iterator;
+        }
+
+        @Override
+        public Iterator<T> iterator() {
+            Iterator<T> result = iterator;
+            if (result == null) {
+                throw new IllegalStateException();
+            }
+            iterator = null;
+            return result;
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR enables `@Once` and `@Spill` for co-group inputs in Asakusa on M3BP and Asakusa Vanilla.

## Background, Problem or Goal of the patch

see asakusafw/asakusafw#695.

## Design of the fix, or a new feature

This PR includes the following enhancements:
* the compiler facilities now can handle custom attributes on operator inputs/outputs
  * operator graph models
  * flow DSL analyzer
  * inspection tools
* introduced `GroupOperatorUtil` to obtain `BufferType` of co-group like operator inputs
* enable `@Once` and `@Spill` annotations in Asakusa on M3BP and Asakusa Vanilla

## Related Issue, Pull Request or Code

* asakusafw/asakusafw#695

## Wanted reviewer

@akirakw : this may fail until the related PR was merged