### PR TITLE
Fix views in co-group kind operators.

### DIFF
--- a/dag/compiler/plan/src/main/java/com/asakusafw/dag/compiler/planner/Util.java
+++ b/dag/compiler/plan/src/main/java/com/asakusafw/dag/compiler/planner/Util.java
@@ -175,7 +175,8 @@ final class Util {
             .filter(x -> x.isEmpty() == false)
             .peek(x -> Invariants.require(x.size() == 1))
             .map(x -> x.iterator().next().getOwner())
-            .map(o -> Invariants.requireNonNull(map.get(o)))
+            .filter(map::containsKey)
+            .map(map::get)
             .collect(Collectors.toList());
         Invariants.require(results.size() == primary.size());
         return results;


### PR DESCRIPTION
## Summary

This PR fixes views in co-group kind operators (e.g. `@CoGroup`), on DSL compiler for {M3BP, Vanilla}.

## Background, Problem or Goal of the patch

If views are appeared in co-group kind operators, DSL compiler will failed with `IllegalStateException`.

```
java.lang.IllegalStateException: null
    at com.asakusafw.lang.utils.common.Invariants.require(Invariants.java:78)
    at com.asakusafw.lang.utils.common.Invariants.requireNonNull(Invariants.java:41)
    at com.asakusafw.dag.compiler.planner.Util.lambda$sortPrimaryInputs$8(Util.java:178)
(snip)
    at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
    at com.asakusafw.dag.compiler.planner.Util.sortPrimaryInputs(Util.java:179)
    at com.asakusafw.dag.compiler.planner.Util.sortInputs(Util.java:154)
    at com.asakusafw.dag.compiler.planner.Util.computeIds(Util.java:115)
...
```

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.
