### PR TITLE
Fix operator adapter class cache conflict.

### DIFF
--- a/dag/compiler/builtin/src/main/java/com/asakusafw/dag/compiler/builtin/ProjectOperatorGenerator.java
+++ b/dag/compiler/builtin/src/main/java/com/asakusafw/dag/compiler/builtin/ProjectOperatorGenerator.java
@@ -41,6 +41,7 @@ import com.asakusafw.lang.compiler.model.graph.CoreOperator;
 import com.asakusafw.lang.compiler.model.graph.CoreOperator.CoreOperatorKind;
 import com.asakusafw.lang.compiler.model.graph.OperatorInput;
 import com.asakusafw.lang.compiler.model.graph.OperatorOutput;
+import com.asakusafw.lang.compiler.model.graph.OperatorProperty;
 import com.asakusafw.runtime.core.Result;
 import com.asakusafw.vocabulary.operator.Project;
 
@@ -84,8 +85,8 @@ public class ProjectOperatorGenerator extends CoreOperatorNodeGenerator {
         ClassWriter writer = newWriter(target, Object.class, Result.class);
         FieldRef bufferField = defineField(writer, target, "buffer", typeOf(outputType));
 
-        List<VertexElement> dependencies = getDependencies(context, operator);
-        Map<VertexElement, FieldRef> deps = defineDependenciesConstructor(target, writer, dependencies, method -> {
+        Map<OperatorProperty, FieldRef> deps = defineDependenciesConstructor(
+                context, operator.getOutputs(), target, writer, method -> {
             method.visitVarInsn(Opcodes.ALOAD, 0);
             getNew(method, outputType.getDeclaration());
             putField(method, bufferField);
@@ -104,7 +105,7 @@ public class ProjectOperatorGenerator extends CoreOperatorNodeGenerator {
             mapping(method, loader, mappings, inputs, outputs);
 
             method.visitVarInsn(Opcodes.ALOAD, 0);
-            getField(method, deps.get(dependencies.get(0)));
+            getField(method, deps.get(operator.getOutput(Project.ID_OUTPUT)));
             method.visitVarInsn(Opcodes.ALOAD, 2);
             invokeResultAdd(method);
         });

--- a/dag/compiler/builtin/src/main/java/com/asakusafw/dag/compiler/builtin/SummarizeOperatorGenerator.java
+++ b/dag/compiler/builtin/src/main/java/com/asakusafw/dag/compiler/builtin/SummarizeOperatorGenerator.java
@@ -155,9 +155,7 @@ public class SummarizeOperatorGenerator extends UserOperatorNodeGenerator {
                 Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC);
 
         OperatorOutput output = operator.getOutput(Summarize.ID_OUTPUT);
-        List<VertexElement> dependencies = getDependencies(context, operator);
-        Invariants.require(dependencies.size() == 1);
-        defineDependenciesConstructor(target, writer, dependencies,
+        defineDependenciesConstructor(context, operator.getOutputs(), target, writer,
                 method -> {
                     method.visitVarInsn(Opcodes.ALOAD, 0);
                     getNew(method, combinerClass);

--- a/dag/compiler/builtin/src/main/java/com/asakusafw/dag/compiler/builtin/Util.java
+++ b/dag/compiler/builtin/src/main/java/com/asakusafw/dag/compiler/builtin/Util.java
@@ -21,7 +21,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -166,15 +165,7 @@ final class Util {
             ClassVisitor writer,
             Consumer<MethodVisitor> superConstructor,
             Consumer<MethodVisitor> body) {
-        Map<OperatorProperty, VertexElement> elements = new LinkedHashMap<>();
-        for (OperatorProperty property : properties) {
-            elements.put(property, context.getDependency(property));
-        }
-        Map<VertexElement, FieldRef> deps = AsmUtil.defineDependenciesConstructor(
-                aClass, writer, elements.values(), superConstructor, body);
-        Map<OperatorProperty, FieldRef> results = new LinkedHashMap<>();
-        elements.forEach((k, v) -> results.put(k, Invariants.requireNonNull(deps.get(v))));
-        return results;
+        return defineDependenciesConstructor(context, properties, aClass, writer, superConstructor, body);
     }
 
     static List<OperatorInput> getPrimaryInputs(Operator operator) {

--- a/dag/compiler/codegen/src/main/java/com/asakusafw/dag/compiler/codegen/BufferOperatorGenerator.java
+++ b/dag/compiler/codegen/src/main/java/com/asakusafw/dag/compiler/codegen/BufferOperatorGenerator.java
@@ -18,7 +18,6 @@ package com.asakusafw.dag.compiler.codegen;
 import static com.asakusafw.dag.compiler.codegen.AsmUtil.*;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import org.objectweb.asm.ClassWriter;
@@ -35,6 +34,7 @@ import com.asakusafw.lang.compiler.model.description.Descriptions;
 import com.asakusafw.lang.compiler.model.description.ReifiableTypeDescription;
 import com.asakusafw.lang.compiler.model.description.TypeDescription;
 import com.asakusafw.lang.utils.common.Arguments;
+import com.asakusafw.lang.utils.common.Tuple;
 import com.asakusafw.runtime.core.Result;
 
 /**
@@ -81,7 +81,7 @@ public final class BufferOperatorGenerator {
         TypeDescription dataType = getDataType(successors);
         ClassWriter writer = newWriter(target, Object.class, Result.class);
         FieldRef buffer = defineField(writer, target, "buffer", typeOf(dataType));
-        Map<VertexElement, FieldRef> deps = defineDependenciesConstructor(target, writer, successors, v -> {
+        List<Tuple<VertexElement, FieldRef>> pairs = defineDependenciesConstructor(target, writer, successors, v -> {
             v.visitVarInsn(Opcodes.ALOAD, 0);
             getNew(v, dataType);
             putField(v, buffer);
@@ -92,9 +92,9 @@ public final class BufferOperatorGenerator {
             self.load(method);
             getField(method, buffer);
             LocalVarRef buf = putLocalVar(method, Type.OBJECT, 2);
-            for (int i = 0, n = successors.size(); i < n; i++) {
+            for (int i = 0, n = pairs.size(); i < n; i++) {
                 self.load(method);
-                getField(method, deps.get(successors.get(i)));
+                getField(method, pairs.get(i).right());
                 if (i < n - 1) {
                     buf.load(method);
                     input.load(method);


### PR DESCRIPTION
## Summary

This PR fixes invalid cache reuse of operator adapter classes. 

## Background, Problem or Goal of the patch

In the latest implementation, Asakusa {on M3BP, Vanilla} generates invalid operator adapter classes if the operator instance has duplicated outputs (e.g. output to the same operator).

## Design of the fix, or a new feature

We made operator adapter classes work independently of their outputs.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw-dag#38