### PR TITLE
Fix multiple outputs from the same origin.

### DIFF
--- a/dag/compiler/model/src/main/java/com/asakusafw/dag/compiler/model/build/GraphInfoBuilder.java
+++ b/dag/compiler/model/src/main/java/com/asakusafw/dag/compiler/model/build/GraphInfoBuilder.java
@@ -15,7 +15,9 @@
  */
 package com.asakusafw.dag.compiler.model.build;
 
+import java.text.MessageFormat;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -150,11 +152,14 @@ public class GraphInfoBuilder {
             if (targets.isEmpty()) {
                 continue;
             }
-            // FIXME check - each descriptor must be compatible
-            EdgeDescriptor descriptor = targets.stream()
+            List<EdgeDescriptor> candidates = targets.stream()
                 .map(ResolvedInputInfo::getDescriptor)
-                .findFirst()
-                .orElseThrow(IllegalStateException::new);
+                .distinct()
+                .collect(Collectors.toList());
+            Invariants.require(candidates.size() == 1, () -> MessageFormat.format(
+                    "ambiguous edges: {}",
+                    candidates));
+            EdgeDescriptor descriptor = candidates.get(0);
             PortInfo upstream = entry.getValue();
             targets.stream()
                 .map(is::get)


### PR DESCRIPTION
## Summary

This PR fixes multiple external outputs from the same operator output.

## Background, Problem or Goal of the patch

When an operator output is connected to two or more outputs,

```
                  +--[Output1]
                 /
.. --[Operator]-+
                 \
                  +--[Output2]
```

the DSL compiler will insert vertex bounds in front of the individual outputs.

```
                  +--[Bound1]--[Output1]
                 /
.. --[Operator]-+
                 \
                  +--[Bound2]--[Output2]
```

These bounds manages shuffle operations of each output, but the consequent optimizer may unify them.

```
                           +--[Output1]
                          /
.. --[Operator]--[Bound]-+
                          \
                           +--[Output2]
```

This may cause error if each shuffle operations are different at Asakusa {on M3BP, Vanilla} runtime.

```
Exception in thread "main" java.lang.IllegalStateException: ambiguous edges: Port[INPUT](vN:input) ([Edge(SCATTER_GATHER), Edge(SCATTER_GATHER)])
...
        at com.asakusafw.m3bp.mirror.FlowGraphDriver.drive(FlowGraphDriver.java:47)
...
```

## Design of the fix, or a new feature

We have introduced a new optimization rule to suppress unifying vertex bounds before outputs.

## Related Issue, Pull Request or Code

N/A.
