### PR TITLE
Reduce memory usage of `SpillListBuilder`.

### DIFF
--- a/dag/runtime/runtime/src/main/java/com/asakusafw/dag/runtime/data/SpillListBuilder.java
+++ b/dag/runtime/runtime/src/main/java/com/asakusafw/dag/runtime/data/SpillListBuilder.java
@@ -245,7 +245,7 @@ public class SpillListBuilder<T> implements ListBuilder<T> {
         private long putContents(long begin, ByteBuffer contents) throws IOException {
             contents.flip();
             if (LOG.isTraceEnabled()) {
-                LOG.trace(String.format("writing page fragment: %s#%,d@%,d+%,d", path, begin, contents.remaining())); //$NON-NLS-1$
+                LOG.trace(String.format("writing page fragment: %s@%,d+%,d", path, begin, contents.remaining())); //$NON-NLS-1$
             }
             long offset = begin;
             while (contents.hasRemaining()) {
@@ -308,7 +308,7 @@ public class SpillListBuilder<T> implements ListBuilder<T> {
             int fileSize = (int) (fileEnd - fileBegin);
             buf.clear().limit(fileSize);
             if (LOG.isTraceEnabled()) {
-                LOG.trace(String.format("reading page fragment: %s#%,d@%,d+%,d", path, fileBegin, buf.remaining())); //$NON-NLS-1$
+                LOG.trace(String.format("reading page fragment: %s@%,d+%,d", path, fileBegin, buf.remaining())); //$NON-NLS-1$
             }
             long offset = fileBegin;
             while (buf.hasRemaining()) {

--- a/dag/runtime/runtime/src/test/java/com/asakusafw/dag/runtime/data/SpillListBuilderTest.java
+++ b/dag/runtime/runtime/src/test/java/com/asakusafw/dag/runtime/data/SpillListBuilderTest.java
@@ -125,12 +125,11 @@ public class SpillListBuilderTest {
                 IntOption value = list.get(i);
                 assertEquals(i + begin, value.get());
             }
-        }
-        try (SpillListBuilder<IntOption> builder = new SpillListBuilder<>(new IntOptionAdapter())) {
-            int begin = 2_000_000;
-            int end = 3_000_000;
-            int size = end - begin;
-            List<IntOption> list = builder.build(IntOptionAdapter.range(begin, end));
+
+            begin = 2_000_000;
+            end = 3_000_000;
+            size = end - begin;
+            list = builder.build(IntOptionAdapter.range(begin, end));
             assertThat(list.size(), is(size));
             for (int i = 0, n = end - begin; i < n; i++) {
                 IntOption value = list.get(i);
@@ -182,6 +181,100 @@ public class SpillListBuilderTest {
             for (IntOption value : list) {
                 assertThat(value, is(new IntOption(index++)));
             }
+        }
+    }
+
+    /**
+     * w/ fragments.
+     * @throws Exception if failed
+     */
+    @Test
+    public void fragments() throws Exception {
+        try (SpillListBuilder<IntOption> builder = new SpillListBuilder<>(
+                new IntOptionAdapter(), 1024, 4096)) {
+            int begin = 0;
+            int end = 100_000;
+            int size = end - begin;
+            List<IntOption> list = builder.build(IntOptionAdapter.range(begin, end));
+            assertThat(list.size(), is(size));
+            for (int i = 0, n = end - begin; i < n; i++) {
+                IntOption value = list.get(i);
+                assertEquals(i + begin, value.get());
+            }
+        }
+    }
+
+    /**
+     * just fragment size.
+     * @throws Exception if failed
+     */
+    @Test
+    public void fragments_just() throws Exception {
+        try (SpillListBuilder<IntOption> builder = new SpillListBuilder<>(
+                new IntOptionAdapter(), 1024, 5 * 1024 * 2)) {
+            int begin = 0;
+            int end = 100_000;
+            int size = end - begin;
+            List<IntOption> list = builder.build(IntOptionAdapter.range(begin, end));
+            assertThat(list.size(), is(size));
+            for (int i = 0, n = end - begin; i < n; i++) {
+                IntOption value = list.get(i);
+                assertEquals(i + begin, value.get());
+            }
+        }
+    }
+
+    /**
+     * w/ fragments.
+     * @throws Exception if failed
+     */
+    @Test
+    public void fragments_reuse() throws Exception {
+        try (SpillListBuilder<IntOption> builder = new SpillListBuilder<>(
+                new IntOptionAdapter(), 2000, 4096)) {
+            int begin = 0;
+            int end = 100_000;
+            int size = end - begin;
+            List<IntOption> list = builder.build(IntOptionAdapter.range(begin, end));
+            assertThat(list.size(), is(size));
+            for (int i = 0, n = end - begin; i < n; i++) {
+                IntOption value = list.get(i);
+                assertEquals(i + begin, value.get());
+            }
+
+            begin = 100_000;
+            end = 200_000;
+            size = end - begin;
+            list = builder.build(IntOptionAdapter.range(begin, end));
+            assertThat(list.size(), is(size));
+            for (int i = 0, n = end - begin; i < n; i++) {
+                IntOption value = list.get(i);
+                assertEquals(i + begin, value.get());
+            }
+        }
+    }
+
+    /**
+     * w/ fragments.
+     * @throws Exception if failed
+     */
+    @Test
+    public void fragments_huge() throws Exception {
+        try (SpillListBuilder<IntOption> builder = new SpillListBuilder<>(
+                new IntOptionAdapter(), 2000, 4096)) {
+            int begin = 0;
+            int end = 100_000_000;
+            int size = end - begin;
+            long t0 = System.currentTimeMillis();
+            List<IntOption> list = builder.build(IntOptionAdapter.range(begin, end));
+            assertThat(list.size(), is(size));
+            long t1 = System.currentTimeMillis();
+            for (int i = 0, n = end - begin; i < n; i++) {
+                IntOption value = list.get(i);
+                assertEquals(i + begin, value.get());
+            }
+            long t2 = System.currentTimeMillis();
+            System.out.printf("fragments - write: %,dms, read: %,dms%n", t1 - t0, t2 - t1);
         }
     }
 

--- a/utils/buffer/src/main/java/com/asakusafw/lang/utils/buffer/nio/ResizableNioDataBuffer.java
+++ b/utils/buffer/src/main/java/com/asakusafw/lang/utils/buffer/nio/ResizableNioDataBuffer.java
@@ -28,7 +28,7 @@ import com.asakusafw.lang.utils.buffer.DataIoUtils;
  */
 public class ResizableNioDataBuffer implements DataBuffer {
 
-    private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocateDirect(0).order(ByteOrder.nativeOrder());
+    private static final ByteBuffer EMPTY_BUFFER = allocate(0);
 
     static final double DEFAULT_BUFFER_EXPANSION_FACTOR = 1.5;
 
@@ -56,8 +56,12 @@ public class ResizableNioDataBuffer implements DataBuffer {
      * @param expansionFactor the buffer expansion factor
      */
     public ResizableNioDataBuffer(int initialCapacity, double expansionFactor) {
-        this.contents = EMPTY_BUFFER;
+        this.contents = initialCapacity <= 0 ? EMPTY_BUFFER : allocate(initialCapacity);
         this.expansionFactor = Math.max(expansionFactor, MINIMUM_BUFFER_EXPANSION_FACTOR);
+    }
+
+    private static ByteBuffer allocate(int size) {
+        return ByteBuffer.allocateDirect(size).order(ByteOrder.nativeOrder());
     }
 
     @Override


### PR DESCRIPTION
## Summary

This PR reduces memory usage of `@Spill` in Asakusa on M3BP and Asakusa Vanilla.

## Background, Problem or Goal of the patch

The latest implementation of `SpillListBuffer` sometimes requires large ser/de buffer. It grows up to `[buffer page size] = [the number of objects should be cached on Java heap] * [object serialization size in bytes]`. In addition, building a list will be failed if the page size becomes `>=2GB`. This is addressing limit of Java `ByteBuffer`.

## Design of the fix, or a new feature

This implementation will flush if the serialization size of each object was larger than the threshold (`bufferSoftLimit`). Clients can change this value by setting `com.asakusafw.dag.input.file.buffer.size` in individual engine configurations (internal).

## Related Issue, Pull Request or Code

* #101 

## Wanted reviewer

@akirakw 