### PR TITLE
Resource pattern of direct output now can accept decimal format.

### DIFF
--- a/compiler-project/extension-directio/src/main/java/com/asakusafw/lang/compiler/extension/directio/OutputPattern.java
+++ b/compiler-project/extension-directio/src/main/java/com/asakusafw/lang/compiler/extension/directio/OutputPattern.java
@@ -41,6 +41,7 @@ import com.asakusafw.runtime.value.BooleanOption;
 import com.asakusafw.runtime.value.ByteOption;
 import com.asakusafw.runtime.value.DateOption;
 import com.asakusafw.runtime.value.DateTimeOption;
+import com.asakusafw.runtime.value.DecimalOption;
 import com.asakusafw.runtime.value.DoubleOption;
 import com.asakusafw.runtime.value.FloatOption;
 import com.asakusafw.runtime.value.IntOption;
@@ -51,6 +52,8 @@ import com.asakusafw.vocabulary.directio.DirectFileOutputDescription;
 
 /**
  * Processes patterns in {@link DirectFileOutputDescription}.
+ * @since 0.1.0
+ * @version 0.4.1
  */
 public final class OutputPattern {
 
@@ -73,6 +76,21 @@ public final class OutputPattern {
             map.put(Descriptions.classOf(aClass), aClass);
         }
         VALUE_TYPES = Collections.unmodifiableMap(map);
+    }
+
+    private static final Map<Class<?>, Format> FORMATS;
+    static {
+        Map<Class<?>, Format> map = new HashMap<>();
+        map.put(ByteOption.class, Format.BYTE);
+        map.put(ShortOption.class, Format.SHORT);
+        map.put(IntOption.class, Format.INT);
+        map.put(LongOption.class, Format.LONG);
+        map.put(FloatOption.class, Format.FLOAT);
+        map.put(DoubleOption.class, Format.DOUBLE);
+        map.put(DecimalOption.class, Format.DECIMAL);
+        map.put(DateOption.class, Format.DATE);
+        map.put(DateTimeOption.class, Format.DATETIME);
+        FORMATS = Collections.unmodifiableMap(map);
     }
 
     static final int CHAR_BRACE_OPEN = '{';
@@ -342,13 +360,7 @@ public final class OutputPattern {
             return Format.NATURAL;
         }
         Class<?> type = getType(property);
