### PR TITLE
Avoid using deprecated methods since Gradle 4.0.

### DIFF
--- a/vanilla/gradle/build.gradle
+++ b/vanilla/gradle/build.gradle
@@ -25,7 +25,7 @@ ext.parentPom = { f ->
         hadoopVersion : xml['properties']['hadoop.version'].text(),
     ]
 }(project.file('../../pom.xml')) // I'm on './vanilla/gradle/build.gradle'.
- 
+
 group = 'com.asakusafw.vanilla'
 version = parentPom.projectVersion
 
@@ -71,6 +71,19 @@ tasks.withType(AbstractCompile) { task ->
 
 eclipse.jdt {
     javaRuntimeName = "JavaSE-${sourceCompatibility}"
+}
+if (project.hasProperty('referProject')) {
+    eclipse.classpath.file.whenMerged { classpath ->
+        classpath.entries = classpath.entries.collect { entry ->
+            if (entry instanceof org.gradle.plugins.ide.eclipse.model.Library \
+                    && entry.moduleVersion \
+                    && entry.moduleVersion.name == 'asakusa-gradle-plugins') {
+                new org.gradle.plugins.ide.eclipse.model.ProjectDependency('/asakusa-gradle-plugins')
+            } else {
+                entry
+            }
+        }.unique() as List
+    }
 }
 
 groovydoc {

--- a/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaSdkPlugin.groovy
+++ b/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaSdkPlugin.groovy
@@ -79,7 +79,7 @@ class AsakusaVanillaSdkPlugin implements Plugin<Project> {
             task.toolClasspath << { project.configurations.asakusaVanillaCompiler }
             task.toolClasspath << { project.sourceSets.main.compileClasspath - project.configurations.compile }
 
-            task.explore << { [project.sourceSets.main.output.classesDir].findAll { it.exists() } }
+            task.explore << { PluginUtils.getClassesDirs(project, project.sourceSets.main.output).findAll { it.exists() } }
             task.embed << { [project.sourceSets.main.output.resourcesDir].findAll { it.exists() } }
             task.attach << { project.configurations.embedded }
 


### PR DESCRIPTION
## Summary

This PR replaces uses of Gradle API which will be deprecated since Gradle 4.0.

## Background, Problem or Goal of the patch

see asakusafw/asakusafw-sdk#138.

## Design of the fix, or a new feature

This suppresses warnings on building Asakusa projects with `asakusafw-vanilla` plugin.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw-sdk#138
