### PR TITLE
Add WindGate information into `etc/batch-info.json`.

### DIFF
--- a/compiler-project/extension-windgate/src/main/java/com/asakusafw/lang/compiler/extension/windgate/info/WindGateIoAttributeCollector.java
+++ b/compiler-project/extension-windgate/src/main/java/com/asakusafw/lang/compiler/extension/windgate/info/WindGateIoAttributeCollector.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.compiler.extension.windgate.info;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.lang.compiler.extension.windgate.DescriptionModel;
+import com.asakusafw.lang.compiler.extension.windgate.WindGateConstants;
+import com.asakusafw.lang.compiler.model.description.ClassDescription;
+import com.asakusafw.lang.compiler.model.graph.ExternalPort;
+import com.asakusafw.lang.compiler.model.graph.Jobflow;
+import com.asakusafw.lang.compiler.model.graph.OperatorGraph;
+import com.asakusafw.lang.compiler.model.info.ExternalPortInfo;
+import com.asakusafw.lang.info.api.AttributeCollector;
+import com.asakusafw.lang.info.windgate.WindGateInputInfo;
+import com.asakusafw.lang.info.windgate.WindGateIoAttribute;
+import com.asakusafw.lang.info.windgate.WindGateOutputInfo;
+import com.asakusafw.lang.info.windgate.WindGatePortInfo;
+import com.asakusafw.windgate.core.DriverScript;
+
+/**
+ * An implementation of {@link AttributeCollector} for WindGate.
+ * @since 0.4.2
+ */
+public class WindGateIoAttributeCollector implements AttributeCollector {
+
+    static final Logger LOG = LoggerFactory.getLogger(WindGateIoAttributeCollector.class);
+
+    @Override
+    public void process(Context context, Jobflow jobflow) {
+        OperatorGraph graph = jobflow.getOperatorGraph();
+        List<WindGateInputInfo> inputs = collect(graph.getInputs().values(), WindGateInputInfo::new);
+        List<WindGateOutputInfo> outputs = collect(graph.getOutputs().values(), WindGateOutputInfo::new);
+        if (inputs.isEmpty() == false || outputs.isEmpty() == false) {
+            context.putAttribute(new WindGateIoAttribute(inputs, outputs));
+        }
+    }
+
+    private static <T extends WindGatePortInfo> List<T> collect(
+            Collection<? extends ExternalPort> ports,
+            InfoFactory<T> factory) {
+        return ports.stream()
+                .filter(ExternalPort::isExternal)
+                .filter(p -> p.getInfo().getModuleName().equals(WindGateConstants.MODULE_NAME))
+                .map(factory::convert)
+                .flatMap(opt -> opt.map(Stream::of).orElse(Stream.empty()))
+                .sorted(Comparator.nullsFirst(Comparator.comparing(WindGatePortInfo::getName)))
+                .collect(Collectors.toList());
+    }
+
+    static String name(ClassDescription aClass) {
+        return Optional.ofNullable(aClass)
+                .map(ClassDescription::getBinaryName)
+                .orElse(null);
+    }
+
+    @FunctionalInterface
+    private interface InfoFactory<T> {
+
+        T newInstance(
+                String name,
+                String profileName,
+                String resourceName,
+                Map<String, String> configuration);
+
+        default Optional<T> convert(ExternalPort port) {
+            ClassLoader classLoader = DescriptionModel.class.getClassLoader();
+            ExternalPortInfo info = port.getInfo();
+            try {
+                DescriptionModel model = (DescriptionModel) info.getContents().resolve(classLoader);
+                DriverScript script = model.getDriverScript();
+                return Optional.of(newInstance(
+                        port.getName(),
+                        model.getProfileName(),
+                        script.getResourceName(),
+                        script.getConfiguration()));
+            } catch (ReflectiveOperationException e) {
+                LOG.debug("error occurred while building information model: {}",
+                        info.getDescriptionClass().getClassName(),
+                        e);
+                return Optional.empty();
+            }
+        }
+    }
+}

--- a/compiler-project/extension-windgate/src/main/java/com/asakusafw/lang/compiler/extension/windgate/info/package-info.java
+++ b/compiler-project/extension-windgate/src/main/java/com/asakusafw/lang/compiler/extension/windgate/info/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Asakusa WindGate information models.
+ */
+package com.asakusafw.lang.compiler.extension.windgate.info;

--- a/compiler-project/extension-windgate/src/main/resources/META-INF/services/com.asakusafw.lang.info.api.AttributeCollector
+++ b/compiler-project/extension-windgate/src/main/resources/META-INF/services/com.asakusafw.lang.info.api.AttributeCollector
@@ -1,0 +1,1 @@
+com.asakusafw.lang.compiler.extension.windgate.info.WindGateIoAttributeCollector

