### PR TITLE
Add `DirectFileInputSplit.toString()`.

### DIFF
--- a/bridge-project/runtime-hadoop/src/main/java/com/asakusafw/bridge/hadoop/directio/DirectFileInputSplit.java
+++ b/bridge-project/runtime-hadoop/src/main/java/com/asakusafw/bridge/hadoop/directio/DirectFileInputSplit.java
@@ -152,4 +152,13 @@ public class DirectFileInputSplit extends InputSplit implements Configurable, Wr
     public DirectInputFragment getInputFragment() {
         return fragment;
     }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "DirectFileInputSplit(type=%s, container=%s, fragment=%s)", //$NON-NLS-1$
+                definition.getDataClass().getSimpleName(),
+                containerPath,
+                fragment);
+    }
 }


### PR DESCRIPTION
## Summary

This PR adds `toString()` method to `DirectFileInputSplit`.

## Background, Problem or Goal of the patch

Several platforms will show `DirectFileInputSplit` in their log.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

N/A.
