### PR TITLE
Revise error message about type error in `GroupView.find()`.

### DIFF
--- a/dag/runtime/runtime/src/main/java/com/asakusafw/dag/runtime/table/BasicDataTable.java
+++ b/dag/runtime/runtime/src/main/java/com/asakusafw/dag/runtime/table/BasicDataTable.java
@@ -234,10 +234,10 @@ public class BasicDataTable<T> implements DataTable<T> {
         Class<? extends Object> actual = element.getClass();
         if (actual.equals(keyElementTypes[index]) == false) {
             throw new IllegalArgumentException(MessageFormat.format(
-                    "key element at \"{0}\" must be type of \"{1}\": {2}",
+                    "key element at {0} is inconsistent type: required={1}, actual={2}",
                     index,
-                    keyElementTypes[index],
-                    actual));
+                    keyElementTypes[index].getName(),
+                    actual.getName()));
         }
     }
 

--- a/dag/runtime/runtime/src/test/java/com/asakusafw/dag/runtime/table/BasicDataTableTest.java
+++ b/dag/runtime/runtime/src/test/java/com/asakusafw/dag/runtime/table/BasicDataTableTest.java
@@ -390,7 +390,7 @@ public class BasicDataTableTest {
         DataTable<Integer> table = builder.build();
 
         assertThat(table.find(k(0)), hasSize(1));
-        AssertUtil.catching(() -> table.find(new LongOption(0)));
+        AssertUtil.catching(() -> table.find(0));
     }
 
     /**
@@ -404,7 +404,7 @@ public class BasicDataTableTest {
         DataTable<Integer> table = builder.build();
 
         assertThat(table.find(k(0), k(1)), hasSize(1));
-        AssertUtil.catching(() -> table.find(k(0), new LongOption(1)));
+        AssertUtil.catching(() -> table.find(k(0), 1));
     }
 
     /**
@@ -418,7 +418,7 @@ public class BasicDataTableTest {
         DataTable<Integer> table = builder.build();
 
         assertThat(table.find(k(0), k(1), k(2)), hasSize(1));
-        AssertUtil.catching(() -> table.find(k(0), k(1), new LongOption(2)));
+        AssertUtil.catching(() -> table.find(k(0), k(1), 2));
     }
 
     /**
@@ -432,7 +432,7 @@ public class BasicDataTableTest {
         DataTable<Integer> table = builder.build();
 
         assertThat(table.find(k(0), k(1), k(2), k(3)), hasSize(1));
-        AssertUtil.catching(() -> table.find(k(0), k(1), k(2), new LongOption(3)));
+        AssertUtil.catching(() -> table.find(k(0), k(1), k(2), 3));
     }
 
     /**
@@ -446,7 +446,7 @@ public class BasicDataTableTest {
         DataTable<Integer> table = builder.build();
 
         assertThat(table.find(k(0), k(1), k(2), k(3), k(4), k(5)), hasSize(1));
-        AssertUtil.catching(() -> table.find(k(0), k(1), k(2), k(3), k(4), new LongOption(5)));
+        AssertUtil.catching(() -> table.find(k(0), k(1), k(2), k(3), k(4), 5));
     }
 
     private <T> BasicDataTable.Builder<T> start() {


### PR DESCRIPTION
## Summary

This PR revise error messages about type error in `GroupView.find()`.

## Background, Problem or Goal of the patch

* before

  ```
  java.lang.IllegalArgumentException: key element at "2" must be type of "class com.asakusafw.runtime.value.IntOption": class java.lang.Integer
      at com.asakusafw.dag.runtime.table.BasicDataTable.checkType(BasicDataTable.java:236)
      at com.asakusafw.dag.runtime.table.BasicDataTable.find(BasicDataTable.java:176)
      ...
  ```

* after

  ```
  java.lang.IllegalArgumentException: key element at 2 is inconsistent type: required=com.asakusafw.runtime.value.IntOption, actual=java.lang.Integer
      at com.asakusafw.dag.runtime.table.BasicDataTable.checkType(BasicDataTable.java:236)
      at com.asakusafw.dag.runtime.table.BasicDataTable.find(BasicDataTable.java:176)
      ...
  ```

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* #106 

## Wanted reviewer

@akirakw 