### PR TITLE
Enable `asaksua-test-windows` module into Vanilla testkit.

### DIFF
--- a/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaSdkBasePlugin.groovy
+++ b/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaSdkBasePlugin.groovy
@@ -97,6 +97,11 @@ class AsakusaVanillaSdkBasePlugin implements Plugin<Project> {
                     asakusaVanillaTestkit "com.asakusafw.vanilla.testkit:asakusa-vanilla-test-adapter:${base.featureVersion}"
                     asakusaVanillaTestkit "com.asakusafw.vanilla.testkit:asakusa-vanilla-test-inprocess:${base.featureVersion}"
                     asakusaVanillaTestkit "com.asakusafw:asakusa-test-inprocess:${base.coreVersion}"
+                    asakusaVanillaTestkit "com.asakusafw:asakusa-test-windows:${base.coreVersion}"
+
+                    if (features.windgate) {
+                        asakusaVanillaTestkit "com.asakusafw:asakusa-windgate-test-inprocess:${base.coreVersion}"
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

This PR enables `asakusa-test-windows` module, which enables testing batch applications on Windows, into Asakusa Vanilla testkit.

## Background, Problem or Goal of the patch

In release `0.4.0`, the module had been lacked Asakusa Vanilla Gradle plug-ins.

## Design of the fix, or a new feature

This PR also enables `asakusa-windgate-test-inprocess` module if WindGate feature is enabled.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 