--- a/info/pom.xml
+++ b/info/pom.xml
@@ -16,5 +16,6 @@
     <module>model</module>
     <module>api</module>
     <module>directio</module>
+    <module>windgate</module>
   </modules>
 </project>

--- a/info/windgate/.gitignore
+++ b/info/windgate/.gitignore
@@ -1,0 +1,8 @@
+/.gradle
+/build
+/target
+/.project
+/.classpath
+/.settings
+/bin
+

--- a/info/windgate/pom.xml
+++ b/info/windgate/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <name>Asakusa DSL Compiler Extension for WindGate</name>
-  <artifactId>asakusa-compiler-extension-windgate</artifactId>
+  <name>Asakusa WindGate Information Models</name>
+  <artifactId>asakusa-info-windgate</artifactId>
   <parent>
     <artifactId>project</artifactId>
-    <groupId>com.asakusafw.lang.compiler</groupId>
+    <groupId>com.asakusafw.lang.info</groupId>
     <version>0.4.2-SNAPSHOT</version>
   </parent>
 
@@ -14,22 +14,8 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>asakusa-compiler-extension-externalio</artifactId>
+      <artifactId>asakusa-info-model</artifactId>
       <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.asakusafw.lang.info</groupId>
-      <artifactId>asakusa-info-api</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.asakusafw.lang.info</groupId>
-      <artifactId>asakusa-info-windgate</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.asakusafw</groupId>
-      <artifactId>asakusa-windgate-vocabulary</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -40,13 +26,15 @@
       <artifactId>slf4j-simple</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>jcl-over-slf4j</artifactId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>asakusa-info-model</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>asakusa-compiler-api-testing</artifactId>
-      <version>${project.version}</version>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/info/windgate/src/main/java/com/asakusafw/lang/info/windgate/Util.java
+++ b/info/windgate/src/main/java/com/asakusafw/lang/info/windgate/Util.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.windgate;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+final class Util {
+
+    private Util() {
+        return;
+    }
+
+    static <T> List<T> freeze(Collection<? extends T> elements) {
+        if (elements == null) {
+            return Collections.emptyList();
+        }
+        return Collections.unmodifiableList(new ArrayList<>(elements));
+    }
+
+    static <K, V> Map<K, V> freeze(Map<? extends K, ? extends V> elements) {
+        if (elements == null) {
+            return Collections.emptyMap();
+        }
+        return Collections.unmodifiableMap(new LinkedHashMap<>(elements));
+    }
+}

--- a/info/windgate/src/main/java/com/asakusafw/lang/info/windgate/WindGateInputInfo.java
+++ b/info/windgate/src/main/java/com/asakusafw/lang/info/windgate/WindGateInputInfo.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.windgate;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Information of WindGate input.
+ * @since 0.4.2
+ */
+public class WindGateInputInfo extends WindGatePortInfo {
+
+    /**
+     * Creates a new instance.
+     * @param name the port name
+     * @param profileName the profile name
+     * @param resourceName the resource name
+     * @param configuration the driver configuration
+     */
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public WindGateInputInfo(
+            @JsonProperty(ID_NAME) String name,
+            @JsonProperty(ID_PROFILE_NAME) String profileName,
+            @JsonProperty(ID_RESOURCE_NAME) String resourceName,
+            @JsonProperty(ID_CONFIGURATION) Map<String, String> configuration) {
+        super(name, profileName, resourceName, configuration);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode() + 1;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!super.equals(obj)) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        return super.equals(obj);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("WindGateInput(name=%s)", getName()); //$NON-NLS-1$
+    }
+}

