### PR TITLE
Support Oracle Database partitions in JDBC direct mode.

### DIFF
--- a/dag/runtime/api/src/main/java/com/asakusafw/dag/api/processor/basic/BasicTaskSchedule.java
+++ b/dag/runtime/api/src/main/java/com/asakusafw/dag/api/processor/basic/BasicTaskSchedule.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.OptionalInt;
 
 import com.asakusafw.dag.api.processor.TaskInfo;
 import com.asakusafw.dag.api.processor.TaskSchedule;
@@ -28,10 +29,13 @@ import com.asakusafw.lang.utils.common.Arguments;
 /**
  * A basic implementation of {@link TaskSchedule}.
  * @since 0.4.0
+ * @version 0.4.2
  */
 public class BasicTaskSchedule implements TaskSchedule {
 
     private final List<TaskInfo> tasks;
+
+    private final int maxConcurrency;
 
     /**
      * Creates a new empty instance.
@@ -45,8 +49,7 @@ public class BasicTaskSchedule implements TaskSchedule {
      * @param tasks each task information
      */
     public BasicTaskSchedule(List<? extends TaskInfo> tasks) {
-        Arguments.requireNonNull(tasks);
-        this.tasks = new ArrayList<>(tasks);
+        this(new ArrayList<>(Arguments.requireNonNull(tasks)), -1);
     }
 
     /**
@@ -57,9 +60,34 @@ public class BasicTaskSchedule implements TaskSchedule {
         this(Arrays.asList(tasks));
     }
 
+    private BasicTaskSchedule(List<TaskInfo> tasks, int maxConcurrency) {
+        Arguments.requireNonNull(tasks);
+        this.tasks = tasks;
+        this.maxConcurrency = maxConcurrency;
+    }
+
+    /**
+     * Returns a new schedule with the given max concurrency.
+     * @param newValue the new max concurrency
+     * @return the created object
+     * @since 0.4.2
+     */
+    public BasicTaskSchedule withMaxConcurrency(int newValue) {
+        return new BasicTaskSchedule(tasks, newValue);
+    }
+
     @Override
     public List<TaskInfo> getTasks() {
         return Collections.unmodifiableList(tasks);
+    }
+
+    @Override
+    public OptionalInt getMaxConcurrency() {
+        if (maxConcurrency >= 1) {
+            return OptionalInt.of(maxConcurrency);
+        } else {
+            return OptionalInt.empty();
+        }
     }
 
     @Override

--- a/dag/runtime/jdbc/src/conf/findbugs/exclude.xml
+++ b/dag/runtime/jdbc/src/conf/findbugs/exclude.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FindBugsFilter>
-  <Match classregex="com.asakusafw.dag.runtime.jdbc.basic..+">
+  <Match classregex="com.asakusafw.dag.runtime.jdbc.(basic|oracle)..+">
     <Or>
       <Bug pattern="ODR_OPEN_DATABASE_RESOURCE" />
       <Bug pattern="OBL_UNSATISFIED_OBLIGATION" />

--- a/dag/runtime/jdbc/src/main/java/com/asakusafw/dag/runtime/jdbc/JdbcInputDriver.java
+++ b/dag/runtime/jdbc/src/main/java/com/asakusafw/dag/runtime/jdbc/JdbcInputDriver.java
@@ -18,6 +18,7 @@ package com.asakusafw.dag.runtime.jdbc;
 import java.io.IOException;
 import java.sql.Connection;
 import java.util.List;
+import java.util.OptionalDouble;
 
 import com.asakusafw.dag.api.processor.ObjectReader;
 
@@ -40,6 +41,7 @@ public interface JdbcInputDriver {
     /**
      * Represents a partition of JDBC input.
      * @since 0.4.0
+     * @version 0.4.2
      */
     @FunctionalInterface
     interface Partition {
@@ -52,5 +54,13 @@ public interface JdbcInputDriver {
          * @throws InterruptedException if interrupted while computing input partitions
          */
         ObjectReader open(Connection connection) throws IOException, InterruptedException;
+
+        /**
+         * Returns the number of estimated rows in this partition.
+         * @return the estimated row count
+         */
+        default OptionalDouble getEsitimatedRowCount() {
+            return OptionalDouble.empty();
+        }
     }
 }

--- a/dag/runtime/jdbc/src/main/java/com/asakusafw/dag/runtime/jdbc/operation/Util.java
+++ b/dag/runtime/jdbc/src/main/java/com/asakusafw/dag/runtime/jdbc/operation/Util.java
@@ -13,31 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.dag.api.processor;
+package com.asakusafw.dag.runtime.jdbc.operation;
 
-import java.util.List;
-import java.util.OptionalInt;
+import com.asakusafw.dag.api.processor.ProcessorContext;
 
-/**
- * Represents a custom task schedule.
- * @since 0.4.0
- * @version 0.4.2
- */
-@FunctionalInterface
-public interface TaskSchedule {
+final class Util {
 
-    /**
-     * Returns the custom tasks schedule.
-     * @return the custom tasks schedule
-     */
-    List<? extends TaskInfo> getTasks();
+    static final String KEY_WORKAROUND_CONCURRENCY = JdbcEnvironmentInstaller.KEY_PREFIX + "workaround.concurrency";
 
-    /**
-     * Returns the number of max concurrency.
-     * @return the number of max concurrency, or empty if it is not limited
-     * @since 0.4.2
-     */
-    default OptionalInt getMaxConcurrency() {
-        return OptionalInt.empty();
+    private Util() {
+        return;
+    }
+
+    static boolean isMaxConcurrencyEnabled(ProcessorContext context) {
+        return context.getProperty(KEY_WORKAROUND_CONCURRENCY)
+                .map(Boolean::parseBoolean)
+                .orElse(false);
     }
 }

--- a/dag/runtime/jdbc/src/main/java/com/asakusafw/dag/runtime/jdbc/oracle/OracleSyntax.java
+++ b/dag/runtime/jdbc/src/main/java/com/asakusafw/dag/runtime/jdbc/oracle/OracleSyntax.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dag.runtime.jdbc.oracle;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+final class OracleSyntax {
+
+    private static final char LITERAL_ESCAPE = '\\';
+
+    private static final char STRING_QUOTE = '\'';
+
+    private static final Pattern PATTERN_IDENTIFIER = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
+
+    private OracleSyntax() {
+        return;
+    }
+
+    private static final Set<String> RESERVED;
+    static {
+        String[] keywords = { "ACCESS", "ADD", "ALL", "ALTER", "AND", "ANY", "AS", "ASC", "AUDIT", "BETWEEN", "BY",
+                "CHAR", "CHECK", "CLUSTER", "COLUMN", "COLUMN_VALUE", "COMMENT", "COMPRESS", "CONNECT", "CREATE",
+                "CURRENT", "DATE", "DECIMAL", "DEFAULT", "DELETE", "DESC", "DISTINCT", "DROP", "ELSE", "EXCLUSIVE",
+                "EXISTS", "FILE", "FLOAT", "FOR", "FROM", "GRANT", "GROUP", "HAVING", "IDENTIFIED", "IMMEDIATE", "IN",
+                "INCREMENT", "INDEX", "INITIAL", "INSERT", "INTEGER", "INTERSECT", "INTO", "IS", "LEVEL", "LIKE",
+                "LOCK", "LONG", "MAXEXTENTS", "MINUS", "MLSLABEL", "MODE", "MODIFY", "NESTED_TABLE_ID", "NOAUDIT",
+                "NOCOMPRESS", "NOT", "NOWAIT", "NULL", "NUMBER", "OF", "OFFLINE", "ON", "ONLINE", "OPTION", "OR",
+                "ORDER", "PCTFREE", "PRIOR", "PUBLIC", "RAW", "RENAME", "RESOURCE", "REVOKE", "ROW", "ROWID", "ROWNUM",
+                "ROWS", "SELECT", "SESSION", "SET", "SHARE", "SIZE", "SMALLINT", "START", "SUCCESSFUL", "SYNONYM",
+                "SYSDATE", "TABLE", "THEN", "TO", "TRIGGER", "UID", "UNION", "UNIQUE", "UPDATE", "USER", "VALIDATE",
+                "VALUES", "VARCHAR", "VARCHAR2", "VIEW", "WHENEVER", "WHERE", "WITH", };
+        Set<String> s = new HashSet<>(keywords.length * 2);
+        Collections.addAll(s, keywords);
+        RESERVED = Collections.unmodifiableSet(s);
+    }
+
+    /**
+     * Returns the valid name token in Oracle DDL.
+     * @param text the bare name
+     * @return the valid name token
+     */
+    public static String quoteName(String text) {
+        if (RESERVED.contains(text) || PATTERN_IDENTIFIER.matcher(text).matches() == false) {
+            // FIXME some character still can not appear in the name, but we does not check it here
+            return "\"" + text + "\"";
+        }
+        return text;
+    }
+
+    /**
+     * Returns the quoted string literal for Oracle DDL.
+     * @param text the target string
+     * @return the quoted string literal
+     */
+    public static String quoteLiteral(String text) {
+        StringBuilder buf = new StringBuilder();
+        buf.append(STRING_QUOTE);
+        for (int i = 0, n = text.length(); i < n; i++) {
+            char c = text.charAt(i);
+            if (c == STRING_QUOTE || c == LITERAL_ESCAPE) {
+                buf.append(LITERAL_ESCAPE);
+                buf.append(c);
+            } else if (Character.isISOControl(c)) {
+                buf.append(String.format("\\u%04x", (int) c)); //$NON-NLS-1$
+            } else {
+                buf.append(c);
+            }
+        }
+        buf.append(STRING_QUOTE);
+        return buf.toString();
+    }
+}

--- a/dag/runtime/jdbc/src/main/java/com/asakusafw/dag/runtime/jdbc/oracle/PartitionedJdbcInputDriver.java
+++ b/dag/runtime/jdbc/src/main/java/com/asakusafw/dag/runtime/jdbc/oracle/PartitionedJdbcInputDriver.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dag.runtime.jdbc.oracle;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.OptionalDouble;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.dag.api.processor.ObjectReader;
+import com.asakusafw.dag.runtime.jdbc.JdbcInputDriver;
+import com.asakusafw.dag.runtime.jdbc.JdbcProfile;
+import com.asakusafw.dag.runtime.jdbc.ResultSetAdapter;
+import com.asakusafw.dag.runtime.jdbc.basic.BasicJdbcInputDriver;
+import com.asakusafw.dag.runtime.jdbc.util.JdbcUtil;
+import com.asakusafw.lang.utils.common.InterruptibleIo.Closer;
+
+/**
+ * {@link JdbcInputDriver} for partitioned tables.
+ * @since 0.4.2
+ */
+public class PartitionedJdbcInputDriver implements JdbcInputDriver {
+
+    static final Logger LOG = LoggerFactory.getLogger(PartitionedJdbcInputDriver.class);
+
+    final JdbcProfile profile;
+
+    final String tableName;
+
+    final List<String> columnNames;
+
+    final String condition;
+
+    final Supplier<? extends ResultSetAdapter<?>> adapters;
+
+    /**
+     * Creates a new instance.
+     * @param profile the current profile
+     * @param tableName the target table name
+     * @param columnNames the target column names
+     * @param condition the input condition (optional)
+     * @param adapters the result set adapter provider
+     */
+    public PartitionedJdbcInputDriver(
+            JdbcProfile profile,
+            String tableName,
+            List<String> columnNames,
+            String condition,
+            Supplier<? extends ResultSetAdapter<?>> adapters) {
+        this.profile = profile;
+        this.tableName = tableName;
+        this.columnNames = columnNames;
+        this.condition = condition;
+        this.adapters = adapters;
+    }
+
+    @Override
+    public List<? extends JdbcInputDriver.Partition> getPartitions(
+            Connection connection) throws IOException, InterruptedException {
+        List<Partition> partitions = collectPartitions(connection);
+        if (partitions.isEmpty()) {
+            throw new IOException(MessageFormat.format(
+                    "there are no available partitions in table \"{0}\"",
+                    tableName));
+        }
+        return partitions;
+    }
+
+    private List<Partition> collectPartitions(Connection connection) throws IOException, InterruptedException {
+        List<Partition> partitions = collectPartitions(connection, true);
+        if (partitions.isEmpty() == false) {
+            return partitions;
+        }
+        return collectPartitions(connection, false);
+    }
+
+    private List<Partition> collectPartitions(
+            Connection connection,
+            boolean caseSensitive) throws IOException, InterruptedException {
+        String sql = buildPartitionInfoStatement(caseSensitive);
+        LOG.debug("collect partitions: {}", sql);
+        try (Closer closer = new Closer()) {
+            Statement statement = connection.createStatement();
+            closer.add(JdbcUtil.wrap(statement::close));
+            ResultSet rs = statement.executeQuery(sql);
+            closer.add(JdbcUtil.wrap(rs::close));
+
+            List<Partition> results = new ArrayList<>();
+            while (rs.next()) {
+                String partitionName = rs.getString(1);
+                double rows = rs.getDouble(2);
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("partition status: table={}, partition={}, rows={}",
+                            tableName, partitionName, rows);
+                }
+                if (Double.isNaN(rows) || rows < 1) {
+                    rows = 1.0;
+                }
+                results.add(new Partition(partitionName, rows));
+            }
+            return results;
+        } catch (SQLException e) {
+            throw JdbcUtil.wrap(e);
+        }
+    }
+
+    String buildPartitionInfoStatement(boolean caseSensitive) {
+        StringBuilder buf = new StringBuilder();
+        buf.append("SELECT PARTITION_NAME, NUM_ROWS")
+            .append(" FROM ALL_TAB_PARTITIONS")
+            .append(" WHERE ")
+            .append(caseSensitive ? "TABLE_NAME" : "UPPER(TABLE_NAME)")
+            .append(" = ")
+            .append(OracleSyntax.quoteLiteral(caseSensitive ? tableName : tableName.toUpperCase(Locale.ENGLISH)));
+        return buf.toString();
+    }
+
+    String buildSelectStatement(String partitionName) {
+        StringBuilder buf = new StringBuilder();
+        buf.append(JdbcUtil.getSelectStatement(tableName, columnNames));
+        buf.append(" PARTITION(").append(OracleSyntax.quoteName(partitionName)).append(")"); //$NON-NLS-1$ //$NON-NLS-2$
+        if (condition != null) {
+            buf.append(" WHERE ").append(condition); //$NON-NLS-1$
+        }
+        return buf.toString();
+    }
+
+    private final class Partition implements JdbcInputDriver.Partition {
+
+        private final String name;
+
+        private final double size;
+
+        Partition(String name, double size) {
+            this.name = name;
+            this.size = size;
+        }
+
+        @Override
+        public ObjectReader open(Connection connection) throws IOException, InterruptedException {
+            String sql = buildSelectStatement(name);
+            int fetchSize = profile.getFetchSize().orElse(-1);
+            return BasicJdbcInputDriver.open(connection, sql, adapters.get(), fetchSize);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("Partition(table=%s, name=%s, size=%f)", tableName, name, size);
+        }
+
+        @Override
+        public OptionalDouble getEsitimatedRowCount() {
+            return OptionalDouble.of(size);
+        }
+    }
+}

--- a/dag/runtime/jdbc/src/main/java/com/asakusafw/dag/runtime/jdbc/oracle/package-info.java
+++ b/dag/runtime/jdbc/src/main/java/com/asakusafw/dag/runtime/jdbc/oracle/package-info.java
@@ -13,31 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.dag.api.processor;
-
-import java.util.List;
-import java.util.OptionalInt;
-
 /**
- * Represents a custom task schedule.
- * @since 0.4.0
- * @version 0.4.2
+ * Oracle databases targeted JDBC adapter for Asakusa DAG.
  */
-@FunctionalInterface
-public interface TaskSchedule {
-
-    /**
-     * Returns the custom tasks schedule.
-     * @return the custom tasks schedule
-     */
-    List<? extends TaskInfo> getTasks();
-
-    /**
-     * Returns the number of max concurrency.
-     * @return the number of max concurrency, or empty if it is not limited
-     * @since 0.4.2
-     */
-    default OptionalInt getMaxConcurrency() {
-        return OptionalInt.empty();
-    }
-}
+package com.asakusafw.dag.runtime.jdbc.oracle;

--- a/dag/runtime/jdbc/src/test/java/com/asakusafw/dag/runtime/jdbc/util/WindGateJdbcDirectTest.java
+++ b/dag/runtime/jdbc/src/test/java/com/asakusafw/dag/runtime/jdbc/util/WindGateJdbcDirectTest.java
@@ -30,6 +30,7 @@ import com.asakusafw.dag.runtime.jdbc.JdbcDagTestRoot;
 import com.asakusafw.dag.runtime.jdbc.JdbcInputDriver;
 import com.asakusafw.dag.runtime.jdbc.JdbcOperationDriver;
 import com.asakusafw.dag.runtime.jdbc.JdbcOutputDriver;
+import com.asakusafw.dag.runtime.jdbc.basic.BasicJdbcInputDriver;
 import com.asakusafw.dag.runtime.jdbc.operation.OutputClearKind;
 import com.asakusafw.dag.runtime.jdbc.testing.KsvJdbcAdapter;
 import com.asakusafw.dag.runtime.jdbc.testing.KsvModel;
@@ -143,6 +144,56 @@ public class WindGateJdbcDirectTest extends JdbcDagTestRoot {
                     .flatMap(Collection::stream)
                     .sorted((a, b) -> Long.compare(a.getKey(), b.getKey()))
                     .collect(Collectors.toList()), is(in));
+        });
+    }
+
+    /**
+     * input - w/ oracle partitions.
+     * @throws Exception if failed
+     */
+    @Test
+    public void input_oracle_partition() throws Exception {
+        edit(b -> b
+                .withOption(WindGateJdbcDirect.OPTIMIAZATION_ORACLE_PARTITION)
+                .withMaxInputConcurrency(2));
+        context("testing", c -> {
+            JdbcInputDriver driver = WindGateJdbcDirect.input("testing", TABLE, COLUMNS, KsvJdbcAdapter::new)
+                    .withOption(WindGateJdbcDirect.OPTIMIAZATION_ORACLE_PARTITION)
+                    .build(c);
+            assertThat(driver, is(not(instanceOf(BasicJdbcInputDriver.class))));
+        });
+    }
+
+    /**
+     * input - w/ oracle partitions - w/o input option.
+     * @throws Exception if failed
+     */
+    @Test
+    public void input_oracle_partition_missing_input_option() throws Exception {
+        edit(b -> b
+                .withOption(WindGateJdbcDirect.OPTIMIAZATION_ORACLE_PARTITION)
+                .withMaxInputConcurrency(2));
+        context("testing", c -> {
+            JdbcInputDriver driver = WindGateJdbcDirect.input("testing", TABLE, COLUMNS, KsvJdbcAdapter::new)
+                    .build(c);
+            assertThat(driver, is(instanceOf(BasicJdbcInputDriver.class)));
+        });
+    }
+
+    /**
+     * input - w/ oracle partitions - w/ input concurrency = 1.
+     * @throws Exception if failed
+     */
+    @Test
+    public void input_oracle_partition_no_concurrency_moment() throws Exception {
+        edit(b -> b
+                .withOption(WindGateJdbcDirect.OPTIMIAZATION_ORACLE_PARTITION)
+                .withMaxInputConcurrency(1));
+        context("testing", c -> {
+            JdbcInputDriver driver = WindGateJdbcDirect.input("testing", TABLE, COLUMNS, KsvJdbcAdapter::new)
+                    .withOption(WindGateJdbcDirect.OPTIMIAZATION_ORACLE_PARTITION)
+                    .build(c);
+            assertThat(driver, is(instanceOf(BasicJdbcInputDriver.class)));
         });
     }
 


### PR DESCRIPTION
## Summary

This PR enables Oracle Database partitions in JDBC direct mode (available in Asakusa {on M3BP, Vanilla}).

## Background, Problem or Goal of the patch

In the latest implementation, JDBC direct mode always obtains input data from a table in single-threaded. This PR enables reading individual partitions of a table in parallel.

## Design of the fix, or a new feature

We have introduced a new optimization option:

* `ORACLE_PARTITION`
  * enable partitions for Oracle Databases
  * required following settings:
    * `com.asakusafw.dag.jdbc.<profile-name>.input.threads` (`> 1`)
    * `JdbcImporterDescription.getOptions()`
    * `com.asakusafw.dag.jdbc.<profile-name>.optimizations` (append `ORACLE_PARTITION`)

## Related Issue, Pull Request or Code

N/A.
