### PR TITLE
DSL compiler for vanilla now generates jobflow launcher.

### DIFF
--- a/bridge-project/runtime/src/main/java/com/asakusafw/bridge/launch/BatchArgumentsOption.java
+++ b/bridge-project/runtime/src/main/java/com/asakusafw/bridge/launch/BatchArgumentsOption.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.bridge.launch;
+
+import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.asakusafw.bridge.stage.StageInfo;
+
+/**
+ * A {@link LaunchOption} which handles (extra) batch arguments.
+ * @since 0.4.1
+ */
+public class BatchArgumentsOption implements LaunchOption<Map<String, String>> {
+
+    private final Set<String> commandNames;
+
+    private final Map<String, String> arguments = new LinkedHashMap<>();
+
+    /**
+     * Creates a new instance.
+     * @param commandNames the command names
+     */
+    public BatchArgumentsOption(String... commandNames) {
+        this(Arrays.asList(commandNames));
+    }
+
+    /**
+     * Creates a new instance.
+     * @param commandNames the command names
+     */
+    public BatchArgumentsOption(Collection<String> commandNames) {
+        this.commandNames = Collections.unmodifiableSet(new LinkedHashSet<>(commandNames));
+    }
+
+    @Override
+    public Set<String> getCommands() {
+        return commandNames;
+    }
+
+    @Override
+    public void accept(String command, String value) throws LaunchConfigurationException {
+        int delimiter = value.indexOf('=');
+        String argKey;
+        String argValue;
+        if (delimiter < 0) {
+            argKey = value;
+            argValue = "true";
+        } else {
+            argKey = value.substring(0, delimiter);
+            argValue = value.substring(delimiter + 1);
+        }
+        if (arguments.putIfAbsent(argKey, argValue) != null) {
+            throw new LaunchConfigurationException(MessageFormat.format(
+                    "duplicate batch argument: {0} {1}",
+                    command,
+                    argKey));
+        }
+        arguments.put(argKey, argValue);
+    }
+
+    @Override
+    public Map<String, String> resolve() throws LaunchConfigurationException {
+        return Collections.unmodifiableMap(new LinkedHashMap<>(arguments));
+    }
+
+    /**
+     * Merges the arguments into {@link StageInfo}.
+     * @param info the target {@link StageInfo}
+     * @return the merged {@link StageInfo}
+     */
+    public StageInfo mergeTo(StageInfo info) {
+        if (arguments.isEmpty()) {
+            return info;
+        }
+        Map<String, String> merged = new LinkedHashMap<>(info.getBatchArguments());
+        merged.putAll(arguments);
+        return new StageInfo(
+                info.getUserName(),
+                info.getBatchId(), info.getFlowId(), info.getStageId(), info.getExecutionId(),
+                merged);
+    }
+}

--- a/bridge-project/runtime/src/main/java/com/asakusafw/bridge/launch/LaunchConfiguration.java
+++ b/bridge-project/runtime/src/main/java/com/asakusafw/bridge/launch/LaunchConfiguration.java
@@ -34,7 +34,7 @@ import com.asakusafw.bridge.stage.StageInfo;
 /**
  * Provides launching configuration.
  */
