### PR TITLE
Introduce sub-directory divisions in buffer spilling.

### DIFF
--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/VanillaConfiguration.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/VanillaConfiguration.java
@@ -39,6 +39,7 @@ import com.asakusafw.vanilla.core.util.SystemProperty;
 /**
  * A configuration of Asakusa Vanilla runtime.
  * @since 0.4.0
+ * @version 0.4.1
  */
 public class VanillaConfiguration {
 
@@ -62,6 +63,13 @@ public class VanillaConfiguration {
      * ({@value}: {@link #DEFAULT_SWAP_DIRECTORY}).
      */
     public static final String KEY_SWAP_DIRECTORY = KEY_ENGINE_PREFIX + "pool.swap"; //$NON-NLS-1$
+
+    /**
+     * The configuration key of max entries in each swap sub-directory, or {@code 0} to disable it
+     * ({@value}: {@value #DEFAULT_SWAP_DIVISION}).
+     * @since 0.4.1
+     */
+    public static final String KEY_SWAP_DIVISION = KEY_ENGINE_PREFIX + "pool.division"; //$NON-NLS-1$
 
     /**
      * The configuration key of output buffer size in bytes({@value}: {@value #DEFAULT_OUTPUT_BUFFER_SIZE}).
@@ -96,6 +104,12 @@ public class VanillaConfiguration {
     public static final File DEFAULT_SWAP_DIRECTORY = SystemProperty.getTemporaryDirectory();
 
     /**
+     * The default value of {@link #KEY_SWAP_DIVISION} (disabled).
+     * @since 0.4.1
+     */
+    public static final int DEFAULT_SWAP_DIVISION = 0;
+
+    /**
      * The default value of {@link #KEY_OUTPUT_BUFFER_SIZE}.
      */
     public static final int DEFAULT_OUTPUT_BUFFER_SIZE = 4 * 1024 * 1024;
@@ -119,6 +133,8 @@ public class VanillaConfiguration {
     private OptionalLong bufferPoolSize = OptionalLong.empty();
 
     private Optional<File> swapDirectory = Optional.empty();
+
+    private OptionalInt swapDivision = OptionalInt.empty();
 
     private OptionalInt outputBufferSize = OptionalInt.empty();
 
@@ -195,6 +211,24 @@ public class VanillaConfiguration {
     }
 
     /**
+     * Returns the swap division.
+     * @return the swap division
+     * @since 0.4.1
+     */
+    public int getSwapDivision() {
+        return swapDivision.orElse(DEFAULT_SWAP_DIVISION);
+    }
+
+    /**
+     * Sets the swap division.
+     * @param newValue the swap division
+     * @since 0.4.1
+     */
+    public void setSwapDivision(int newValue) {
+        this.swapDivision = OptionalInt.of(newValue);
+    }
+
+    /**
      * Returns the individual output buffer size.
      * @return the output buffer size, in bytes
      * @see #KEY_OUTPUT_BUFFER_SIZE
@@ -268,6 +302,7 @@ public class VanillaConfiguration {
         configureInt(conf::setNumberOfPartitions, options, KEY_PARTITION_COUNT);
         configureLong(conf::setBufferPoolSize, options, KEY_BUFFER_POOL_SIZE);
         configureFile(conf::setSwapDirectory, options, KEY_SWAP_DIRECTORY);
+        configureInt(conf::setSwapDivision, options, KEY_SWAP_DIVISION);
         configureInt(conf::setOutputBufferSize, options, KEY_OUTPUT_BUFFER_SIZE);
         configureDouble(conf::setOutputBufferFlush, options, KEY_OUTPUT_BUFFER_FLUSH);
         configureInt(conf::setOutputRecordSize, options, KEY_OUTPUT_RECORD_SIZE);
@@ -288,6 +323,8 @@ public class VanillaConfiguration {
                     KEY_SWAP_DIRECTORY, Optionals.of(conf.getSwapDirectory())
                         .map(File::getAbsolutePath)
                         .orElse("N/A"))); //$NON-NLS-1$
+            LOG.debug(MessageFormat.format("{0}: {1}", //$NON-NLS-1$
+                    KEY_SWAP_DIVISION, conf.getSwapDivision()));
         }
         return conf;
     }

--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/VanillaLauncher.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/VanillaLauncher.java
@@ -282,11 +282,12 @@ public class VanillaLauncher {
         Arguments.requireNonNull(context);
         Arguments.requireNonNull(configuration);
         Arguments.requireNonNull(graph);
+        BasicBufferStore.Builder storeBuilder = BasicBufferStore.builder();
+        Optionals.of(configuration.getSwapDirectory()).ifPresent(storeBuilder::withDirectory);
+
         GraphMirror mirror = GraphMirror.of(graph);
         VertexScheduler scheduler = new BasicVertexScheduler();
-        try (BasicBufferStore store = Optionals.of(configuration.getSwapDirectory())
-                        .map(BasicBufferStore::new)
-                        .orElseGet(BasicBufferStore::new);
+        try (BasicBufferStore store = storeBuilder.build();
                 BasicEdgeDriver edges = new BasicEdgeDriver(
                         context.getClassLoader(),
                         mirror,

--- a/vanilla/runtime/client/src/test/java/com/asakusafw/vanilla/client/VanillaConfigurationTest.java
+++ b/vanilla/runtime/client/src/test/java/com/asakusafw/vanilla/client/VanillaConfigurationTest.java
@@ -42,6 +42,7 @@ public class VanillaConfigurationTest {
         assertThat(conf.getNumberOfPartitions(), is(conf.getNumberOfThreads()));
         assertThat(conf.getBufferPoolSize(), is(DEFAULT_BUFFER_POOL_SIZE));
         assertThat(conf.getSwapDirectory(), is(DEFAULT_SWAP_DIRECTORY));
+        assertThat(conf.getSwapDivision(), is(DEFAULT_SWAP_DIVISION));
         assertThat(conf.getOutputBufferSize(), is(DEFAULT_OUTPUT_BUFFER_SIZE));
         assertThat(conf.getOutputBufferFlush(), closeTo(DEFAULT_OUTPUT_BUFFER_FLUSH, 0.01));
         assertThat(conf.getOutputRecordSize(), is(DEFAULT_OUTPUT_RECORD_SIZE));
@@ -61,6 +62,7 @@ public class VanillaConfigurationTest {
         pairs.put(KEY_OUTPUT_BUFFER_SIZE, 5);
         pairs.put(KEY_OUTPUT_BUFFER_FLUSH, 6);
         pairs.put(KEY_OUTPUT_RECORD_SIZE, 7);
+        pairs.put(KEY_SWAP_DIVISION, 8);
         pairs.put(KEY_SWAP_DIRECTORY, f);
 
         VanillaConfiguration conf = VanillaConfiguration.extract(key -> Optionals.get(pairs, key)
@@ -72,6 +74,7 @@ public class VanillaConfigurationTest {
         assertThat(conf.getOutputBufferSize(), is(5));
         assertThat(conf.getOutputBufferFlush(), is(6d));
         assertThat(conf.getOutputRecordSize(), is(7));
+        assertThat(conf.getSwapDivision(), is(8));
         assertThat(conf.getSwapDirectory().getCanonicalFile(), is(f));
     }
 

--- a/vanilla/runtime/core/src/test/java/com/asakusafw/vanilla/core/io/BasicBufferStoreTest.java
+++ b/vanilla/runtime/core/src/test/java/com/asakusafw/vanilla/core/io/BasicBufferStoreTest.java
@@ -20,8 +20,12 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.Test;
+
+import com.asakusafw.lang.utils.common.Optionals;
 
 /**
  * Test for {@link BasicBufferStore}.
@@ -61,6 +65,37 @@ public class BasicBufferStoreTest {
                 assertThat(read(c1), is("Hello1"));
                 assertThat(read(c2), is("Hello2"));
             }
+        }
+        assertThat(directory.exists(), is(false));
+    }
+
+    /**
+     * w/ division.
+     * @throws Exception if failed
+     */
+    @Test
+    public void division() throws Exception {
+        File directory;
+        try (BasicBufferStore store = new BasicBufferStore(null, 2)) {
+            directory = store.getDirectory();
+            try (DataReader.Provider c0 = store.store(buffer("Hello0"));
+                    DataReader.Provider c1 = store.store(buffer("Hello1"));
+                    DataReader.Provider c2 = store.store(buffer("Hello2"));
+                    DataReader.Provider c3 = store.store(buffer("Hello3"));
+                    DataReader.Provider c4 = store.store(buffer("Hello4"))) {
+                assertThat(read(c0), is("Hello0"));
+                assertThat(read(c1), is("Hello1"));
+                assertThat(read(c2), is("Hello2"));
+                assertThat(read(c3), is("Hello3"));
+                assertThat(read(c4), is("Hello4"));
+            }
+            long count = Optionals.of(directory.listFiles())
+                .map(Arrays::asList)
+                .orElse(Collections.emptyList())
+                .stream()
+                .peek(f -> assertThat(f.isDirectory(), is(true)))
+                .count();
+            assertThat(count, is(3L));
         }
         assertThat(directory.exists(), is(false));
     }


### PR DESCRIPTION
## Summary

This PR enables Asakusa Vanilla to divide buffer swap files into individual sub-directories.

## Background, Problem or Goal of the patch

The latest implementation, the engine only can put swap files into a single swap directory. It may slow down operations if there are too many files.

## Design of the fix, or a new feature

This introduces a new engine configuration item (undocumented).

* `com.asakusafw.vanilla.pool.division`
  * max swap files in each swap sub-directory, or 0 to disable the feature
  * default: `0` (disabled)

## Related Issue, Pull Request or Code

N/A.