--- a/info/windgate/src/main/java/com/asakusafw/lang/info/windgate/WindGateIoAttribute.java
+++ b/info/windgate/src/main/java/com/asakusafw/lang/info/windgate/WindGateIoAttribute.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.windgate;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import com.asakusafw.lang.info.Attribute;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * An attribute of WindGate.
+ * @since 0.4.2
+ */
+public class WindGateIoAttribute implements Attribute {
+
+    /**
+     * The attribute ID.
+     */
+    public static final String ID = "windgate";
+
+    private final List<? extends WindGateInputInfo> inputs;
+
+    private final List<? extends WindGateOutputInfo> outputs;
+
+    /**
+     * Creates a new instance.
+     * @param inputs the input ports
+     * @param outputs the output ports
+     */
+    public WindGateIoAttribute(
+            Collection<? extends WindGateInputInfo> inputs,
+            Collection<? extends WindGateOutputInfo> outputs) {
+        this.inputs = Util.freeze(inputs);
+        this.outputs = Util.freeze(outputs);
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    static WindGateIoAttribute of(
+            @JsonProperty("id") String id,
+            @JsonProperty("inputs") Collection<? extends WindGateInputInfo> inputs,
+            @JsonProperty("outputs") Collection<? extends WindGateOutputInfo> outputs) {
+        if (Objects.equals(id, ID) == false) {
+            throw new IllegalArgumentException();
+        }
+        return new WindGateIoAttribute(inputs, outputs);
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    /**
+     * Returns the inputs.
+     * @return the inputs
+     */
+    @JsonProperty("inputs")
+    public List<? extends WindGateInputInfo> getInputs() {
+        return inputs;
+    }
+
+    /**
+     * Returns the outputs.
+     * @return the outputs
+     */
+    @JsonProperty("outputs")
+    public List<? extends WindGateOutputInfo> getOutputs() {
+        return outputs;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Objects.hashCode(inputs);
+        result = prime * result + Objects.hashCode(outputs);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        WindGateIoAttribute other = (WindGateIoAttribute) obj;
+        return Objects.equals(inputs, other.inputs)
+                && Objects.equals(outputs, other.outputs);
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "WindGate(inputs={%s}, outputs={%s})",
+                inputs.stream().map(WindGatePortInfo::getName).collect(Collectors.joining(", ")), //$NON-NLS-1$
+                outputs.stream().map(WindGatePortInfo::getName).collect(Collectors.joining(", "))); //$NON-NLS-1$
+    }
+}

--- a/info/windgate/src/main/java/com/asakusafw/lang/info/windgate/WindGateOutputInfo.java
+++ b/info/windgate/src/main/java/com/asakusafw/lang/info/windgate/WindGateOutputInfo.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.windgate;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Information of WindGate output.
+ * @since 0.4.2
+ */
+public class WindGateOutputInfo extends WindGatePortInfo {
+
+    /**
+     * Creates a new instance.
+     * @param name the port name
+     * @param profileName the profile name
+     * @param resourceName the resource name
+     * @param configuration the driver configuration
+     */
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public WindGateOutputInfo(
+            @JsonProperty(ID_NAME) String name,
+            @JsonProperty(ID_PROFILE_NAME) String profileName,
+            @JsonProperty(ID_RESOURCE_NAME) String resourceName,
+            @JsonProperty(ID_CONFIGURATION) Map<String, String> configuration) {
+        super(name, profileName, resourceName, configuration);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode() + 1;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!super.equals(obj)) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        return super.equals(obj);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("WindGateInput(name=%s)", getName()); //$NON-NLS-1$
+    }
+}

--- a/info/windgate/src/main/java/com/asakusafw/lang/info/windgate/WindGatePortInfo.java
+++ b/info/windgate/src/main/java/com/asakusafw/lang/info/windgate/WindGatePortInfo.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.windgate;
+
+import java.util.Map;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * An abstract implementation of WindGate port information.
+ * @since 0.4.2
+ */
+public abstract class WindGatePortInfo {
+
+    static final String ID_NAME = "name";
+
+    static final String ID_PROFILE_NAME = "profile";
+
+    static final String ID_RESOURCE_NAME = "resource";
+
+    static final String ID_CONFIGURATION = "configuration";
+
+    private final String name;
+
+    private final String profileName;
+
+    private final String resourceName;
+
+    private final Map<String, String> configuration;
+
+    /**
+     * Creates a new instance.
+     * @param name the port name
+     * @param profileName the profile name
+     * @param resourceName the resource name
+     * @param configuration the driver configuration
+     */
+    protected WindGatePortInfo(
+            String name,
+            String profileName,
+            String resourceName,
+            Map<String, String> configuration) {
+        this.name = name;
+        this.profileName = profileName;
+        this.resourceName = resourceName;
+        this.configuration = Util.freeze(configuration);
+    }
+
+    /**
+     * Returns the port name.
+     * @return the port name
+     */
+    @JsonProperty(ID_NAME)
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the profile name.
+     * @return the profile name
+     */
+    @JsonProperty(ID_PROFILE_NAME)
+    public String getProfileName() {
+        return profileName;
+    }
+
+    /**
+     * Returns the resource name.
+     * @return the resource name
+     */
+    @JsonProperty(ID_RESOURCE_NAME)
+    public String getResourceName() {
+        return resourceName;
+    }
+
+    /**
+     * Returns the driver configuration.
+     * @return the driver configuration
+     */
+    @JsonProperty(ID_CONFIGURATION)
+    public Map<String, String> getConfiguration() {
+        return configuration;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Objects.hashCode(name);
+        result = prime * result + Objects.hashCode(profileName);
+        result = prime * result + Objects.hashCode(resourceName);
+        result = prime * result + Objects.hashCode(configuration);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        WindGatePortInfo other = (WindGatePortInfo) obj;
+        return Objects.equals(name, other.name)
+                && Objects.equals(profileName, other.profileName)
+                && Objects.equals(resourceName, other.resourceName)
+                && Objects.equals(configuration, other.configuration);
+    }
+}

