### PR TITLE
Raise NPE in summarize operator with MAX/MIN for null values.

### DIFF
--- a/dag/compiler/codegen/src/main/java/com/asakusafw/dag/compiler/codegen/AsmUtil.java
+++ b/dag/compiler/codegen/src/main/java/com/asakusafw/dag/compiler/codegen/AsmUtil.java
@@ -349,7 +349,7 @@ public final class AsmUtil {
     }
 
     /**
-     * Adds a string array on to the top of the stack.
+     * Adds an array on to the top of the stack.
      * @param method the current method visitor
      * @param elementType the element type
      * @param values the array elements
@@ -362,6 +362,24 @@ public final class AsmUtil {
             method.visitInsn(Opcodes.DUP);
             getInt(method, index);
             getConst(method, values[index]);
+            method.visitInsn(Opcodes.AASTORE);
+        }
+    }
+
+    /**
+     * Adds an array on to the top of the stack.
+     * @param method the current method visitor
+     * @param elementType the element type
+     * @param values the array elements
+     * @since 0.4.1
+     */
+    public static void getArray(MethodVisitor method, Type elementType, LocalVarRef[] values) {
+        getInt(method, values.length);
+        method.visitTypeInsn(Opcodes.ANEWARRAY, elementType.getInternalName());
+        for (int index = 0; index < values.length; index++) {
+            method.visitInsn(Opcodes.DUP);
+            getInt(method, index);
+            values[index].load(method);
             method.visitInsn(Opcodes.AASTORE);
         }
     }
@@ -476,7 +494,19 @@ public final class AsmUtil {
     }
 
     /**
-     * Copies a {@code ValueOption}.
+     * Invokes {@code ValueOption#isNull()}.
+     * @param method the target method
+     * @param dataType the data type
+     */
+    public static void getNullity(MethodVisitor method, TypeDescription dataType) {
+        method.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
+                typeOf(dataType).getInternalName(), "isNull",
+                Type.getMethodDescriptor(Type.BOOLEAN_TYPE),
+                false);
+    }
+
+    /**
+     * Invokes {@code ValueOption#copyFrom(ValueOption)}.
      * @param method the target method
      * @param dataType the data type
      */
@@ -499,7 +529,19 @@ public final class AsmUtil {
     }
 
     /**
-     * Copies a {@code DataModel}.
+     * Invokes {@code DataModel#reset()}.
+     * @param method the target method
+     * @param dataType the data type
+     */
+    public static void resetDataModel(MethodVisitor method, TypeDescription dataType) {
+        method.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
+                typeOf(dataType).getInternalName(), "reset",
+                Type.getMethodDescriptor(Type.VOID_TYPE),
+                false);
+    }
+
+    /**
+     * Invokes {@code DataModel#copyFrom(DataModel)}.
      * @param method the target method
      * @param dataType the data type
      */


### PR DESCRIPTION
## Summary

This PR fixes summarize operator behavior that must raise `NullPointerException` if `max/min` target input represented `NULL`.

## Background, Problem or Goal of the patch

The latest implementation, `max/min` operations just set `NULL` for `NULL` inputs, but must raise NPE instead in such cases. Asakusa on {on M3BP, Vanilla} only have this problem, and other platforms already work correctly.

## Design of the fix, or a new feature

In this PR, we check nullity of properties at converting input data models into the corresponded summarized data models. At that time, the implementation will raise NPE for `NULL` inputs with more helpful error messages as like
`MockDataModel.sort must not be null (in Op.simple): {key=100, sort=null, value=Hello, world!}`.

## Related Issue, Pull Request or Code

N/A.