-public class LaunchConfiguration {
+public class LaunchConfiguration implements LaunchInfo {
 
     static final Logger LOG = LoggerFactory.getLogger(LaunchConfiguration.class);
 
@@ -156,34 +156,22 @@ public class LaunchConfiguration {
         return commands;
     }
 
-    /**
-     * Returns the stage client class.
-     * @return the stage client class
-     */
+    @Override
     public Class<?> getStageClient() {
         return stageClient;
     }
 
-    /**
-     * Returns the stage information.
-     * @return the stage information
-     */
+    @Override
     public StageInfo getStageInfo() {
         return stageInfo;
     }
 
-    /**
-     * Returns the properties for Hadoop platform.
-     * @return the Hadoop properties
-     */
+    @Override
     public Map<String, String> getHadoopProperties() {
         return hadoopProperties;
     }
 
-    /**
-     * Returns the properties for stage engine.
-     * @return the properties for stage engine
-     */
+    @Override
     public Map<String, String> getEngineProperties() {
         return engineProperties;
     }

--- a/bridge-project/runtime/src/main/java/com/asakusafw/bridge/launch/LaunchInfo.java
+++ b/bridge-project/runtime/src/main/java/com/asakusafw/bridge/launch/LaunchInfo.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.bridge.launch;
+
+import java.util.Map;
+
+import com.asakusafw.bridge.stage.StageInfo;
+
+/**
+ * Information of launching application.
+ * @since 0.4.1
+ */
+public interface LaunchInfo {
+
+    /**
+     * Returns the stage client class.
+     * @return the stage client class
+     */
+    Class<?> getStageClient();
+
+    /**
+     * Returns the stage information.
+     * @return the stage information
+     */
+    StageInfo getStageInfo();
+
+    /**
+     * Returns the properties for Hadoop platform.
+     * @return the Hadoop properties
+     */
+    Map<String, String> getHadoopProperties();
+
+    /**
+     * Returns the properties for stage engine.
+     * @return the properties for stage engine
+     */
+    Map<String, String> getEngineProperties();
+}

--- a/dag/runtime/iterative/.gitignore
+++ b/dag/runtime/iterative/.gitignore
@@ -1,0 +1,5 @@
+/target
+/.project
+/.classpath
+/.settings
+/bin

--- a/dag/runtime/iterative/pom.xml
+++ b/dag/runtime/iterative/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <name>CLI of Asakusa Vanilla</name>
-  <artifactId>asakusa-vanilla-client</artifactId>
+  <name>Asakusa DAG Iterative Extensions</name>
+  <artifactId>asakusa-dag-iterative</artifactId>
   <parent>
     <artifactId>project</artifactId>
-    <groupId>com.asakusafw.vanilla.runtime</groupId>
+    <groupId>com.asakusafw.dag.runtime</groupId>
     <version>0.4.1-SNAPSHOT</version>
   </parent>
 
@@ -13,26 +13,27 @@
 
   <dependencies>
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>asakusa-vanilla-core</artifactId>
+      <groupId>com.asakusafw.lang.utils</groupId>
+      <artifactId>asakusa-lang-common</artifactId>
       <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.asakusafw.dag.runtime</groupId>
-      <artifactId>asakusa-dag-iterative</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.asakusafw</groupId>
-      <artifactId>asakusa-runtime</artifactId>
     </dependency>
     <dependency>
       <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-iterative-common</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-common</artifactId>
+      <groupId>com.asakusafw.iterative</groupId>
+      <artifactId>asakusa-iterative-launch</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.asakusafw.bridge</groupId>
+      <artifactId>asakusa-bridge-runtime</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/dag/runtime/iterative/src/main/java/com/asakusafw/dag/iterative/DirectLaunchConfiguration.java
+++ b/dag/runtime/iterative/src/main/java/com/asakusafw/dag/iterative/DirectLaunchConfiguration.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dag.iterative;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+
+import com.asakusafw.bridge.launch.BatchArgumentsOption;
+import com.asakusafw.bridge.launch.LaunchConfiguration;
+import com.asakusafw.bridge.launch.LaunchConfigurationException;
+import com.asakusafw.bridge.launch.LaunchInfo;
+import com.asakusafw.bridge.launch.LaunchOption;
+import com.asakusafw.bridge.stage.StageInfo;
+import com.asakusafw.iterative.common.BaseCursor;
+import com.asakusafw.iterative.common.IterativeExtensions;
+import com.asakusafw.iterative.common.ParameterTable;
+import com.asakusafw.iterative.launch.IterativeStageInfo;
+
+/**
+ * Provides launching configuration for iterative batches.
+ * @since 0.4.1
+ */
+public final class DirectLaunchConfiguration {
+
+    private final LaunchConfiguration origin;
+
+    private final ParameterTable parameterTable;
+
+    private DirectLaunchConfiguration(LaunchConfiguration origin, ParameterTable parameterTable) {
+        this.origin = origin;
+        this.parameterTable = parameterTable != null ? parameterTable : IterativeExtensions.builder().build();
+    }
+
+    /**
+     * Analyzes launch arguments and returns {@link DirectLaunchConfiguration} from them.
+     * @param classLoader the current class loader
+     * @param arguments the launch arguments
+     * @return the analyzed configuration
+     * @throws LaunchConfigurationException if arguments are wrong
+     */
+    public static DirectLaunchConfiguration parse(
+            ClassLoader classLoader,
+            String... arguments) throws LaunchConfigurationException {
+        return parse(classLoader, Arrays.asList(arguments));
+    }
+
+    /**
+     * Analyzes launch arguments and returns {@link DirectLaunchConfiguration} from them.
+     * @param classLoader the current class loader
+     * @param arguments the launch arguments
+     * @param extraOptions the extra launch options
+     * @return the analyzed configuration
+     * @throws LaunchConfigurationException if arguments are wrong
+     */
+    public static DirectLaunchConfiguration parse(
+            ClassLoader classLoader,
+            List<String> arguments,
+            LaunchOption<?>... extraOptions) throws LaunchConfigurationException {
+        BatchArgumentsOption batchArguments = new BatchArgumentsOption("-A", "--argument");
+        LaunchOption<ParameterTable> parameterTable = new DirectParameterTableOption("-AA", "--parameter-table");
+        List<LaunchOption<?>> options = new ArrayList<>();
+        Collections.addAll(options, batchArguments);
+        Collections.addAll(options, parameterTable);
+        Collections.addAll(options, extraOptions);
+        LaunchOption<?>[] optionArray = options.toArray(new LaunchOption<?>[options.size()]);
+        LaunchConfiguration origin = LaunchConfiguration.parse(classLoader, arguments, optionArray);
+        return new DirectLaunchConfiguration(
+                new LaunchConfiguration(
+                        origin.getStageClient(),
+                        batchArguments.mergeTo(origin.getStageInfo()),
+                        origin.getHadoopProperties(),
+                        origin.getEngineProperties()),
+                parameterTable.resolve());
+    }
+
+    /**
+     * Returns a new cursor of {@link LaunchInfo}.
+     * @return the created cursor
+     */
+    public Cursor newCursor() {
+        return new Cursor(origin, getStageInfo());
+    }
+
+
+    /**
+     * Returns the stage information.
+     * @return the stage information
+     */
+    public IterativeStageInfo getStageInfo() {
+        EnumSet<IterativeStageInfo.Option> options = EnumSet.noneOf(IterativeStageInfo.Option.class);
+        if (parameterTable.getRowCount() >= 2) {
+            options.add(IterativeStageInfo.Option.QUALIFY_EXECUTION_ID);
+        }
+        return new IterativeStageInfo(origin.getStageInfo(), parameterTable, options);
+    }
+
+    /**
+     * A {@link LaunchInfo} cursor of {@link DirectLaunchConfiguration}.
+     * @since 0.4.1
+     */
+    public static class Cursor implements BaseCursor<LaunchInfo> {
+
+        private final LaunchConfiguration origin;
+
+        private final IterativeStageInfo.Cursor cursor;
+
+        Cursor(LaunchConfiguration origin, com.asakusafw.iterative.launch.IterativeStageInfo stages) {
+            this.origin = origin;
+            this.cursor = stages.newCursor();
+        }
+
+        @Override
+        public boolean next() {
+            return cursor.next();
+        }
+
+        @Override
+        public LaunchInfo get() {
+            return new Info(origin, cursor.get());
+        }
+    }
+
+    private static final class Info implements LaunchInfo {
+
+        private final LaunchConfiguration origin;
+
+        private final StageInfo stage;
+
+        Info(LaunchConfiguration origin, StageInfo stage) {
+            this.origin = origin;
+            this.stage = stage;
+        }
+
+        @Override
+        public StageInfo getStageInfo() {
+            return stage;
+        }
+
+        @Override
+        public Class<?> getStageClient() {
+            return origin.getStageClient();
+        }
+
+        @Override
+        public Map<String, String> getHadoopProperties() {
+            return origin.getHadoopProperties();
+        }
+
+        @Override
+        public Map<String, String> getEngineProperties() {
+            return origin.getEngineProperties();
+        }
+    }
+}

--- a/dag/runtime/iterative/src/main/java/com/asakusafw/dag/iterative/DirectParameterTableOption.java
+++ b/dag/runtime/iterative/src/main/java/com/asakusafw/dag/iterative/DirectParameterTableOption.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dag.iterative;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.MessageFormat;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.bridge.launch.AbstractFileOption;
+import com.asakusafw.bridge.launch.LaunchConfigurationException;
+import com.asakusafw.iterative.common.IterativeExtensions;
+import com.asakusafw.iterative.common.ParameterTable;
+import com.asakusafw.lang.utils.common.Arguments;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+
+/**
+ * Parses JSON style {@link ParameterTable}.
+ * @since 0.4.1
+ */
+public class DirectParameterTableOption extends AbstractFileOption<ParameterTable> {
+
+    static final Logger LOG = LoggerFactory.getLogger(DirectParameterTableOption.class);
+
+    private final Set<String> commandNames;
+
+    private ParameterTable result;
+
+    /**
+     * Creates a new instance.
+     * @param commandNames the command names
+     */
+    public DirectParameterTableOption(String... commandNames) {
+        this.commandNames = Arguments.freezeToSet(commandNames);
+    }
+
+    @Override
+    public Set<String> getCommands() {
+        return commandNames;
+    }
+
+    @Override
+    protected void accept(String command, File value) throws LaunchConfigurationException {
+        if (result != null) {
+            throw new LaunchConfigurationException(MessageFormat.format(
+                    "duplicate launch option: {0}",
+                    command));
+        }
+        LOG.debug("extracting parameter table: {}", value); //$NON-NLS-1$
+        try {
+            result = parse(value);
+        } catch (IOException e) {
+            throw new LaunchConfigurationException(MessageFormat.format(
+                    "error occurred while extracting parameter table ({0}): {1}",
+                    command, value), e);
+        }
+    }
+
+    @Override
+    public ParameterTable resolve() throws LaunchConfigurationException {
+        return result;
+    }
+
+    /**
+     * Parses the given JSON file and generates {@link ParameterTable}.
+     * @param file the target JSON file
+     * @return the parsed {@link ParameterTable}
+     * @throws IOException if I/O error was occurred while parsing the given file
+     */
+    public static ParameterTable parse(File file) throws IOException {
+        LOG.debug("parsing JSON parameter table: {}", file); //$NON-NLS-1$
+        JsonFactory json = new JsonFactory();
+        json.disable(JsonParser.Feature.AUTO_CLOSE_SOURCE);
+        json.enable(JsonParser.Feature.ALLOW_COMMENTS);
+        json.enable(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES);
+        json.enable(JsonParser.Feature.ALLOW_SINGLE_QUOTES);
+        json.enable(JsonParser.Feature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER);
+        json.enable(JsonParser.Feature.ALLOW_NUMERIC_LEADING_ZEROS);
+        try (JsonParser parser = json.createParser(file)) {
+            ParameterTable.Builder builder = IterativeExtensions.builder();
+            while (true) {
+                JsonToken t = parser.nextToken();
+                if (t == null) {
+                    break;
+                } else if (t == JsonToken.START_OBJECT) {
+                    builder.next();
+                    parseRow(parser, builder);
+                } else {
+                    throw new IOException(MessageFormat.format(
+                            "invalid JSON format (invalid start object): {0}",
+                            parser.getCurrentLocation()));
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    private static void parseRow(JsonParser parser, ParameterTable.Builder builder) throws IOException {
+        while (true) {
+            JsonToken t0 = parser.nextToken();
+            if (t0 == JsonToken.END_OBJECT) {
+                return;
+            } else if (t0 != JsonToken.FIELD_NAME) {
+                throw new IOException(MessageFormat.format(
+                        "invalid JSON format (invalid field name): {0}",
+                        parser.getCurrentLocation()));
+            }
+            String name = parser.getCurrentName();
+
+            JsonToken t1 = parser.nextToken();
+            if (t1 == null) {
+                throw new IOException(MessageFormat.format(
+                        "invalid JSON format (unexpected EOF): {0}",
+                        parser.getCurrentLocation()));
+            }
+            switch (t1) {
+            case VALUE_STRING:
+            case VALUE_NUMBER_FLOAT:
+            case VALUE_NUMBER_INT:
+            case VALUE_TRUE:
+            case VALUE_FALSE:
+                // ok
+                break;
+            default:
+                throw new IOException(MessageFormat.format(
+                        "invalid JSON format (unsupported value): {0}",
+                        parser.getCurrentLocation()));
+            }
+            String value = parser.getValueAsString();
+
+            builder.put(name, value);
+        }
+    }
+}

--- a/dag/runtime/iterative/src/main/java/com/asakusafw/dag/iterative/package-info.java
+++ b/dag/runtime/iterative/src/main/java/com/asakusafw/dag/iterative/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Iterative exteisons for Asakusa DAG.
+ */
+package com.asakusafw.dag.iterative;

--- a/dag/runtime/pom.xml
+++ b/dag/runtime/pom.xml
@@ -21,6 +21,7 @@
     <module>internalio</module>
     <module>directio</module>
     <module>jdbc</module>
+    <module>iterative</module>
 
     <!-- extensions -->
     <module>extension/counter</module>

--- a/vanilla/compiler/core/src/main/java/com/asakusafw/vanilla/compiler/core/VanillaDirectBatchProcessor.java
+++ b/vanilla/compiler/core/src/main/java/com/asakusafw/vanilla/compiler/core/VanillaDirectBatchProcessor.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.compiler.core;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Scanner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.lang.compiler.api.BatchProcessor;
+import com.asakusafw.lang.compiler.api.reference.BatchReference;
+import com.asakusafw.lang.compiler.api.reference.CommandTaskReference;
+import com.asakusafw.lang.compiler.api.reference.JobflowReference;
+import com.asakusafw.lang.compiler.api.reference.TaskReference;
+import com.asakusafw.lang.compiler.common.Location;
+import com.asakusafw.lang.utils.common.Arguments;
+import com.asakusafw.lang.utils.common.Optionals;
+import com.asakusafw.vanilla.compiler.common.VanillaTask;
+
+/**
+ * Generates launch scripts of direct Vanilla jobflows.
+ * @since 0.4.1
+ */
+public class VanillaDirectBatchProcessor implements BatchProcessor {
+
+    static final Logger LOG = LoggerFactory.getLogger(VanillaDirectBatchProcessor.class);
+
+    private static final int ARG_APPLICATION_INDEX = 4;
+
+    private static final String SCRIPT_TEMPLATE_FILE = "direct.sh.template";
+
+    private static final String[] SCRIPT_TEMPLATE;
+    static {
+        try (Scanner scanner = new Scanner(
+                VanillaDirectBatchProcessor.class.getResourceAsStream(SCRIPT_TEMPLATE_FILE),
+                StandardCharsets.US_ASCII.name())) {
+            List<String> lines = new ArrayList<>();
+            while (scanner.hasNextLine()) {
+                lines.add(scanner.nextLine());
+            }
+            SCRIPT_TEMPLATE = lines.toArray(new String[lines.size()]);
+        }
+    }
+
+    private static final Pattern SCRIPT_PLACEHOLDER = Pattern.compile("\\{{3}(\\w+)\\}{3}"); //$NON-NLS-1$
+
+    /**
+     * Returns the generating script location.
+     * @param flowId the flow ID
+     * @return the script location
+     */
+    public static Location getScriptLocation(String flowId) {
+        Arguments.requireNonNull(flowId);
+        return Location.of(String.format("bin/%s.sh", flowId)); //$NON-NLS-1$
+
+    }
+
+    @Override
+    public void process(Context context, BatchReference source) throws IOException {
+        for (JobflowReference jobflow : source.getJobflows()) {
+            CommandTaskReference command = find(jobflow)
+                    .filter(task -> task.getCommand().equals(VanillaTask.PATH_COMMAND))
+                    .filter(task -> task.getArguments().size() > ARG_APPLICATION_INDEX)
+                    .orElse(null);
+            if (command == null) {
+                LOG.debug("{}:{} does not support Vanilla direct launching", source.getBatchId(), jobflow.getFlowId()); //$NON-NLS-1$
+                continue;
+            }
+            Map<String, String> variables = new LinkedHashMap<>();
+            variables.put("BATCH_ID", escape(source.getBatchId()));
+            variables.put("FLOW_ID", escape(jobflow.getFlowId()));
+            variables.put("APPLICATION", escape(command.getArguments().get(ARG_APPLICATION_INDEX).getImage()));
+            Location location = getScriptLocation(jobflow.getFlowId());
+            LOG.debug("generating direct vanilla script: {} ({})", location, variables);
+            try (Writer writer = new PrintWriter(
+                    new OutputStreamWriter(context.addResourceFile(location), StandardCharsets.UTF_8))) {
+                write(writer, variables);
+            }
+        }
+    }
+
+    private static Optional<CommandTaskReference> find(JobflowReference jobflow) {
+        List<TaskReference> tasks = Arrays.stream(TaskReference.Phase.values())
+                .flatMap(phase -> jobflow.getTasks(phase).stream())
+                .collect(Collectors.toList());
+        if (tasks.size() != 1) {
+            return Optional.empty();
+        }
+        return Optionals.of(tasks.get(0))
+                .filter(task -> task instanceof CommandTaskReference)
+                .map(CommandTaskReference.class::cast);
+    }
+
+    private static void write(Appendable writer, Map<String, String> variables) throws IOException {
+        for (String line : SCRIPT_TEMPLATE) {
+            Matcher matcher = SCRIPT_PLACEHOLDER.matcher(line);
+            int start = 0;
+            while (matcher.find(start)) {
+                writer.append(line, start, matcher.start());
+                String name = matcher.group(1);
+                String value = variables.get(name);
+                if (value == null) {
+                    throw new IllegalStateException(MessageFormat.format(
+                            "[Internal Error] unknown placeholder: {0}",
+                            name));
+                }
+                writer.append(value);
+                start = matcher.end();
+            }
+            writer.append(line, start, line.length());
+            writer.append('\n'); // LF-only
+        }
+    }
+
+    private static String escape(String value) {
+        if (value.indexOf('\'') >= 0) {
+            throw new IllegalStateException(value);
+        }
+        return String.format("'%s'", value); //$NON-NLS-1$
+    }
+}

--- a/vanilla/compiler/core/src/main/resources/META-INF/services/com.asakusafw.lang.compiler.api.BatchProcessor
+++ b/vanilla/compiler/core/src/main/resources/META-INF/services/com.asakusafw.lang.compiler.api.BatchProcessor
@@ -1,0 +1,1 @@
+com.asakusafw.vanilla.compiler.core.VanillaDirectBatchProcessor

--- a/vanilla/compiler/core/src/main/resources/com/asakusafw/vanilla/compiler/core/direct.sh.template
+++ b/vanilla/compiler/core/src/main/resources/com/asakusafw/vanilla/compiler/core/direct.sh.template
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Copyright 2011-2017 Asakusa Framework Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [ "$ASAKUSA_HOME" = "" ]
+then
+    echo '$ASAKUSA_HOME is not defined' 1>&2
+    exit 1
+fi
+
+_SCRIPT="$ASAKUSA_HOME/vanilla/bin/execute.sh"
+
+if [ ! -e "$_SCRIPT" ]
+then
+    echo "launcher script is not found: $_SCRIPT"
+fi
+
+_BATCH_ID={{{BATCH_ID}}}
+_FLOW_ID={{{FLOW_ID}}}
+_EXECUTION_ID="$(echo -n $(od -An -t x4 -N4 /dev/random))"
+_BATCH_ARGUMENTS="-"
+_APPLICATION={{{APPLICATION}}}
+
+exec "$_SCRIPT" "$_BATCH_ID" "$_FLOW_ID" "$_EXECUTION_ID" "$_BATCH_ARGUMENTS" "$_APPLICATION" "$@"

--- a/vanilla/runtime/assembly/pom.xml
+++ b/vanilla/runtime/assembly/pom.xml
@@ -44,6 +44,12 @@
                   <exclude>org.slf4j:*</exclude>
                 </excludes>
               </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>com.fasterxml.jackson</pattern>
+                  <shadedPattern>com.asakusafw.vanilla.shaded.com.fasterxml.jackson</shadedPattern>
+                </relocation>
+              </relocations>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
               </transformers>
@@ -90,6 +96,11 @@
     <dependency>
       <groupId>com.asakusafw</groupId>
       <artifactId>simple-graph</artifactId>
+      <scope>runtime</scope> <!-- default: provided -->
+    </dependency>
+    <dependency>
+      <groupId>com.asakusafw</groupId>
+      <artifactId>asakusa-iterative-common</artifactId>
       <scope>runtime</scope> <!-- default: provided -->
     </dependency>
   </dependencies>

--- a/vanilla/runtime/assembly/src/main/dist/vanilla/bin/execute.sh
+++ b/vanilla/runtime/assembly/src/main/dist/vanilla/bin/execute.sh
@@ -34,6 +34,7 @@ Parameters:
         The arguments for this execution
         This must be form of "key1=value1,key2=value2,...",
         and the special characters '=', ',', '\' can be escaped by '\'.
+        Or '-' to launch as direct mode.
     class-name
         Fully qualified class name of program entry
     direct-arguments...
@@ -73,7 +74,14 @@ _OPT_FLOW_ID="$1"
 shift
 _OPT_EXECUTION_ID="$1"
 shift
-_OPT_BATCH_ARGUMENTS="$1"
+if [ "$1" = "-" ]
+then
+    _JAVA_MAIN=com.asakusafw.vanilla.client.VanillaDirect
+    _OPT_BATCH_ARGUMENTS=""
+else
+    _JAVA_MAIN=com.asakusafw.vanilla.client.VanillaLauncher
+    _OPT_BATCH_ARGUMENTS="$1"
+fi
 shift
 _OPT_APPLICATION="$1"
 shift
@@ -135,7 +143,7 @@ then
     export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS $ASAKUSA_VANILLA_OPTS"
     export HADOOP_CLASSPATH="$HADOOP_CLASSPATH:$(IFS=:; echo "${_CLASSPATH[*]}")"
     "${_EXEC[@]}" \
-        "com.asakusafw.vanilla.client.VanillaLauncher" \
+        "$_JAVA_MAIN" \
         --client "$_OPT_APPLICATION" \
         --batch-id "$_OPT_BATCH_ID" \
         --flow-id "$_OPT_FLOW_ID" \
@@ -147,7 +155,7 @@ else
     "${_EXEC[@]}" \
         $ASAKUSA_VANILLA_OPTS \
         -classpath "$(IFS=:; echo "${_CLASSPATH[*]}")" \
-        "com.asakusafw.vanilla.client.VanillaLauncher" \
+        "$_JAVA_MAIN" \
         --client "$_OPT_APPLICATION" \
         --batch-id "$_OPT_BATCH_ID" \
         --flow-id "$_OPT_FLOW_ID" \

--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/VanillaDirect.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/VanillaDirect.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.client;
+
+import java.util.Arrays;
+
+import org.apache.hadoop.conf.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.bridge.launch.LaunchConfigurationException;
+import com.asakusafw.dag.iterative.DirectLaunchConfiguration;
+import com.asakusafw.runtime.core.context.RuntimeContext;
+
+/**
+ * Direct program entry of Asakusa Vanilla.
+ * @since 0.4.1
+ * @see VanillaLauncher
+ */
+public final class VanillaDirect {
+
+    static final Logger LOG = LoggerFactory.getLogger(VanillaDirect.class);
+
+    private VanillaDirect() {
+        return;
+    }
+
+    /**
+     * Program entry.
+     * @param args launching configurations
+     * @throws LaunchConfigurationException if launching configuration is something wrong
+     */
+    public static void main(String... args) throws LaunchConfigurationException {
+        ClassLoader loader = VanillaDirect.class.getClassLoader();
+        RuntimeContext.set(RuntimeContext.DEFAULT.apply(System.getenv()));
+        RuntimeContext.get().verifyApplication(loader);
+
+        int status = exec(loader, args);
+        if (status != 0) {
+            System.exit(status);
+        }
+    }
+
+    /**
+     * Program entry.
+     * @param loader the launch class loader
+     * @param args launching configurations
+     * @return the exit code
+     * @throws LaunchConfigurationException if launching configuration is something wrong
+     * @see VanillaLauncher#EXEC_SUCCESS
+     * @see VanillaLauncher#EXEC_ERROR
+     * @see VanillaLauncher#EXEC_INTERRUPTED
+     */
+    public static int exec(ClassLoader loader, String... args) throws LaunchConfigurationException {
+        DirectLaunchConfiguration conf = DirectLaunchConfiguration.parse(loader, Arrays.asList(args));
+        Configuration hadoop = new Configuration();
+        hadoop.setClassLoader(loader);
+        int numberOfRounds = conf.getStageInfo().getRoundCount();
+        int currentRound = 0;
+        DirectLaunchConfiguration.Cursor cursor = conf.newCursor();
+        while (cursor.next()) {
+            LOG.info("Round: {}/{}", ++currentRound, numberOfRounds);
+            int result = new VanillaLauncher(cursor.get(), hadoop).exec();
+            if (result != VanillaLauncher.EXEC_SUCCESS) {
+                return result;
+            }
+        }
+        return VanillaLauncher.EXEC_SUCCESS;
+    }
+}

--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/VanillaLauncher.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/VanillaLauncher.java
@@ -32,6 +32,7 @@ import com.asakusafw.bridge.broker.ResourceBroker;
 import com.asakusafw.bridge.broker.ResourceSession;
 import com.asakusafw.bridge.launch.LaunchConfiguration;
 import com.asakusafw.bridge.launch.LaunchConfigurationException;
+import com.asakusafw.bridge.launch.LaunchInfo;
 import com.asakusafw.bridge.stage.StageInfo;
 import com.asakusafw.dag.api.model.GraphInfo;
 import com.asakusafw.dag.api.processor.ProcessorContext;
@@ -79,7 +80,7 @@ public class VanillaLauncher {
      */
     public static final int EXEC_INTERRUPTED = 2;
 
-    private final LaunchConfiguration configuration;
+    private final LaunchInfo configuration;
 
     private final ClassLoader applicationLoader;
 
@@ -89,7 +90,7 @@ public class VanillaLauncher {
      * Creates a new instance.
      * @param configuration the launching configuration
      */
-    public VanillaLauncher(LaunchConfiguration configuration) {
+    public VanillaLauncher(LaunchInfo configuration) {
         this(Arguments.requireNonNull(configuration), configuration.getStageClient().getClassLoader());
     }
 
@@ -98,15 +99,16 @@ public class VanillaLauncher {
      * @param configuration the launching configuration
      * @param classLoader the application class loader
      */
-    public VanillaLauncher(LaunchConfiguration configuration, ClassLoader classLoader) {
+    public VanillaLauncher(LaunchInfo configuration, ClassLoader classLoader) {
         Arguments.requireNonNull(configuration);
         Arguments.requireNonNull(classLoader);
         this.configuration = configuration;
         this.applicationLoader = classLoader;
         this.hadoop = new Configuration();
+        this.hadoop.setClassLoader(classLoader);
     }
 
-    private VanillaLauncher(LaunchConfiguration configuration, Configuration hadoop) {
+    VanillaLauncher(LaunchInfo configuration, Configuration hadoop) {
         Arguments.requireNonNull(configuration);
         Arguments.requireNonNull(hadoop);
         this.configuration = configuration;


### PR DESCRIPTION
## Summary

This PR enables DSL compiler for Asakusa Vanilla to generate launcher script for individual jobflows.

## Background, Problem or Goal of the patch

N/A.

## Design of the fix, or a new feature

The launcher scripts will be located on `$ASAKUSA_HOME/batchapps/<batch-id>/bin/<flow-id>.sh`, and they accept batch arguments as "-A name=value" or "-AA /path/to/json".

This feature only generates script for jobflow which consists of only one task, that is, such jobflows only can have Direct I/O or WindGate JDBC direct for its external I/Os.

## Related Issue, Pull Request or Code

N/A.