### PR TITLE
Enable extra parameters on `Master{Join,Check}`.

### DIFF
--- a/dag/compiler/builtin/src/main/java/com/asakusafw/dag/compiler/builtin/MasterCheckOperatorGenerator.java
+++ b/dag/compiler/builtin/src/main/java/com/asakusafw/dag/compiler/builtin/MasterCheckOperatorGenerator.java
@@ -15,7 +15,6 @@
  */
 package com.asakusafw.dag.compiler.builtin;
 
-import static com.asakusafw.dag.compiler.builtin.Util.*;
 import static com.asakusafw.dag.compiler.codegen.AsmUtil.*;
 
 import java.lang.annotation.Annotation;
@@ -42,11 +41,6 @@ public class MasterCheckOperatorGenerator extends MasterJoinLikeOperatorGenerato
     @Override
     protected Class<? extends Annotation> getAnnotationClass() {
         return MasterCheck.class;
-    }
-
-    @Override
-    protected void validate(Context context, UserOperator operator) {
-        checkPorts(operator, i -> i == 2, i -> i >= 1);
     }
 
     @Override

--- a/dag/compiler/builtin/src/main/java/com/asakusafw/dag/compiler/builtin/MasterJoinOperatorGenerator.java
+++ b/dag/compiler/builtin/src/main/java/com/asakusafw/dag/compiler/builtin/MasterJoinOperatorGenerator.java
@@ -57,11 +57,6 @@ public class MasterJoinOperatorGenerator extends MasterJoinLikeOperatorGenerator
     }
 
     @Override
-    protected void validate(Context context, UserOperator operator) {
-        checkPorts(operator, i -> i == 2, i -> i >= 1);
-    }
-
-    @Override
     protected Consumer<MethodVisitor> defineExtraFields(
             ClassVisitor writer, Context context,
             UserOperator operator, ClassDescription target) {

--- a/dag/compiler/builtin/src/test/java/com/asakusafw/dag/compiler/builtin/MockTable.java
+++ b/dag/compiler/builtin/src/test/java/com/asakusafw/dag/compiler/builtin/MockTable.java
@@ -45,6 +45,13 @@ public class MockTable<T> implements DataTable<T> {
 
     /**
      * Creates a new instance.
+     */
+    public MockTable() {
+        this(m -> Collections.emptyList(), null);
+    }
+
+    /**
+     * Creates a new instance.
      * @param keys key term extractor
      */
     public MockTable(Function<? super T, ?> keys) {


### PR DESCRIPTION
## Summary

This PR enables `Master{Join,Check}` operators to take extra parameters in Asakusa {on M3BP, Vanilla}.

## Background, Problem or Goal of the patch

see asakusafw/asakusafw#708.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw#708

## Wanted reviewer

@akirakw 