--- a/info/windgate/src/main/java/com/asakusafw/lang/info/windgate/package-info.java
+++ b/info/windgate/src/main/java/com/asakusafw/lang/info/windgate/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Asakusa WindGate information models.
+ */
+package com.asakusafw.lang.info.windgate;

--- a/info/windgate/src/test/java/com/asakusafw/lang/info/windgate/WindGateInputInfoTest.java
+++ b/info/windgate/src/test/java/com/asakusafw/lang/info/windgate/WindGateInputInfoTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.windgate;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import com.asakusafw.lang.info.InfoSerDe;
+
+/**
+ * Test for {@link WindGateInputInfo}.
+ */
+public class WindGateInputInfoTest {
+
+    /**
+     * simple case.
+     */
+    @Test
+    public void simple() {
+        InfoSerDe.checkRestore(
+                WindGateInputInfo.class,
+                new WindGateInputInfo(
+                        "test-name",
+                        "test-profile",
+                        "test-resource",
+                        Arrays.stream(new String[][] {
+                            { "A", "a" },
+                            { "B", "b" },
+                            { "C", "c" },
+                        }).collect(Collectors.toMap(it -> it[0], it -> it[1]))));
+    }
+}

--- a/info/windgate/src/test/java/com/asakusafw/lang/info/windgate/WindGateIoAttributeTest.java
+++ b/info/windgate/src/test/java/com/asakusafw/lang/info/windgate/WindGateIoAttributeTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.windgate;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import com.asakusafw.lang.info.Attribute;
+import com.asakusafw.lang.info.InfoSerDe;
+
+/**
+ * Test for {@link WindGateIoAttribute}.
+ */
+public class WindGateIoAttributeTest {
+
+    /**
+     * simple case.
+     */
+    @Test
+    public void simple() {
+        InfoSerDe.checkRestore(
+                Attribute.class,
+                new WindGateIoAttribute(
+                        Arrays.asList(new WindGateInputInfo(
+                                "test-name",
+                                "test-profile",
+                                "test-resource",
+                                Arrays.stream(new String[][] {
+                                    { "A", "a" },
+                                    { "B", "b" },
+                                    { "C", "c" },
+                                }).collect(Collectors.toMap(it -> it[0], it -> it[1])))),
+                        Arrays.asList(new WindGateOutputInfo(
+                                "test-name",
+                                "test-profile",
+                                "test-resource",
+                                Arrays.stream(new String[][] {
+                                    { "D", "d" },
+                                    { "E", "e" },
+                                    { "F", "f" },
+                                }).collect(Collectors.toMap(it -> it[0], it -> it[1]))))));
+    }
+}

--- a/info/windgate/src/test/java/com/asakusafw/lang/info/windgate/WindGateOutputInfoTest.java
+++ b/info/windgate/src/test/java/com/asakusafw/lang/info/windgate/WindGateOutputInfoTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.windgate;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import com.asakusafw.lang.info.InfoSerDe;
+
+/**
+ * Test for {@link WindGateOutputInfo}.
+ */
+public class WindGateOutputInfoTest {
+
+    /**
+     * simple case.
+     */
+    @Test
+    public void simple() {
+        InfoSerDe.checkRestore(
+                WindGateOutputInfo.class,
+                new WindGateOutputInfo(
+                        "test-name",
+                        "test-profile",
+                        "test-resource",
+                        Arrays.stream(new String[][] {
+                            { "A", "a" },
+                            { "B", "b" },
+                            { "C", "c" },
+                        }).collect(Collectors.toMap(it -> it[0], it -> it[1]))));
+    }
+}


### PR DESCRIPTION
## Summary

This PR enables to add WindGate information into `etc/batch-info.json`.

## Background, Problem or Goal of the patch

N/A.

## Design of the fix, or a new feature

This is enhancement of #113 to for WindGate.

The following `jq` command line is an example of extracting WindGate I/O information from `etc/batch-info.json`:

```
jq '.jobflows[].attributes[] | select(.id == "windgate")'
```

Note that, this feature is only enabled in Gradle if `asakusafw.sdk.incubating` is `true`.

## Related Issue, Pull Request or Code

* #113 