-        if (type == DateOption.class) {
-            return Format.DATE;
-        }
-        if (type == DateTimeOption.class) {
-            return Format.DATETIME;
-        }
-        return null;
+        return FORMATS.get(type);
     }
 
     static Class<?> getType(PropertyReference property) {

--- a/compiler-project/extension-directio/src/test/java/com/asakusafw/lang/compiler/extension/directio/OutputPatternTest.java
+++ b/compiler-project/extension-directio/src/test/java/com/asakusafw/lang/compiler/extension/directio/OutputPatternTest.java
@@ -82,6 +82,19 @@ public class OutputPatternTest {
     }
 
     /**
+     * resource pattern with numeric placeholder.
+     */
+    @Test
+    public void resource_placeholder_int() {
+        List<CompiledSegment> pattern = OutputPattern.compileResourcePattern(
+                "{intValue:#,###}", dataClass);
+        assertThat(pattern.size(), is(1));
+        assertThat(pattern.get(0).getTarget().getName(), is(PropertyName.of("intValue")));
+        assertThat(pattern.get(0).getFormat(), is(Format.INT));
+        assertThat(pattern.get(0).getArgument(), is("#,###"));
+    }
+
+    /**
      * resource pattern with date placeholder.
      */
     @Test

--- a/dag/compiler/directio/src/main/java/com/asakusafw/dag/compiler/directio/OutputPatternSerDeGenerator.java
+++ b/dag/compiler/directio/src/main/java/com/asakusafw/dag/compiler/directio/OutputPatternSerDeGenerator.java
@@ -152,6 +152,27 @@ public class OutputPatternSerDeGenerator {
                     case NATURAL:
                         getEnumConstant(v, OutputPatternSerDe.Format.NATURAL);
                         break;
+                    case BYTE:
+                        getEnumConstant(v, OutputPatternSerDe.Format.BYTE);
+                        break;
+                    case SHORT:
+                        getEnumConstant(v, OutputPatternSerDe.Format.SHORT);
+                        break;
+                    case INT:
+                        getEnumConstant(v, OutputPatternSerDe.Format.INT);
+                        break;
+                    case LONG:
+                        getEnumConstant(v, OutputPatternSerDe.Format.LONG);
+                        break;
+                    case FLOAT:
+                        getEnumConstant(v, OutputPatternSerDe.Format.FLOAT);
+                        break;
+                    case DOUBLE:
+                        getEnumConstant(v, OutputPatternSerDe.Format.DOUBLE);
+                        break;
+                    case DECIMAL:
+                        getEnumConstant(v, OutputPatternSerDe.Format.DECIMAL);
+                        break;
                     case DATE:
                         getEnumConstant(v, OutputPatternSerDe.Format.DATE);
                         break;

--- a/dag/compiler/directio/src/test/java/com/asakusafw/dag/compiler/directio/OutputPatternSerDeGeneratorTest.java
+++ b/dag/compiler/directio/src/test/java/com/asakusafw/dag/compiler/directio/OutputPatternSerDeGeneratorTest.java
@@ -101,6 +101,23 @@ public class OutputPatternSerDeGeneratorTest extends ClassGeneratorTestRoot {
     }
 
     /**
+     * use property - int.
+     * @throws Exception if failed
+     */
+    @SuppressWarnings("deprecation")
+    @Test
+    public void property_int() throws Exception {
+        serde(sd -> {
+            MockData data = new MockData();
+            data.getIntValueOption().modify(1);
+            byte[] key = dump(o -> sd.serializeKey(data, o));
+
+            Object restored = sd.deserializeKey(data(key));
+            assertThat(restored, is("p-0001"));
+        }, "p-{int_value:0000}");
+    }
+
+    /**
      * use property - date.
      * @throws Exception if failed
      */

--- a/dag/runtime/directio/src/main/java/com/asakusafw/dag/runtime/directio/OutputPatternSerDe.java
+++ b/dag/runtime/directio/src/main/java/com/asakusafw/dag/runtime/directio/OutputPatternSerDe.java
@@ -18,7 +18,10 @@ package com.asakusafw.dag.runtime.directio;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.text.DateFormat;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -30,11 +33,19 @@ import org.apache.hadoop.io.Writable;
 
 import com.asakusafw.dag.api.common.KeyValueSerDe;
 import com.asakusafw.lang.utils.common.Arguments;
+import com.asakusafw.runtime.value.ByteOption;
 import com.asakusafw.runtime.value.Date;
 import com.asakusafw.runtime.value.DateOption;
 import com.asakusafw.runtime.value.DateTime;
 import com.asakusafw.runtime.value.DateTimeOption;
 import com.asakusafw.runtime.value.DateUtil;
+import com.asakusafw.runtime.value.DecimalOption;
+import com.asakusafw.runtime.value.DoubleOption;
+import com.asakusafw.runtime.value.FloatOption;
+import com.asakusafw.runtime.value.IntOption;
+import com.asakusafw.runtime.value.LongOption;
+import com.asakusafw.runtime.value.ShortOption;
+import com.asakusafw.runtime.value.ValueOption;
 
 /**
  * Ser/De for Direct I/O file output patterns.
@@ -134,6 +145,8 @@ public abstract class OutputPatternSerDe implements KeyValueSerDe {
 
     /**
      * Format of each fragment.
+     * @since 0.4.0
+     * @version 0.4.1
      */
     public enum Format {
 
@@ -146,7 +159,119 @@ public abstract class OutputPatternSerDe implements KeyValueSerDe {
                 return new Variable() {
                     @Override
                     void update(Object propertyValue) {
-                        value = (String.valueOf(propertyValue));
+                        setValue(String.valueOf(propertyValue));
+                    }
+                };
+            }
+        },
+
+        /**
+         * Converts numeric value (use {@link DecimalFormat}).
+         * @since 0.4.1
+         */
+        BYTE {
+            @Override
+            public Fragment newFragment(String formatString) {
+                return new NumericVariable<ByteOption>(new DecimalFormat(formatString)) {
+                    @Override
+                    void doUpdate(ByteOption option) {
+                        setValue(option.get());
+                    }
+                };
+            }
+        },
+
+        /**
+         * Converts numeric value (use {@link DecimalFormat}).
+         * @since 0.4.1
+         */
+        SHORT {
+            @Override
+            public Fragment newFragment(String formatString) {
+                return new NumericVariable<ShortOption>(new DecimalFormat(formatString)) {
+                    @Override
+                    void doUpdate(ShortOption option) {
+                        setValue(option.get());
+                    }
+                };
+            }
+        },
+
+        /**
+         * Converts numeric value (use {@link DecimalFormat}).
+         * @since 0.4.1
+         */
+        INT {
+            @Override
+            public Fragment newFragment(String formatString) {
+                return new NumericVariable<IntOption>(new DecimalFormat(formatString)) {
+                    @Override
+                    void doUpdate(IntOption option) {
+                        setValue(option.get());
+                    }
+                };
+            }
+        },
+
+        /**
+         * Converts numeric value (use {@link DecimalFormat}).
+         * @since 0.4.1
+         */
+        LONG {
+            @Override
+            public Fragment newFragment(String formatString) {
+                return new NumericVariable<LongOption>(new DecimalFormat(formatString)) {
+                    @Override
+                    void doUpdate(LongOption option) {
+                        setValue(option.get());
+                    }
+                };
+            }
+        },
+
+        /**
+         * Converts numeric value (use {@link DecimalFormat}).
+         * @since 0.4.1
+         */
+        FLOAT {
+            @Override
+            public Fragment newFragment(String formatString) {
+                return new NumericVariable<FloatOption>(new DecimalFormat(formatString)) {
+                    @Override
+                    void doUpdate(FloatOption option) {
+                        setValue(option.get());
+                    }
+                };
+            }
+        },
+
+        /**
+         * Converts numeric value (use {@link DecimalFormat}).
+         * @since 0.4.1
+         */
+        DOUBLE {
+            @Override
+            public Fragment newFragment(String formatString) {
+                return new NumericVariable<DoubleOption>(new DecimalFormat(formatString)) {
+                    @Override
+                    void doUpdate(DoubleOption option) {
+                        setValue(option.get());
+                    }
+                };
+            }
+        },
+
+        /**
+         * Converts numeric value (use {@link DecimalFormat}).
+         * @since 0.4.1
+         */
+        DECIMAL {
+            @Override
+            public Fragment newFragment(String formatString) {
+                return new NumericVariable<DecimalOption>(new DecimalFormat(formatString)) {
+                    @Override
+                    void doUpdate(DecimalOption option) {
+                        setValue(option.get());
                     }
                 };
             }
@@ -158,20 +283,10 @@ public abstract class OutputPatternSerDe implements KeyValueSerDe {
         DATE {
             @Override
             public Fragment newFragment(String formatString) {
-                Arguments.requireNonNull(formatString);
-                Calendar calendar = Calendar.getInstance();
-                DateFormat dateFormat = new SimpleDateFormat(formatString);
-                return new Variable() {
+                return new DateVariable<DateOption>(new SimpleDateFormat(formatString)) {
                     @Override
-                    void update(Object propertyValue) {
-                        DateOption option = (DateOption) propertyValue;
-                        if (option.isNull()) {
-                            value = String.valueOf(option);
-                        } else {
-                            Date date = option.get();
-                            DateUtil.setDayToCalendar(date.getElapsedDays(), calendar);
-                            value = String.valueOf(dateFormat.format(calendar.getTime()));
-                        }
+                    void doUpdate(DateOption option) {
+                        setValue(option.get());
                     }
                 };
             }
@@ -183,20 +298,10 @@ public abstract class OutputPatternSerDe implements KeyValueSerDe {
         DATETIME {
             @Override
             public Fragment newFragment(String formatString) {
-                Arguments.requireNonNull(formatString);
-                Calendar calendar = Calendar.getInstance();
-                DateFormat dateFormat = new SimpleDateFormat(formatString);
-                return new Variable() {
+                return new DateVariable<DateTimeOption>(new SimpleDateFormat(formatString)) {
                     @Override
-                    void update(Object propertyValue) {
-                        DateTimeOption option = (DateTimeOption) propertyValue;
-                        if (option.isNull()) {
-                            value = String.valueOf(option);
-                        } else {
-                            DateTime date = option.get();
-                            DateUtil.setSecondToCalendar(date.getElapsedSeconds(), calendar);
-                            value = String.valueOf(dateFormat.format(calendar.getTime()));
-                        }
+                    void doUpdate(DateTimeOption option) {
+                        setValue(option.get());
                     }
                 };
             }
@@ -242,13 +347,21 @@ public abstract class OutputPatternSerDe implements KeyValueSerDe {
 
     private abstract static class Variable implements Fragment {
 
-        String value = ""; //$NON-NLS-1$
+        private String value = ""; //$NON-NLS-1$
 
         Variable() {
             return;
         }
 
         abstract void update(Object propertyValue);
+
+        final void setNull() {
+            value = "null"; //$NON-NLS-1$
+        }
+
+        final void setValue(String value) {
+            this.value = value;
+        }
 
         @Override
         public void appendTo(StringBuilder target) {
@@ -263,6 +376,68 @@ public abstract class OutputPatternSerDe implements KeyValueSerDe {
         @Override
         public void readFields(DataInput in) throws IOException {
             value = in.readUTF();
+        }
+    }
+
+    private abstract static class PropertyVariable<T extends ValueOption<T>> extends Variable {
+
+        PropertyVariable() {
+            return;
+        }
+
+        @Override
+        final void update(Object propertyValue) {
+            @SuppressWarnings("unchecked")
+            T option = (T) propertyValue;
+            if (option.isNull()) {
+                setNull();
+            } else {
+                doUpdate(option);
+            }
+        }
+
+        abstract void doUpdate(T option);
+    }
+
+    private abstract static class NumericVariable<T extends ValueOption<T>> extends PropertyVariable<T> {
+
+        private final NumberFormat format;
+
+        NumericVariable(NumberFormat format) {
+            this.format = format;
+        }
+
+        final void setValue(long v) {
+            setValue(format.format(v));
+        }
+
+        final void setValue(double v) {
+            setValue(format.format(v));
+        }
+
+        final void setValue(BigDecimal v) {
+            setValue(format.format(v));
+        }
+    }
+
+    private abstract static class DateVariable<T extends ValueOption<T>> extends PropertyVariable<T> {
+
+        private final DateFormat format;
+
+        private final Calendar calendarBuffer = Calendar.getInstance();
+
+        DateVariable(DateFormat format) {
+            this.format = format;
+        }
+
+        final void setValue(Date value) {
+            DateUtil.setDayToCalendar(value.getElapsedDays(), calendarBuffer);
+            setValue(format.format(calendarBuffer.getTime()));
+        }
+
+        final void setValue(DateTime value) {
+            DateUtil.setSecondToCalendar(value.getElapsedSeconds(), calendarBuffer);
+            setValue(format.format(calendarBuffer.getTime()));
         }
     }
 


### PR DESCRIPTION
## Summary

Resource pattern of Direct I/O file output now can accept decimal format (DecimalFormat).

## Background, Problem or Goal of the patch

This is asakusafw/asakusafw#719 implementation for Asakusa {on M3BP, Vanilla}.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw#719

## Wanted reviewer

@akirakw 