### PR TITLE
Introduce `batch-info.json` viewer.

### DIFF
--- a/compiler-project/extension-info/src/main/java/com/asakusafw/lang/compiler/extension/info/OperatorGraphAttributeCollector.java
+++ b/compiler-project/extension-info/src/main/java/com/asakusafw/lang/compiler/extension/info/OperatorGraphAttributeCollector.java
@@ -1,0 +1,257 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.compiler.extension.info;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.asakusafw.lang.compiler.model.PropertyName;
+import com.asakusafw.lang.compiler.model.graph.CoreOperator;
+import com.asakusafw.lang.compiler.model.graph.CustomOperator;
+import com.asakusafw.lang.compiler.model.graph.ExternalInput;
+import com.asakusafw.lang.compiler.model.graph.ExternalOutput;
+import com.asakusafw.lang.compiler.model.graph.FlowOperator;
+import com.asakusafw.lang.compiler.model.graph.Group;
+import com.asakusafw.lang.compiler.model.graph.Jobflow;
+import com.asakusafw.lang.compiler.model.graph.MarkerOperator;
+import com.asakusafw.lang.compiler.model.graph.Operator;
+import com.asakusafw.lang.compiler.model.graph.OperatorArgument;
+import com.asakusafw.lang.compiler.model.graph.OperatorGraph;
+import com.asakusafw.lang.compiler.model.graph.OperatorInput;
+import com.asakusafw.lang.compiler.model.graph.OperatorOutput;
+import com.asakusafw.lang.compiler.model.graph.UserOperator;
+import com.asakusafw.lang.info.api.AttributeCollector;
+import com.asakusafw.lang.info.graph.Input;
+import com.asakusafw.lang.info.graph.Node;
+import com.asakusafw.lang.info.graph.Output;
+import com.asakusafw.lang.info.operator.CoreOperatorSpec;
+import com.asakusafw.lang.info.operator.CustomOperatorSpec;
+import com.asakusafw.lang.info.operator.FlowOperatorSpec;
+import com.asakusafw.lang.info.operator.InputAttribute;
+import com.asakusafw.lang.info.operator.InputGranularity;
+import com.asakusafw.lang.info.operator.InputGroup;
+import com.asakusafw.lang.info.operator.InputOperatorSpec;
+import com.asakusafw.lang.info.operator.MarkerOperatorSpec;
+import com.asakusafw.lang.info.operator.OperatorAttribute;
+import com.asakusafw.lang.info.operator.OperatorGraphAttribute;
+import com.asakusafw.lang.info.operator.OperatorSpec;
+import com.asakusafw.lang.info.operator.OutputAttribute;
+import com.asakusafw.lang.info.operator.OutputOperatorSpec;
+import com.asakusafw.lang.info.operator.ParameterInfo;
+import com.asakusafw.lang.info.operator.UserOperatorSpec;
+
+/**
+ * Collects {@link OperatorGraphAttribute}.
+ * @since 0.4.2
+ */
+public class OperatorGraphAttributeCollector implements AttributeCollector {
+
+    @Override
+    public void process(Context context, Jobflow jobflow) {
+        Node root = new Node();
+        process(context, jobflow.getOperatorGraph(), root);
+        context.putAttribute(new OperatorGraphAttribute(root));
+    }
+
+    static void process(Context context, OperatorGraph graph, Node info) {
+        Map<OperatorInput, Input> downstreams = new HashMap<>();
+        Map<OperatorOutput, Output> upstreams = new HashMap<>();
+        Collection<Operator> operators = sort(graph);
+        for (Operator operator : operators) {
+            List<ParameterInfo> parameters = new ArrayList<>();
+            Node node = info.newElement();
+            for (OperatorInput input : operator.getInputs()) {
+                InputAttribute attr = convert(input);
+                Input result = node.newInput().withAttribute(attr);
+                downstreams.put(input, result);
+            }
+            for (OperatorOutput output : operator.getOutputs()) {
+                OutputAttribute attr = convert(output);
+                Output result = node.newOutput().withAttribute(attr);
+                upstreams.put(output, result);
+            }
+            for (OperatorArgument argument : operator.getArguments()) {
+                ParameterInfo attr = convert(argument);
+                parameters.add(attr);
+            }
+            OperatorSpec spec = convert(operator);
+            node.withAttribute(new OperatorAttribute(spec, parameters));
+            if (operator.getOperatorKind() == Operator.OperatorKind.FLOW) {
+                process(context, ((FlowOperator) operator).getOperatorGraph(), node);
+            }
+        }
+        for (Operator operator : operators) {
+            for (OperatorInput downstream : operator.getInputs()) {
+                for (OperatorOutput upstream : downstream.getOpposites()) {
+                    Input d = downstreams.get(downstream);
+                    Output u = upstreams.get(upstream);
+                    if (d != null && u != null) {
+                        d.connect(u);
+                    }
+                }
+            }
+        }
+    }
+
+    private static Collection<Operator> sort(OperatorGraph graph) {
+        // TODO sort operators
+        return graph.getOperators(false);
+    }
+
+    private static OperatorSpec convert(Operator operator) {
+        switch (operator.getOperatorKind()) {
+        case CORE:
+            return convert0((CoreOperator) operator);
+        case USER:
+            return convert0((UserOperator) operator);
+        case FLOW:
+            return convert0((FlowOperator) operator);
+        case INPUT:
+            return convert0((ExternalInput) operator);
+        case OUTPUT:
+            return convert0((ExternalOutput) operator);
+        case MARKER:
+            return convert0((MarkerOperator) operator);
+        case CUSTOM:
+            return convert0((CustomOperator) operator);
+        default:
+            throw new AssertionError(operator);
+        }
+    }
+
+    private static CoreOperatorSpec convert0(CoreOperator operator) {
+        return CoreOperatorSpec.of(translate(operator.getCoreOperatorKind()));
+    }
+
+    private static CoreOperatorSpec.CoreOperatorKind translate(CoreOperator.CoreOperatorKind kind) {
+        switch (kind) {
+        case CHECKPOINT:
+            return CoreOperatorSpec.CoreOperatorKind.CHECKPOINT;
+        case EXTEND:
+            return CoreOperatorSpec.CoreOperatorKind.EXTEND;
+        case PROJECT:
+            return CoreOperatorSpec.CoreOperatorKind.PROJECT;
+        case RESTRUCTURE:
+            return CoreOperatorSpec.CoreOperatorKind.RESTRUCTURE;
+        default:
+            throw new AssertionError(kind);
+        }
+    }
+
+    private static UserOperatorSpec convert0(UserOperator operator) {
+        return UserOperatorSpec.of(
+                Util.convert(operator.getAnnotation()),
+                Util.convert(operator.getMethod().getDeclaringClass()),
+                Util.convert(operator.getImplementationClass()),
+                operator.getMethod().getName());
+    }
+
+    private static FlowOperatorSpec convert0(FlowOperator operator) {
+        return FlowOperatorSpec.of(
+                Optional.ofNullable(operator.getDescriptionClass())
+                    .map(Util::convert)
+                    .orElse(null));
+    }
+
+    private static InputOperatorSpec convert0(ExternalInput operator) {
+        return InputOperatorSpec.of(
+                operator.getName(),
+                Optional.ofNullable(operator.getInfo())
+                    .flatMap(it -> Optional.ofNullable(it.getDescriptionClass()))
+                    .map(Util::convert)
+                    .orElse(null));
+    }
+
+    private static OutputOperatorSpec convert0(ExternalOutput operator) {
+        return OutputOperatorSpec.of(
+                operator.getName(),
+                Optional.ofNullable(operator.getInfo())
+                    .flatMap(it -> Optional.ofNullable(it.getDescriptionClass()))
+                    .map(Util::convert)
+                    .orElse(null));
+    }
+
+    private static MarkerOperatorSpec convert0(MarkerOperator operator) {
+        return MarkerOperatorSpec.get();
+    }
+
+    private static CustomOperatorSpec convert0(CustomOperator operator) {
+        return CustomOperatorSpec.of(operator.getCategory());
+    }
+
+    private static InputAttribute convert(OperatorInput input) {
+        return new InputAttribute(
+                input.getName(),
+                Util.convert(input.getDataType()),
+                translate(input.getInputUnit()),
+                translate(input.getGroup()));
+    }
+
+    private static InputGranularity translate(OperatorInput.InputUnit kind) {
+        switch (kind) {
+        case RECORD:
+            return InputGranularity.RECORD;
+        case GROUP:
+            return InputGranularity.RECORD;
+        case WHOLE:
+            return InputGranularity.RECORD;
+        default:
+            throw new AssertionError(kind);
+        }
+    }
+
+    private static InputGroup translate(Group group) {
+        if (group == null) {
+            return null;
+        }
+        return new InputGroup(
+                group.getGrouping().stream()
+                    .map(PropertyName::toName)
+                    .collect(Collectors.toList()),
+                group.getOrdering().stream()
+                    .map(it -> new InputGroup.Order(it.getPropertyName().toName(), translate(it.getDirection())))
+                    .collect(Collectors.toList()));
+    }
+
+    private static InputGroup.Direction translate(Group.Direction kind) {
+        switch (kind) {
+        case ASCENDANT:
+            return InputGroup.Direction.ASCENDANT;
+        case DESCENDANT:
+            return InputGroup.Direction.ASCENDANT;
+        default:
+            throw new AssertionError(kind);
+        }
+    }
+
+    private static OutputAttribute convert(OperatorOutput output) {
+        return new OutputAttribute(
+                output.getName(),
+                Util.convert(output.getDataType()));
+    }
+
+    private static ParameterInfo convert(OperatorArgument argument) {
+        return new ParameterInfo(
+                argument.getName(),
+                Util.convert(argument.getValue().getValueType()),
+                Util.convert(argument.getValue()));
+    }
+}

--- a/compiler-project/extension-info/src/main/java/com/asakusafw/lang/compiler/extension/info/Util.java
+++ b/compiler-project/extension-info/src/main/java/com/asakusafw/lang/compiler/extension/info/Util.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.compiler.extension.info;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.lang.compiler.model.description.AnnotationDescription;
+import com.asakusafw.lang.compiler.model.description.ArrayDescription;
+import com.asakusafw.lang.compiler.model.description.ArrayTypeDescription;
+import com.asakusafw.lang.compiler.model.description.BasicTypeDescription;
+import com.asakusafw.lang.compiler.model.description.ClassDescription;
+import com.asakusafw.lang.compiler.model.description.EnumConstantDescription;
+import com.asakusafw.lang.compiler.model.description.ImmediateDescription;
+import com.asakusafw.lang.compiler.model.description.SerializableValueDescription;
+import com.asakusafw.lang.compiler.model.description.TypeDescription;
+import com.asakusafw.lang.compiler.model.description.UnknownValueDescription;
+import com.asakusafw.lang.compiler.model.description.ValueDescription;
+import com.asakusafw.lang.info.value.AnnotationInfo;
+import com.asakusafw.lang.info.value.ClassInfo;
+import com.asakusafw.lang.info.value.EnumInfo;
+import com.asakusafw.lang.info.value.ListInfo;
+import com.asakusafw.lang.info.value.UnknownInfo;
+import com.asakusafw.lang.info.value.ValueInfo;
+
+final class Util {
+
+    static final Logger LOG = LoggerFactory.getLogger(Util.class);
+
+    private Util() {
+        return;
+    }
+
+    static ValueInfo convert(ValueDescription value) {
+        switch (value.getValueKind()) {
+        case IMMEDIATE:
+            return convert((ImmediateDescription) value);
+        case ENUM_CONSTANT:
+            return convert((EnumConstantDescription) value);
+        case ARRAY:
+            return convert((ArrayDescription) value);
+        case TYPE:
+            return convert((TypeDescription) value);
+        case ANNOTATION:
+            return convert((AnnotationDescription) value);
+        case SERIALIZABLE:
+            return convert((SerializableValueDescription) value);
+        case UNKNOWN:
+            return convert((UnknownValueDescription) value);
+        default:
+            throw new AssertionError(value);
+        }
+    }
+
+    static ValueInfo convert(ImmediateDescription value) {
+        return ValueInfo.of(value.getValue());
+    }
+
+    static EnumInfo convert(EnumConstantDescription value) {
+        return EnumInfo.of(
+                convert(value.getDeclaringClass()),
+                value.getName());
+    }
+
+    static ListInfo convert(ArrayDescription value) {
+        return ListInfo.of(value.getElements().stream()
+                .map(Util::convert)
+                .collect(Collectors.toList()));
+    }
+
+    static ClassInfo convert(TypeDescription type) {
+        switch (type.getTypeKind()) {
+        case CLASS:
+            return convert((ClassDescription) type);
+        case BASIC:
+            return ClassInfo.of(((BasicTypeDescription) type).getBasicTypeKind().getReflectiveObject());
+        case ARRAY:
+            return convert(((ArrayTypeDescription) type).getComponentType()).getArrayType();
+        default:
+            throw new AssertionError(type);
+        }
+    }
+
+    static ClassInfo convert(ClassDescription type) {
+        return ClassInfo.of(type.getName());
+    }
+
+    static AnnotationInfo convert(AnnotationDescription annotation) {
+        Map<String, ValueInfo> elements = new LinkedHashMap<>();
+        annotation.getElements().forEach((k, v) -> elements.put(k, convert(v)));
+        return AnnotationInfo.of(
+                convert(annotation.getDeclaringClass()),
+                elements);
+    }
+
+    static ValueInfo convert(SerializableValueDescription value) {
+        try {
+            return ValueInfo.of(value.resolve(Util.class.getClassLoader()));
+        } catch (ReflectiveOperationException e) {
+            LOG.trace("error occurred while deserializing value: {}", value, e);
+            return UnknownInfo.of(
+                    convert(value.getValueType()),
+                    "?");
+        }
+    }
+
+    static ValueInfo convert(UnknownValueDescription value) {
+        return UnknownInfo.of(
+                convert(value.getValueType()),
+                value.getLabel());
+    }
+}

--- a/compiler-project/extension-info/src/main/resources/META-INF/services/com.asakusafw.lang.info.api.AttributeCollector
+++ b/compiler-project/extension-info/src/main/resources/META-INF/services/com.asakusafw.lang.info.api.AttributeCollector
@@ -1,1 +1,2 @@
 com.asakusafw.lang.compiler.extension.info.ParameterListAttributeCollector
+com.asakusafw.lang.compiler.extension.info.OperatorGraphAttributeCollector

--- a/compiler-project/extension-windgate/src/main/java/com/asakusafw/lang/compiler/extension/windgate/info/WindGateIoAttributeCollector.java
+++ b/compiler-project/extension-windgate/src/main/java/com/asakusafw/lang/compiler/extension/windgate/info/WindGateIoAttributeCollector.java
@@ -81,6 +81,7 @@ public class WindGateIoAttributeCollector implements AttributeCollector {
 
         T newInstance(
                 String name,
+                String descriptionClass,
                 String profileName,
                 String resourceName,
                 Map<String, String> configuration);
@@ -93,6 +94,9 @@ public class WindGateIoAttributeCollector implements AttributeCollector {
                 DriverScript script = model.getDriverScript();
                 return Optional.of(newInstance(
                         port.getName(),
+                        Optional.ofNullable(info.getDescriptionClass())
+                            .map(ClassDescription::getBinaryName)
+                            .orElse(null),
                         model.getProfileName(),
                         script.getResourceName(),
                         script.getConfiguration()));

--- a/info/cli/.gitignore
+++ b/info/cli/.gitignore
@@ -1,0 +1,8 @@
+/.gradle
+/build
+/target
+/.project
+/.classpath
+/.settings
+/bin
+

--- a/info/cli/pom.xml
+++ b/info/cli/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <name>CLI for Information Models</name>
+  <artifactId>asakusa-info-cli</artifactId>
+  <parent>
+    <artifactId>project</artifactId>
+    <groupId>com.asakusafw.lang.info</groupId>
+    <version>0.4.2-SNAPSHOT</version>
+  </parent>
+
+  <packaging>jar</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <relocations>
+                <relocation>
+                  <pattern>com.fasterxml.jackson</pattern>
+                  <shadedPattern>com.asakusafw.lang.info.shaded.com.fasterxml.jackson</shadedPattern>
+                </relocation>
+              </relocations>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>com.asakusafw.lang.info.cli.Info</mainClass>
+                </transformer>
+              </transformers>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>exec</shadedClassifierName>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>asakusa-info-model</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>asakusa-info-directio</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>asakusa-info-windgate</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.airlift</groupId>
+      <artifactId>airline</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/BaseCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/BaseCommand.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.cli;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.charset.Charset;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.airlift.airline.Option;
+
+/**
+ * An abstract super implementation of commands.
+ * @since 0.4.2
+ */
+public abstract class BaseCommand implements Runnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BaseCommand.class);
+
+    @Option(
+            name = { "--output", "-o" },
+            title = "file",
+            description = "output file",
+            arity = 1,
+            required = false)
+    File output;
+
+    @Option(
+            name = { "--encoding", "-e" },
+            title = "encoding",
+            description = "output character encoding",
+            arity = 1,
+            required = false)
+    String encoding = Charset.defaultCharset().name();
+
+    private Status status = Status.INITIALIZED;
+
+    @Override
+    public final void run() {
+        this.status = process0();
+    }
+
+    private Status process0() {
+        try {
+            if (output != null) {
+                File dir = output.getParentFile();
+                if (dir != null) {
+                    if (dir.mkdirs() == false && dir.isDirectory() == false) {
+                        LOG.error("error occurred while creating output file: {}", output);
+                        return Status.PREPARE_ERROR;
+                    }
+                }
+                try (PrintWriter writer = new PrintWriter(output, encoding)) {
+                    return process(writer);
+                }
+            } else {
+                PrintWriter writer = new PrintWriter(new OutputStreamWriter(System.out, encoding), true);
+                Status s = process(writer);
+                writer.flush();
+                return s;
+            }
+        } catch (IOException e) {
+            LOG.error("error occurred while processing command", e);
+            return Status.PROCESS_ERROR;
+        }
+    }
+
+    /**
+     * Returns the command status.
+     * @return the command status
+     */
+    protected Status getStatus() {
+        return status;
+    }
+
+    /**
+     * Executes the command body.
+     * @param writer the output writer
+     * @return the command body
+     */
+    protected abstract Status process(PrintWriter writer);
+
+    /**
+     * Represents command status.
+     * @since 0.4.2
+     */
+    protected enum Status {
+
+        /**
+         * Initialized.
+         */
+        INITIALIZED,
+
+        /**
+         * Completed without errors.
+         */
+        SUCCESS,
+
+        /**
+         * Failed at preparing command.
+         */
+        PREPARE_ERROR,
+
+        /**
+         * Failed at processing command.
+         */
+        PROCESS_ERROR,
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/DrawJobflowCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/DrawJobflowCommand.java
@@ -74,7 +74,7 @@ public class DrawJobflowCommand extends InfoCommand {
         writer.println("}");
     }
 
-    private String analyzeJobflow(JobflowInfo it){
+    private String analyzeJobflow(JobflowInfo it) {
         if (showAll || showJobflowType) {
             return String.join("\n",
                     it.getId(),

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/DrawJobflowCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/DrawJobflowCommand.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.cli;
+
+import static com.asakusafw.lang.info.cli.DrawUtil.*;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Optional;
+
+import com.asakusafw.lang.info.BatchInfo;
+import com.asakusafw.lang.info.JobflowInfo;
+import com.asakusafw.lang.info.value.ClassInfo;
+
+import io.airlift.airline.Command;
+import io.airlift.airline.Option;
+
+/**
+ * A command for generating DOT script about jobflow graphs.
+ * @since 0.4.2
+ */
+@Command(
+        name = "jobflow",
+        description = "Generates jobflow graph as Graphviz DOT script",
+        hidden = false
+)
+public class DrawJobflowCommand extends InfoCommand {
+
+    @Option(
+            name = { "--show-type", },
+            title = "display jobflow type",
+            description = "display jobflow type",
+            arity = 0,
+            required = false)
+    boolean showJobflowType = false;
+
+    @Option(
+            name = { "--show-all", "-a", },
+            title = "display all information",
+            description = "display all information",
+            arity = 0,
+            required = false)
+    boolean showAll = false;
+
+    @Override
+    protected void process(PrintWriter writer, BatchInfo info) throws IOException {
+        writer.println("digraph {");
+        writer.printf("label=%s;%n", literal(Optional.ofNullable(info.getDescriptionClass())
+                .map(ClassInfo::of)
+                .map(ClassInfo::getSimpleName)
+                .orElse(info.getId())));
+        info.getJobflows().forEach(it -> writer.printf(
+                "%s [label=%s];%n",
+                literal(it.getId()),
+                literal(analyzeJobflow(it))));
+        info.getJobflows().forEach(
+                downstream -> downstream.getBlockerIds().forEach(
+                        upstreamId -> writer.printf("%s -> %s",
+                                literal(upstreamId),
+                                literal(downstream.getId()))));
+        writer.println("}");
+    }
+
+    private String analyzeJobflow(JobflowInfo it){
+        if (showAll || showJobflowType) {
+            return String.join("\n",
+                    it.getId(),
+                    Optional.ofNullable(it.getDescriptionClass())
+                        .map(ClassInfo::of)
+                        .map(ClassInfo::getSimpleName)
+                        .orElse("N/A"));
+        } else {
+            return it.getId();
+        }
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/DrawOperatorCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/DrawOperatorCommand.java
@@ -1,0 +1,558 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.cli;
+
+import static com.asakusafw.lang.info.cli.DrawUtil.*;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.asakusafw.lang.info.BatchInfo;
+import com.asakusafw.lang.info.JobflowInfo;
+import com.asakusafw.lang.info.operator.CoreOperatorSpec;
+import com.asakusafw.lang.info.operator.CustomOperatorSpec;
+import com.asakusafw.lang.info.operator.FlowOperatorSpec;
+import com.asakusafw.lang.info.operator.InputGroup;
+import com.asakusafw.lang.info.operator.InputOperatorSpec;
+import com.asakusafw.lang.info.operator.MarkerOperatorSpec;
+import com.asakusafw.lang.info.operator.OperatorGraphAttribute;
+import com.asakusafw.lang.info.operator.OperatorSpec.OperatorKind;
+import com.asakusafw.lang.info.operator.OutputOperatorSpec;
+import com.asakusafw.lang.info.operator.UserOperatorSpec;
+import com.asakusafw.lang.info.operator.view.InputView;
+import com.asakusafw.lang.info.operator.view.OperatorGraphView;
+import com.asakusafw.lang.info.operator.view.OperatorView;
+import com.asakusafw.lang.info.operator.view.OutputView;
+import com.asakusafw.lang.info.value.ClassInfo;
+
+import io.airlift.airline.Command;
+import io.airlift.airline.Option;
+
+/**
+ * A command for generating DOT script about operator graphs.
+ * @since 0.4.2
+ */
+@Command(
+        name = "operator",
+        description = "Generates operator graph as Graphviz DOT script",
+        hidden = false
+)
+public class DrawOperatorCommand extends SingleJobflowInfoCommand {
+
+    @Option(
+            name = { "--depth", },
+            title = "depth",
+            description = "limit number of depth",
+            arity = 1,
+            required = false)
+    int limitDepth = Integer.MAX_VALUE;
+
+    @Option(
+            name = { "--flow-part", },
+            title = "class name",
+            description = "only displays in the ",
+            arity = 1,
+            required = false)
+    String flowPart;
+
+    @Option(
+            name = { "--show-argument", },
+            title = "display operator argument",
+            description = "display operator argument",
+            arity = 0,
+            required = false)
+    boolean showArgument = false;
+
+    @Option(
+            name = { "--show-io", },
+            title = "display external I/O class",
+            description = "display external I/O class",
+            arity = 0,
+            required = false)
+    boolean showExternalIo = false;
+
+    @Option(
+            name = { "--show-name", },
+            title = "display port name",
+            description = "display port name",
+            arity = 0,
+            required = false)
+    boolean showPortName = false;
+
+    @Option(
+            name = { "--show-key", },
+            title = "display port key",
+            description = "display port key",
+            arity = 0,
+            required = false)
+    boolean showPortKey = false;
+
+    @Option(
+            name = { "--show-type", },
+            title = "display data type",
+            description = "display data type",
+            arity = 0,
+            required = false)
+    boolean showPortType = false;
+
+    @Option(
+            name = { "--show-all", "-a", },
+            title = "display all information",
+            description = "display all information",
+            arity = 0,
+            required = false)
+    boolean showAll = false;
+
+    @Override
+    protected void process(PrintWriter writer, BatchInfo batch, JobflowInfo jobflow) throws IOException {
+        OperatorGraphView graph = jobflow.findAttribute(OperatorGraphAttribute.class)
+                .map(OperatorGraphView::new)
+                .orElseThrow(() -> new IllegalStateException("there are no available operators"));
+        String label = Optional.ofNullable(jobflow.getDescriptionClass())
+                .map(ClassInfo::of)
+                .map(ClassInfo::getSimpleName)
+                .orElse(jobflow.getId());
+        if (flowPart != null) {
+            OperatorView fp = findFlowPart(graph)
+                    .orElseThrow(() -> new IOException(MessageFormat.format(
+                            "there are no flow part named \"{1}\" in jobflow {0}",
+                            Optional.ofNullable(jobflow.getDescriptionClass())
+                                .orElse(jobflow.getId()),
+                            flowPart)));
+            graph = fp.getElementGraph();
+            label = Optional.of(((FlowOperatorSpec) fp.getSpec()).getDescriptionClass())
+                    .map(ClassInfo::getSimpleName)
+                    .orElse(null);
+        }
+        new Engine(writer, graph).print(label);
+    }
+
+    private Optional<OperatorView> findFlowPart(OperatorGraphView graph) {
+        Queue<OperatorView> queue = new LinkedList<>();
+        getFlowParts(graph).forEach(queue::offer);
+        while (queue.isEmpty() == false) {
+            OperatorView next = queue.poll();
+            assert next.getSpec() instanceof FlowOperatorSpec;
+            if (Optional.ofNullable(((FlowOperatorSpec) next.getSpec()).getDescriptionClass())
+                    .filter(it -> flowPart.equals(it.getClassName()) || flowPart.equals(it.getSimpleName()))
+                    .isPresent()) {
+                return Optional.of(next);
+            } else {
+                getFlowParts(next.getElementGraph()).forEach(queue::offer);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static Stream<OperatorView> getFlowParts(OperatorGraphView graph) {
+        return graph.getOperators().stream().filter(it -> it.getSpec() instanceof FlowOperatorSpec);
+    }
+
+    private class Engine {
+
+        private final PrintWriter writer;
+
+        private final OperatorGraphView root;
+
+        private final Map<Object, Id> ids = new HashMap<>();
+
+        private int idCount = 0;
+
+        private final boolean record;
+
+        Engine(PrintWriter writer, OperatorGraphView graph) {
+            this.writer = writer;
+            this.root = graph;
+            this.record = showAll || showPortName || showPortType || showPortType;
+            computeIds(root, 1);
+        }
+
+        private void computeIds(OperatorGraphView graph, int currentDepth) {
+            for (OperatorView operator : graph.getOperators()) {
+                switch (operator.getSpec().getOperatorKind()) {
+                case INPUT:
+                case OUTPUT:
+                case MARKER:
+                    addSimpleIds(operator);
+                    break;
+                case FLOW:
+                    if (currentDepth < limitDepth) {
+                        computeIds(operator.getElementGraph(), currentDepth + 1);
+                        addFlowIds(operator);
+                    } else {
+                        addGeneralIds(operator);
+                    }
+                    break;
+                default:
+                    addGeneralIds(operator);
+                    break;
+                }
+            }
+        }
+
+        private void addSimpleIds(OperatorView operator) {
+            ids.put(operator, getNextId());
+        }
+
+        private void addGeneralIds(OperatorView operator) {
+            if (record == false) {
+                addSimpleIds(operator);
+                return;
+            }
+            Id id = getNextId();
+            ids.put(operator, id);
+            int index = 0;
+            for (InputView port : operator.getInputs()) {
+                ids.put(port, new Id(id, index++));
+            }
+            for (OutputView port : operator.getOutputs()) {
+                ids.put(port, new Id(id, index++));
+            }
+        }
+
+        private void addFlowIds(OperatorView operator) {
+            OperatorGraphView graph = operator.getElementGraph();
+            ids.put(operator, getNextId());
+
+            Map<String, OperatorView> inputs = graph.getInputs();
+            operator.getInputs().stream().forEach(it -> ids.put(
+                    it,
+                    Optional.ofNullable(inputs.get(it.getName()))
+                        .flatMap(v -> Optional.ofNullable(ids.get(v)))
+                        .orElseThrow(IllegalStateException::new)));
+
+            Map<String, OperatorView> outputs = graph.getOutputs();
+            operator.getOutputs().stream().forEach(it -> ids.put(
+                    it,
+                    Optional.ofNullable(outputs.get(it.getName()))
+                        .flatMap(v -> Optional.ofNullable(ids.get(v)))
+                        .orElseThrow(IllegalStateException::new)));
+        }
+
+        private Id getNextId() {
+            return new Id(null, idCount++);
+        }
+
+        String getId(OperatorView operator) {
+            return Optional.ofNullable(ids.get(operator))
+                    .map(Id::asSimple)
+                    .orElseThrow(IllegalStateException::new);
+        }
+
+        String getSimpleId(InputView port) {
+            return Optional.ofNullable(ids.get(port))
+                    .map(Id::asSimple)
+                    .orElseThrow(IllegalStateException::new);
+        }
+
+        String getSimpleId(OutputView port) {
+            return Optional.ofNullable(ids.get(port))
+                    .map(Id::asSimple)
+                    .orElseThrow(IllegalStateException::new);
+        }
+
+        String getQualifiedId(InputView port) {
+            return Optional.ofNullable(ids.get(port))
+                    .map(Id::asQualified)
+                    .orElseGet(() -> getId(port.getOwner()));
+        }
+
+        String getQualifiedId(OutputView port) {
+            return Optional.ofNullable(ids.get(port))
+                    .map(Id::asQualified)
+                    .orElseGet(() -> getId(port.getOwner()));
+        }
+
+        void print(String label) {
+            writer.println("digraph {");
+            Optional.ofNullable(label)
+                .ifPresent(it -> writer.printf("label=%s;%n", literal(it)));
+            printVertices(root, 1);
+            printEdges(root, 1);
+            writer.println("}");
+        }
+
+        private void printVertices(OperatorGraphView graph, int currentDepth) {
+            for (OperatorView operator : graph.getOperators()) {
+                if (operator.getSpec().getOperatorKind() == OperatorKind.FLOW
+                        && currentDepth < limitDepth) {
+                    FlowOperatorSpec spec = (FlowOperatorSpec) operator.getSpec();
+                    writer.printf("subgraph cluster_%s {%n", getId(operator));
+                    Optional.ofNullable(spec.getDescriptionClass())
+                        .map(ClassInfo::getSimpleName)
+                        .ifPresent(it -> writer.printf("label=%s;%n", literal(it)));
+                    printVertices(operator.getElementGraph(), currentDepth + 1);
+                    writer.println("}");
+                } else {
+                    printVertex(operator);
+                }
+            }
+        }
+
+        private void printVertex(OperatorView operator) {
+            switch (operator.getSpec().getOperatorKind()) {
+            case CORE:
+                printCoreVertex(operator, (CoreOperatorSpec) operator.getSpec());
+                break;
+            case USER:
+                printUserVertex(operator, (UserOperatorSpec) operator.getSpec());
+                break;
+            case INPUT:
+                printInputVertex(operator, (InputOperatorSpec) operator.getSpec());
+                break;
+            case OUTPUT:
+                printOutputVertex(operator, (OutputOperatorSpec) operator.getSpec());
+                break;
+            case FLOW:
+                addFlowVertex(operator, (FlowOperatorSpec) operator.getSpec());
+                break;
+            case MARKER:
+                addMarkerVertex(operator, (MarkerOperatorSpec) operator.getSpec());
+                break;
+            case CUSTOM:
+                addCustomVertex(operator, (CustomOperatorSpec) operator.getSpec());
+                break;
+            default:
+                addGeneralIds(operator);
+                break;
+            }
+        }
+
+        private void printCoreVertex(OperatorView operator, CoreOperatorSpec spec) {
+            List<String> body = new ArrayList<>();
+            body.add('@' + spec.getCategory().getAnnotationType().getSimpleName());
+            body.addAll(analyzeBody(operator));
+            if (record) {
+                printRecord(operator, body);
+            } else {
+                printGeneralVertex(operator, "box", body);
+            }
+        }
+
+        private void printUserVertex(OperatorView operator, UserOperatorSpec spec) {
+            List<String> body = new ArrayList<>();
+            body.add('@' + spec.getAnnotation().getDeclaringClass().getSimpleName());
+            body.add(spec.getDeclaringClass().getSimpleName());
+            body.add(spec.getMethodName());
+            body.addAll(analyzeBody(operator));
+            if (record) {
+                printRecord(operator, body);
+            } else {
+                printGeneralVertex(operator, "box", body);
+            }
+        }
+
+        private void printInputVertex(OperatorView operator, InputOperatorSpec spec) {
+            List<String> body = new ArrayList<>();
+            Optional.ofNullable(spec.getDescriptionClass())
+                .ifPresent(it -> body.add("@Import"));
+            body.add(spec.getName());
+            if (showAll || showPortType) {
+                operator.getOutputs().stream()
+                    .findAny()
+                    .map(OutputView::getDataType)
+                    .map(ClassInfo::getSimpleName)
+                    .ifPresent(body::add);
+            }
+            if (showAll || showExternalIo) {
+                Optional.ofNullable(spec.getDescriptionClass())
+                    .map(ClassInfo::getSimpleName)
+                    .ifPresent(body::add);
+            }
+            body.addAll(analyzeBody(operator));
+            printGeneralVertex(operator, "invhouse", body);
+        }
+
+        private void printOutputVertex(OperatorView operator, OutputOperatorSpec spec) {
+            List<String> body = new ArrayList<>();
+            Optional.ofNullable(spec.getDescriptionClass())
+                .ifPresent(it -> body.add("@Export"));
+            body.add(spec.getName());
+            if (showAll || showPortType) {
+                operator.getInputs().stream()
+                    .findAny()
+                    .map(InputView::getDataType)
+                    .map(ClassInfo::getSimpleName)
+                    .ifPresent(body::add);
+            }
+            if (showAll || showExternalIo) {
+                Optional.ofNullable(spec.getDescriptionClass())
+                    .map(ClassInfo::getSimpleName)
+                    .ifPresent(body::add);
+            }
+            body.addAll(analyzeBody(operator));
+            printGeneralVertex(operator, "invhouse", body);
+        }
+
+        private void addFlowVertex(OperatorView operator, FlowOperatorSpec spec) {
+            List<String> body = new ArrayList<>();
+            body.add("@FlowPart");
+            Optional.ofNullable(spec.getDescriptionClass())
+                .map(ClassInfo::getSimpleName)
+                .ifPresent(body::add);
+            body.addAll(analyzeBody(operator));
+            if (record) {
+                printRecord(operator, body);
+            } else {
+                printGeneralVertex(operator, "box", body);
+            }
+        }
+
+        private void addMarkerVertex(OperatorView operator, MarkerOperatorSpec spec) {
+            List<String> body = new ArrayList<>();
+            body.add("(marker)");
+            body.addAll(analyzeBody(operator));
+            printGeneralVertex(operator, "box", body);
+        }
+
+        private void addCustomVertex(OperatorView operator, CustomOperatorSpec spec) {
+            List<String> body = new ArrayList<>();
+            body.add(spec.getCategory());
+            body.addAll(analyzeBody(operator));
+            if (record) {
+                printRecord(operator, body);
+            } else {
+                printGeneralVertex(operator, "box", body);
+            }
+        }
+
+        private void printRecord(OperatorView operator, List<String> body) {
+            String label = String.format(
+                    "{{%s}|%s|{%s}}",
+                    operator.getInputs().stream()
+                        .map(it -> String.format("<%s>%s",
+                                getSimpleId(it),
+                                analyzeInput(it).stream()
+                                    .map(DrawUtil::escapeForRecord)
+                                    .collect(Collectors.joining("\n"))))
+                        .collect(Collectors.joining("|")),
+                    body.stream()
+                        .map(DrawUtil::escapeForRecord)
+                        .collect(Collectors.joining("\n")),
+                    operator.getOutputs().stream()
+                        .map(it -> String.format("<%s>%s",
+                                getSimpleId(it),
+                                analyzeOutput(it).stream()
+                                    .map(DrawUtil::escapeForRecord)
+                                    .collect(Collectors.joining("\n"))))
+                        .collect(Collectors.joining("|")));
+            printGeneralVertex(operator, "record", Collections.singletonList(label));
+        }
+
+        private List<String> analyzeBody(OperatorView operator) {
+            List<String> results = new ArrayList<>();
+            if (showAll || showArgument) {
+                operator.getParameters().stream()
+                    .map(it -> String.format("%s: %s", it.getName(), it.getValue().getObject()))
+                    .forEachOrdered(results::add);
+            }
+            return results;
+        }
+
+        private List<String> analyzeInput(InputView port) {
+            List<String> results = new ArrayList<>();
+            if (showAll || showPortName) {
+                results.add(port.getName());
+            }
+            if (showAll || showPortType) {
+                results.add(port.getDataType().getSimpleName());
+            }
+            if (showAll || showPortKey) {
+                results.add(port.getGranulatity().toString());
+                Optional.ofNullable(port.getGroup())
+                    .map(InputGroup::toString)
+                    .ifPresent(results::add);
+            }
+            return results;
+        }
+
+        private List<String> analyzeOutput(OutputView port) {
+            List<String> results = new ArrayList<>();
+            if (showAll || showPortName) {
+                results.add(port.getName());
+            }
+            if (showAll || showPortType) {
+                results.add(port.getDataType().getSimpleName());
+            }
+            return results;
+        }
+
+        private void printGeneralVertex(OperatorView operator, String shape, List<String> label) {
+            writer.printf("%s [shape=%s, label=%s];%n",
+                    getId(operator),
+                    literal(shape),
+                    literal(String.join("\n", label)));
+        }
+
+        private void printEdges(OperatorGraphView graph, int currentDepth) {
+            for (OperatorView operator : graph.getOperators()) {
+                printEdge(operator);
+                if (operator.getSpec().getOperatorKind() == OperatorKind.FLOW
+                        && currentDepth < limitDepth) {
+                    printEdges(operator.getElementGraph(), currentDepth + 1);
+                }
+            }
+        }
+
+        private void printEdge(OperatorView operator) {
+            // NOTE: we only put upstream -> downstream edges
+            for (OutputView out : operator.getOutputs()) {
+                String upstream = getQualifiedId(out);
+                for (InputView in : out.getOpposites()) {
+                    String downstream = getQualifiedId(in);
+                    writer.printf("%s -> %s;%n",
+                            upstream,
+                            downstream);
+                }
+            }
+        }
+    }
+
+    private static class Id {
+
+        final Id parent;
+
+        final int value;
+
+        Id(Id parent, int value) {
+            this.parent = parent;
+            this.value = value;
+        }
+
+        String asSimple() {
+            return '_' + Integer.toString(value, 36);
+        }
+
+        String asQualified() {
+            if (parent == null) {
+                return asSimple();
+            } else {
+                return parent.asSimple() + ':' + asSimple();
+            }
+        }
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/DrawUsageCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/DrawUsageCommand.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.cli;
+
+import io.airlift.airline.Command;
+
+/**
+ * A command for printing help of draw group.
+ * @since 0.4.2
+ */
+@Command(
+        name = "help",
+        description = "Displays help",
+        hidden = false
+)
+public class DrawUsageCommand extends GroupUsageCommand {
+
+    /**
+     * Creates a new instance.
+     */
+    public DrawUsageCommand() {
+        super("draw");
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/DrawUtil.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/DrawUtil.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.cli;
+
+final class DrawUtil {
+
+    private DrawUtil() {
+        return;
+    }
+
+    static String literal(String string) {
+        StringBuilder buf = new StringBuilder();
+        buf.append('"');
+        for (char c : string.toCharArray()) {
+            if (c == '\\' || c == '"') {
+                buf.append('\\');
+                buf.append(c);
+            } else if (c == '\n') {
+                buf.append('\\');
+                buf.append('n');
+            } else {
+                buf.append(c);
+            }
+        }
+        buf.append('"');
+        return buf.toString();
+    }
+
+    static String escapeForRecord(CharSequence string) {
+        StringBuilder buf = new StringBuilder();
+        for (int i = 0, n = string.length(); i < n; i++) {
+            char c = string.charAt(i);
+            if (c == '{' || c == '<') {
+                buf.append('(');
+            } else if (c == '}' || c == '>') {
+                buf.append(')');
+            } else if (c == '|') {
+                buf.append('/');
+            } else {
+                buf.append(c);
+            }
+        }
+        return buf.toString();
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/GroupUsageCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/GroupUsageCommand.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.cli;
+
+import java.io.PrintWriter;
+import java.util.Collections;
+
+import javax.inject.Inject;
+
+import io.airlift.airline.Help;
+import io.airlift.airline.Option;
+import io.airlift.airline.model.GlobalMetadata;
+
+/**
+ * A command for printing help of group.
+ * @since 0.4.2
+ */
+public class GroupUsageCommand extends BaseCommand {
+
+    private final String groupName;
+
+    @Inject
+    GlobalMetadata metadata;
+
+    @Option(
+            name = { "--verbose", "-v", },
+            title = "verbose mode",
+            description = "verbose mode",
+            arity = 0,
+            required = false)
+    boolean showVerbose = false;
+
+    /**
+     * Creates a new instance.
+     * @param groupName the group name
+     */
+    protected GroupUsageCommand(String groupName) {
+        this.groupName = groupName;
+    }
+
+    @Override
+    protected Status process(PrintWriter writer) {
+        if (showVerbose) {
+            StringBuilder buf = new StringBuilder();
+            Help.help(metadata, Collections.singletonList(groupName), buf);
+            writer.print(buf);
+        } else {
+            writer.printf("usage: %s %s <sub-command> [<args>]%n", metadata.getName(), groupName);
+            writer.println();
+            writer.println("The available sub-commands are:");
+            metadata.getCommandGroups().stream()
+                .filter(it -> it.getName().equals(groupName))
+                .findAny()
+                .get()
+                .getCommands()
+                .forEach(it -> writer.printf("    %s - %s%n", it.getName(), it.getDescription()));
+            writer.println();
+            writer.printf("See '%s help %s <sub-command>' for more information on a specific sub-command.%n",
+                    metadata.getName(),
+                    groupName);
+        }
+        return Status.SUCCESS;
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/Info.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/Info.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.cli;
+
+import java.util.Arrays;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.airlift.airline.Cli;
+import io.airlift.airline.Help;
+import io.airlift.airline.ParseException;
+
+/**
+ * CLI entry for information models.
+ * @since 0.4.2
+ */
+public final class Info {
+
+    static final Logger LOG = LoggerFactory.getLogger(Info.class);
+
+    private Info() {
+        return;
+    }
+
+    /**
+     * Program entry.
+     * @param args command line tokens
+     */
+    public static void main(String... args) {
+        int status = exec(args);
+        if (status != 0) {
+            System.exit(status);
+        }
+    }
+
+    static int exec(String... args) {
+        Cli.CliBuilder<Runnable> builder = Cli.<Runnable>builder("java -jar asakusa-info.jar")
+                .withDefaultCommand(Help.class)
+                .withCommand(Help.class);
+
+        builder.withGroup("list")
+            .withDescription("Displays information list")
+            .withDefaultCommand(ListUsageCommand.class)
+            .withCommand(ListBatchCommand.class)
+            .withCommand(ListParameterCommand.class)
+            .withCommand(ListJobflowCommand.class)
+            .withCommand(ListOperatorCommand.class)
+            .withCommand(ListDirectFileInputCommand.class)
+            .withCommand(ListDirectFileOutputCommand.class)
+            .withCommand(ListWindGateInputCommand.class)
+            .withCommand(ListWindGateOutputCommand.class);
+
+        builder.withGroup("draw")
+            .withDescription("Generates Graphviz DOT scripts")
+            .withDefaultCommand(DrawUsageCommand.class)
+            .withCommand(DrawJobflowCommand.class)
+            .withCommand(DrawOperatorCommand.class);
+
+        Cli<Runnable> cli = builder.build();
+        Runnable command;
+        try {
+            command = cli.parse(args);
+        } catch (ParseException e) {
+            LOG.error("Cannot recognize command, please type \"help\" to show command information: {}",
+                    Arrays.toString(args),
+                    e);
+            return 1;
+        }
+        command.run();
+        if (command instanceof BaseCommand) {
+            switch (((BaseCommand) command).getStatus()) {
+            case PREPARE_ERROR:
+                return 1;
+            case PROCESS_ERROR:
+                return 2;
+            case SUCCESS:
+                return 0;
+            default:
+                return -1;
+            }
+        } else {
+            return 0;
+        }
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/InfoCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/InfoCommand.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.cli;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.text.MessageFormat;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.lang.info.BatchInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.airlift.airline.Arguments;
+
+/**
+ * An abstract implementation of information commands.
+ * @since 0.4.2
+ */
+public abstract class InfoCommand extends BaseCommand {
+
+    private static final Logger LOG = LoggerFactory.getLogger(InfoCommand.class);
+
+    @Arguments(
+            title = "batch ID",
+            description = "batch ID, directory or information file",
+            required = true,
+            usage = "batch.id")
+    File input;
+
+    @Override
+    protected final Status process(PrintWriter writer) {
+        File infoFile = getInfoFile();
+        LOG.debug("loading info file: {}", input);
+
+        ObjectMapper mapper = new ObjectMapper();
+        BatchInfo info;
+        try {
+            info = mapper.readValue(infoFile, BatchInfo.class);
+        } catch (IOException e) {
+            LOG.error("error occurred while loading batch information: {}", infoFile, e);
+            return Status.PREPARE_ERROR;
+        }
+        try {
+            process(writer, info);
+            return Status.SUCCESS;
+        } catch (IOException e) {
+            LOG.error("error occurred while processing batch information: {}", infoFile, e);
+            return Status.PROCESS_ERROR;
+        }
+    }
+
+    private File getInfoFile() {
+        if (input == null) {
+            throw new IllegalStateException();
+        }
+        // just batch-info.json
+        if (input.isFile()) {
+            return input;
+        }
+        // may be a batch directory
+        if (input.isDirectory()) {
+            Optional<File> info = ListUtil.findBatchInfo(input);
+            if (info.isPresent()) {
+                return info.get();
+            }
+        }
+        // may be a batch ID
+        if (input.isAbsolute() == false
+                && Objects.equals(input.getPath(), input.getName())
+                && ListUtil.ASAKUSA_BATCHAPPS_HOME != null) {
+            Optional<File> info = ListUtil.findBatchInfo(new File(ListUtil.ASAKUSA_BATCHAPPS_HOME, input.getName()));
+            if (info.isPresent()) {
+                return info.get();
+            }
+        }
+        // not found
+        throw new IllegalStateException(MessageFormat.format(
+                "cannot find valid Asakusa batch application information: {0}",
+                input));
+    }
+
+    /**
+     * Processes the batch information.
+     * @param writer the output printer
+     * @param info the information
+     * @throws IOException if I/O error was occurred while processing the file
+     */
+    protected abstract void process(PrintWriter writer, BatchInfo info) throws IOException;
+}

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/JobflowInfoCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/JobflowInfoCommand.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.cli;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import com.asakusafw.lang.info.BatchInfo;
+import com.asakusafw.lang.info.JobflowInfo;
+
+import io.airlift.airline.Option;
+
+/**
+ * An abstract implementation of jobflow processing commands.
+ * @since 0.4.2
+ */
+public abstract class JobflowInfoCommand extends InfoCommand {
+
+    @Option(
+            name = { "--jobflow", "-j", },
+            title = "flow-id",
+            description = "target flow ID",
+            arity = 1,
+            required = false)
+    String flowId;
+
+    @Override
+    protected final void process(PrintWriter writer, BatchInfo info) throws IOException {
+        List<JobflowInfo> candidates = new ArrayList<>(info.getJobflows());
+        if (candidates.isEmpty()) {
+            throw new IOException(MessageFormat.format(
+                    "there are no available jobflows in batch: {0}",
+                    info.getId()));
+        }
+        if (flowId != null) {
+            candidates = candidates.stream()
+                    .filter(it -> Objects.equals(it.getId(), flowId))
+                    .collect(Collectors.toList());
+            if (candidates.isEmpty()) {
+                throw new IOException(MessageFormat.format(
+                        "there is no jobflow with flow ID \"{0}\", must be one of: '{'{1}'}'",
+                        info.getId(),
+                        info.getJobflows().stream()
+                            .map(JobflowInfo::getId)
+                            .sorted()
+                            .collect(Collectors.joining(", "))));
+            }
+        }
+        process(writer, info, candidates);
+    }
+
+    /**
+     * Processes the batch information.
+     * @param writer the output printer
+     * @param batch the batch information
+     * @param jobflows the process targets, never empty
+     * @throws IOException if I/O error was occurred while processing the file
+     */
+    protected abstract void process(
+            PrintWriter writer,
+            BatchInfo batch,
+            List<JobflowInfo> jobflows) throws IOException;
+}

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/ListBatchCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/ListBatchCommand.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.cli;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.lang.info.BatchInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.airlift.airline.Arguments;
+import io.airlift.airline.Command;
+import io.airlift.airline.Option;
+
+/**
+ * A command for printing list of batch.
+ * @since 0.4.2
+ */
+@Command(
+        name = "batch",
+        description = "Displays list of batches",
+        hidden = false
+)
+public class ListBatchCommand extends BaseCommand {
+
+    static final Logger LOG = LoggerFactory.getLogger(ListBatchCommand.class);
+
+    @Arguments(
+            title = "batchapps",
+            description = "batch applications directory",
+            required = false,
+            usage = "/path/to/batchapps")
+    File batchApplicationDir = ListUtil.ASAKUSA_BATCHAPPS_HOME;
+
+    @Option(
+            name = { "--verbose", "-v", },
+            title = "verbose mode",
+            description = "verbose mode",
+            arity = 0,
+            required = false)
+    boolean showVerbose = false;
+
+    @Override
+    protected Status process(PrintWriter writer) {
+        if (batchApplicationDir == null) {
+            LOG.error("batch applications directory is not specified");
+            return Status.PREPARE_ERROR;
+        }
+        List<File> batchapps = Optional.ofNullable(batchApplicationDir.listFiles())
+            .map(Arrays::asList)
+            .orElse(Collections.emptyList())
+            .stream()
+            .filter(it -> ListUtil.findBatchInfo(it).isPresent())
+            .sorted(Comparator.comparing(File::getName))
+            .collect(Collectors.toList());
+        if (showVerbose) {
+            ObjectMapper mapper = new ObjectMapper();
+            for (File batchapp : batchapps) {
+                File infoFile = ListUtil.findBatchInfo(batchapp).get();
+                try {
+                    BatchInfo info = mapper.readValue(infoFile, BatchInfo.class);
+                    Map<String, Object> members = new LinkedHashMap<>();
+                    members.put("class", info.getDescriptionClass());
+                    members.put("comment", info.getComment());
+                    writer.printf("%s:%n", info.getId());
+                    ListUtil.printBlock(writer, 4, members);
+                } catch (IOException e) {
+                    LOG.error("error occurred while loading batch information: {}", infoFile, e);
+                }
+            }
+        } else {
+            batchapps.forEach(it -> writer.println(it.getName()));
+        }
+        return Status.SUCCESS;
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/ListDirectFileInputCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/ListDirectFileInputCommand.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.cli;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.asakusafw.lang.info.BatchInfo;
+import com.asakusafw.lang.info.JobflowInfo;
+import com.asakusafw.lang.info.directio.DirectFileInputInfo;
+import com.asakusafw.lang.info.directio.DirectFileIoAttribute;
+
+import io.airlift.airline.Command;
+import io.airlift.airline.Option;
+
+/**
+ * A command for printing list of direct file inputs.
+ * @since 0.4.2
+ */
+@Command(
+        name = "directio-input",
+        description = "Displays direct file input uses",
+        hidden = false
+)
+public class ListDirectFileInputCommand extends JobflowInfoCommand {
+
+    @Option(
+            name = { "--verbose", "-v", },
+            title = "verbose mode",
+            description = "verbose mode",
+            arity = 0,
+            required = false)
+    boolean showVerbose = false;
+
+    @Override
+    protected void process(PrintWriter writer, BatchInfo batch, List<JobflowInfo> jobflows) throws IOException {
+        jobflows.stream()
+            .flatMap(jobflow -> jobflow.getAttributes().stream())
+            .filter(it -> it instanceof DirectFileIoAttribute)
+            .map(it -> (DirectFileIoAttribute) it)
+            .flatMap(it -> it.getInputs().stream())
+            .sorted(Comparator
+                    .comparing(DirectFileInputInfo::getBasePath)
+                    .thenComparing(DirectFileInputInfo::getResourcePattern))
+            .forEachOrdered(info -> {
+                if (showVerbose) {
+                    Map<String, Object> members = new LinkedHashMap<>();
+                    members.put("base-path", info.getBasePath());
+                    members.put("resource-pattern", info.getResourcePattern());
+                    members.put("data-type", info.getDataType());
+                    members.put("filter-class", info.getFilterClass());
+                    members.put("format-class", info.getFormatClass());
+                    members.put("optional", info.isOptional());
+                    writer.printf("%s:%n", info.getDescriptionClass());
+                    ListUtil.printBlock(writer, 4, members);
+                } else {
+                    writer.printf("%s::%s%n", info.getBasePath(), info.getResourcePattern());
+                }
+            });
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/ListDirectFileOutputCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/ListDirectFileOutputCommand.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.cli;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.asakusafw.lang.info.BatchInfo;
+import com.asakusafw.lang.info.JobflowInfo;
+import com.asakusafw.lang.info.directio.DirectFileOutputInfo;
+import com.asakusafw.lang.info.directio.DirectFileIoAttribute;
+
+import io.airlift.airline.Command;
+import io.airlift.airline.Option;
+
+/**
+ * A command for printing list of direct file outputs.
+ * @since 0.4.2
+ */
+@Command(
+        name = "directio-output",
+        description = "Displays direct file output uses",
+        hidden = false
+)
+public class ListDirectFileOutputCommand extends JobflowInfoCommand {
+
+    @Option(
+            name = { "--verbose", "-v", },
+            title = "verbose mode",
+            description = "verbose mode",
+            arity = 0,
+            required = false)
+    boolean showVerbose = false;
+
+    @Override
+    protected void process(PrintWriter writer, BatchInfo batch, List<JobflowInfo> jobflows) throws IOException {
+        jobflows.stream()
+            .flatMap(jobflow -> jobflow.getAttributes().stream())
+            .filter(it -> it instanceof DirectFileIoAttribute)
+            .map(it -> (DirectFileIoAttribute) it)
+            .flatMap(it -> it.getOutputs().stream())
+            .sorted(Comparator
+                    .comparing(DirectFileOutputInfo::getBasePath)
+                    .thenComparing(DirectFileOutputInfo::getResourcePattern))
+            .forEachOrdered(info -> {
+                if (showVerbose) {
+                    Map<String, Object> members = new LinkedHashMap<>();
+                    members.put("base-path", info.getBasePath());
+                    members.put("resource-pattern", info.getResourcePattern());
+                    members.put("order", info.getOrder());
+                    members.put("delete-patterns", info.getDeletePatterns());
+                    members.put("data-type", info.getDataType());
+                    members.put("format-class", info.getFormatClass());
+                    writer.printf("%s:%n", info.getDescriptionClass());
+                    ListUtil.printBlock(writer, 4, members);
+                } else {
+                    writer.printf("%s::%s%n", info.getBasePath(), info.getResourcePattern());
+                }
+            });
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/ListJobflowCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/ListJobflowCommand.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.cli;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.asakusafw.lang.info.BatchInfo;
+import com.asakusafw.lang.info.JobflowInfo;
+
+import io.airlift.airline.Command;
+import io.airlift.airline.Option;
+
+/**
+ * A command for printing list of jobflows.
+ * @since 0.4.2
+ */
+@Command(
+        name = "jobflow",
+        description = "Displays list of jobflows",
+        hidden = false
+)
+public class ListJobflowCommand extends InfoCommand {
+
+    @Option(
+            name = { "--verbose", "-v", },
+            title = "verbose mode",
+            description = "verbose mode",
+            arity = 0,
+            required = false)
+    boolean showVerbose = false;
+
+    @Override
+    protected void process(PrintWriter writer, BatchInfo info) throws IOException {
+        if (showVerbose) {
+            for (JobflowInfo jobflow : info.getJobflows()) {
+                Map<String, Object> members = new LinkedHashMap<>();
+                members.put("class", jobflow.getDescriptionClass());
+                writer.printf("%s:%n", jobflow.getId());
+                ListUtil.printBlock(writer, 4, members);
+            }
+        } else {
+            info.getJobflows().forEach(it -> writer.println(it.getId()));
+        }
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/ListOperatorCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/ListOperatorCommand.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.cli;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.asakusafw.lang.info.BatchInfo;
+import com.asakusafw.lang.info.JobflowInfo;
+import com.asakusafw.lang.info.operator.FlowOperatorSpec;
+import com.asakusafw.lang.info.operator.OperatorGraphAttribute;
+import com.asakusafw.lang.info.operator.UserOperatorSpec;
+import com.asakusafw.lang.info.operator.view.OperatorGraphView;
+import com.asakusafw.lang.info.operator.view.OperatorView;
+
+import io.airlift.airline.Command;
+import io.airlift.airline.Option;
+
+/**
+ * A command for printing operators.
+ * @since 0.4.2
+ */
+@Command(
+        name = "operator",
+        description = "Displays operator uses",
+        hidden = false
+)
+public class ListOperatorCommand extends JobflowInfoCommand {
+
+    @Option(
+            name = { "--verbose", "-v", },
+            title = "verbose mode",
+            description = "verbose mode",
+            arity = 0,
+            required = false)
+    boolean showVerbose = false;
+
+    @Override
+    protected void process(PrintWriter writer, BatchInfo batch, List<JobflowInfo> jobflows) throws IOException {
+        jobflows.stream()
+            .flatMap(jobflow -> jobflow.getAttributes().stream())
+            .filter(it -> it instanceof OperatorGraphAttribute)
+            .map(it -> new OperatorGraphView((OperatorGraphAttribute) it))
+            .flatMap(this::extract)
+            .filter(it -> it.getSpec() instanceof UserOperatorSpec)
+            .map(it -> new UserOp(it, showVerbose))
+            .distinct()
+            .sorted(Comparator
+                    .comparing((UserOp it) -> it.spec().getDeclaringClass().getName())
+                    .thenComparing((UserOp it) -> it.spec().getMethodName()))
+            .forEach(it -> {
+                if (showVerbose) {
+                    writer.printf("%s#%s(@%s){%s}%n",
+                            it.spec().getDeclaringClass().getClassName(),
+                            it.spec().getMethodName(),
+                            it.spec().getAnnotation().getDeclaringClass().getSimpleName(),
+                            it.entity.getParameters().stream()
+                                .map(p -> String.format("%s:%s=%s",
+                                        p.getName(),
+                                        p.getType().getSimpleName(),
+                                        p.getValue().getObject()))
+                                .collect(Collectors.joining(", ")));
+                } else {
+                    writer.printf("%s#%s(@%s)%n",
+                            it.spec().getDeclaringClass().getSimpleName(),
+                            it.spec().getMethodName(),
+                            it.spec().getAnnotation().getDeclaringClass().getSimpleName());
+                }
+            });
+    }
+
+    private Stream<OperatorView> extract(OperatorGraphView graph) {
+        return graph.getOperators().stream()
+                .flatMap(it -> {
+                    if (it.getSpec() instanceof FlowOperatorSpec) {
+                        return extract(it.getElementGraph());
+                    } else {
+                        return Stream.of(it);
+                    }
+                });
+    }
+
+    private static class UserOp {
+
+        final OperatorView entity;
+
+        final boolean verbose;
+
+        UserOp(OperatorView entity, boolean verbose) {
+            this.entity = entity;
+            this.verbose = verbose;
+        }
+
+        UserOperatorSpec spec() {
+            return (UserOperatorSpec) entity.getSpec();
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(entity);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            UserOp other = (UserOp) obj;
+            if (verbose) {
+                return Objects.equals(entity.getSpec(), other.entity.getSpec())
+                        && Objects.equals(entity.getParameters(), entity.getParameters());
+            } else {
+                return Objects.equals(entity.getSpec(), other.entity.getSpec());
+            }
+        }
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/ListParameterCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/ListParameterCommand.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.cli;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.text.MessageFormat;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.asakusafw.lang.info.BatchInfo;
+import com.asakusafw.lang.info.ParameterListAttribute;
+
+import io.airlift.airline.Command;
+import io.airlift.airline.Option;
+
+/**
+ * A command for printing list of batch parameters.
+ * @since 0.4.2
+ */
+@Command(
+        name = "parameter",
+        description = "Displays list of batch parameters",
+        hidden = false
+)
+public class ListParameterCommand extends InfoCommand {
+
+    @Option(
+            name = { "--verbose", "-v", },
+            title = "verbose mode",
+            description = "verbose mode",
+            arity = 0,
+            required = false)
+    boolean showVerbose = false;
+
+    @Override
+    protected void process(PrintWriter writer, BatchInfo info) throws IOException {
+        ParameterListAttribute attr = info.findAttribute(ParameterListAttribute.class)
+                .orElseThrow(() -> new IOException(MessageFormat.format(
+                        "there are no batch parameter information in {0} ({1})",
+                        info.getId(),
+                        ListUtil.normalize(info.getDescriptionClass()))));
+        if (showVerbose) {
+            attr.getElements().forEach(it -> {
+                Map<String, Object> members = new LinkedHashMap<>();
+                members.put("comment", it.getComment());
+                members.put("pattern", it.getPattern());
+                members.put("mandatory", it.isMandatory());
+                writer.printf("%s:%n", it.getName());
+                ListUtil.printBlock(writer, 4, members);
+            });
+        } else {
+            attr.getElements().forEach(writer::println);
+        }
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/ListUsageCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/ListUsageCommand.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.cli;
+
+import io.airlift.airline.Command;
+
+/**
+ * A command for printing usage of list group.
+ * @since 0.4.2
+ */
+@Command(
+        name = "usage",
+        description = "Displays usage of list group",
+        hidden = false
+)
+public class ListUsageCommand extends GroupUsageCommand {
+
+    /**
+     * Creates a new instance.
+     */
+    public ListUsageCommand() {
+        super("list");
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/ListUtil.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/ListUtil.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.cli;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+final class ListUtil {
+
+    static final String ENV_ASAKUSA_HOME = "ASAKUSA_HOME";
+
+    static final File ASAKUSA_BATCHAPPS_HOME;
+    static {
+        ASAKUSA_BATCHAPPS_HOME = Stream.of(
+            Optional.ofNullable(System.getenv("ASAKUSA_BATCHAPPS_HOME"))
+                .map(it -> it.trim())
+                .filter(it -> it.isEmpty() == false)
+                .map(File::new),
+            Optional.ofNullable(System.getenv(ENV_ASAKUSA_HOME))
+                .map(it -> it.trim())
+                .filter(it -> it.isEmpty() == false)
+                .map(File::new)
+                .map(it -> new File(it, "batchapps")))
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .filter(File::isDirectory)
+            .findFirst()
+            .orElse(null);
+    }
+
+    static final String PATH_BATCH_INFO = "etc/batch-info.json";
+
+    private ListUtil() {
+        return;
+    }
+
+    static Optional<File> findBatchInfo(File batchapp) {
+        return Optional.ofNullable(batchapp)
+                .map(it -> new File(batchapp, PATH_BATCH_INFO))
+                .filter(File::isFile);
+    }
+
+    static String normalize(Object value) {
+        return Optional.ofNullable(value)
+                .map(String::valueOf)
+                .orElse("N/A");
+    }
+
+    private static String padding(int count) {
+        if (count < 0) {
+            return "";
+        }
+        StringBuilder buf = new StringBuilder(count);
+        for (int i = 0; i < count; i++) {
+            buf.append(' ');
+        }
+        return buf.toString();
+    }
+
+    static void printBlock(PrintWriter writer, int indent, Map<String, Object> members) {
+        if (members.isEmpty()) {
+            return;
+        }
+        int maxKeyLen = members.keySet().stream()
+                .mapToInt(String::length)
+                .max()
+                .getAsInt();
+        members.forEach((k, v) -> {
+            writer.printf("%s%s: %s%n",
+                    padding(indent + maxKeyLen - k.length()),
+                    k,
+                    normalize(v));
+        });
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/ListWindGateInputCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/ListWindGateInputCommand.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.cli;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.asakusafw.lang.info.BatchInfo;
+import com.asakusafw.lang.info.JobflowInfo;
+import com.asakusafw.lang.info.windgate.WindGateInputInfo;
+import com.asakusafw.lang.info.windgate.WindGateIoAttribute;
+
+import io.airlift.airline.Command;
+import io.airlift.airline.Option;
+
+/**
+ * A command for printing list of WindGate inputs.
+ * @since 0.4.2
+ */
+@Command(
+        name = "windgate-input",
+        description = "Displays WindGate input uses",
+        hidden = false
+)
+public class ListWindGateInputCommand extends JobflowInfoCommand {
+
+    @Option(
+            name = { "--verbose", "-v", },
+            title = "verbose mode",
+            description = "verbose mode",
+            arity = 0,
+            required = false)
+    boolean showVerbose = false;
+
+    @Override
+    protected void process(PrintWriter writer, BatchInfo batch, List<JobflowInfo> jobflows) throws IOException {
+        jobflows.stream()
+            .flatMap(jobflow -> jobflow.getAttributes().stream())
+            .filter(it -> it instanceof WindGateIoAttribute)
+            .map(it -> (WindGateIoAttribute) it)
+            .flatMap(it -> it.getInputs().stream())
+            .sorted(Comparator.comparing(WindGateInputInfo::getName))
+            .forEachOrdered(info -> {
+                Map<String, Object> members = new LinkedHashMap<>();
+                members.put("profile-name", info.getProfileName());
+                members.put("resource-name", info.getResourceName());
+                members.putAll(info.getConfiguration());
+                writer.printf("%s:%n", info.getDescriptionClass());
+                ListUtil.printBlock(writer, 4, members);
+            });
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/ListWindGateOutputCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/ListWindGateOutputCommand.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.cli;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.asakusafw.lang.info.BatchInfo;
+import com.asakusafw.lang.info.JobflowInfo;
+import com.asakusafw.lang.info.windgate.WindGateIoAttribute;
+import com.asakusafw.lang.info.windgate.WindGateOutputInfo;
+
+import io.airlift.airline.Command;
+import io.airlift.airline.Option;
+
+/**
+ * A command for printing list of WindGate outputs.
+ * @since 0.4.2
+ */
+@Command(
+        name = "windgate-output",
+        description = "Displays WindGate output uses",
+        hidden = false
+)
+public class ListWindGateOutputCommand extends JobflowInfoCommand {
+
+    @Option(
+            name = { "--verbose", "-v", },
+            title = "verbose mode",
+            description = "verbose mode",
+            arity = 0,
+            required = false)
+    boolean showVerbose = false;
+
+    @Override
+    protected void process(PrintWriter writer, BatchInfo batch, List<JobflowInfo> jobflows) throws IOException {
+        jobflows.stream()
+            .flatMap(jobflow -> jobflow.getAttributes().stream())
+            .filter(it -> it instanceof WindGateIoAttribute)
+            .map(it -> (WindGateIoAttribute) it)
+            .flatMap(it -> it.getOutputs().stream())
+            .sorted(Comparator.comparing(WindGateOutputInfo::getName))
+            .forEachOrdered(info -> {
+                Map<String, Object> members = new LinkedHashMap<>();
+                members.put("profile-name", info.getProfileName());
+                members.put("resource-name", info.getResourceName());
+                members.putAll(info.getConfiguration());
+                writer.printf("%s:%n", info.getDescriptionClass());
+                ListUtil.printBlock(writer, 4, members);
+            });
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/SingleJobflowInfoCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/SingleJobflowInfoCommand.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.cli;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.asakusafw.lang.info.BatchInfo;
+import com.asakusafw.lang.info.JobflowInfo;
+
+/**
+ * An abstract implementation of single jobflow processing commands.
+ * @since 0.4.2
+ */
+public abstract class SingleJobflowInfoCommand extends JobflowInfoCommand {
+
+    @Override
+    protected final void process(
+            PrintWriter writer,
+            BatchInfo batch,
+            List<JobflowInfo> jobflows) throws IOException {
+        if (jobflows.size() != 1) {
+            throw new IOException(MessageFormat.format(
+                    "target jobflow is ambiguous, please specify \"--jobflow <flow-ID>\": '{'{0}'}'",
+                    jobflows.stream()
+                        .map(JobflowInfo::getId)
+                        .collect(Collectors.joining(", "))));
+        }
+        process(writer, batch, jobflows.get(0));
+    }
+
+    /**
+     * Processes the batch information.
+     * @param writer the output printer
+     * @param batch the batch information
+     * @param jobflow the process target jobflow
+     * @throws IOException if I/O error was occurred while processing the file
+     */
+    protected abstract void process(
+            PrintWriter writer,
+            BatchInfo batch,
+            JobflowInfo jobflow) throws IOException;
+}

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/package-info.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * CLI for information models.
+ */
+package com.asakusafw.lang.info.cli;

--- a/info/model/pom.xml
+++ b/info/model/pom.xml
@@ -34,10 +34,12 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/info/model/src/main/java/com/asakusafw/lang/info/Attribute.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/Attribute.java
@@ -15,6 +15,8 @@
  */
 package com.asakusafw.lang.info;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
@@ -31,9 +33,12 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 public interface Attribute {
 
     /**
-     * Returns the attribute ID.
+     * Returns the attribute ID (optional).
      * @return the attribute ID
      */
     @JsonProperty
-    String getId();
+    @JsonInclude(Include.NON_NULL)
+    default String getId() {
+        return null;
+    }
 }

--- a/info/model/src/main/java/com/asakusafw/lang/info/ElementInfo.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/ElementInfo.java
@@ -16,6 +16,7 @@
 package com.asakusafw.lang.info;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Represents a DSL element.
@@ -40,4 +41,18 @@ public interface ElementInfo {
      * @return the attributes
      */
     List<? extends Attribute> getAttributes();
+
+    /**
+     * Returns an attribute of this elements.
+     * @param <T> the attribute type
+     * @param type the attribute type
+     * @return the attribute, or empty if it is not found
+     * @since 0.4.2
+     */
+    default <T extends Attribute> Optional<T> findAttribute(Class<T> type) {
+        return getAttributes().stream()
+                .filter(type::isInstance)
+                .map(type::cast)
+                .findFirst();
+    }
 }

--- a/info/model/src/main/java/com/asakusafw/lang/info/graph/AbstractElement.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/graph/AbstractElement.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.graph;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+import com.asakusafw.lang.info.Attribute;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+
+@JsonAutoDetect(
+        creatorVisibility = Visibility.NONE,
+        fieldVisibility = Visibility.NONE,
+        getterVisibility = Visibility.NONE,
+        isGetterVisibility = Visibility.NONE,
+        setterVisibility = Visibility.NONE
+)
+abstract class AbstractElement<TSelf extends AbstractElement<TSelf>> implements Element {
+
+    @SuppressWarnings("unchecked")
+    TSelf self() {
+        return (TSelf) this;
+    }
+
+    abstract ElementId id();
+
+    abstract List<Attribute> attributes();
+
+    /**
+     * Configures this object.
+     * @param configure the configurator
+     * @return this
+     */
+    public TSelf configure(Consumer<? super TSelf> configure) {
+        if (configure != null) {
+            configure.accept(self());
+        }
+        return self();
+    }
+
+    @Override
+    public List<? extends Attribute> getAttributes() {
+        return Collections.unmodifiableList(attributes());
+    }
+
+    @Override
+    public TSelf withAttribute(Attribute attribute) {
+        attributes().add(attribute);
+        return self();
+    }
+
+    @Override
+    public TSelf withAttributes(List<? extends Attribute> attributes) {
+        attributes().addAll(attributes);
+        return self();
+    }
+
+    @Override
+    public TSelf withAttributes(Attribute... attributes) {
+        return withAttributes(Arrays.asList(attributes));
+    }
+
+    @Override
+    public String toString() {
+        return id().toString();
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/graph/Constants.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/graph/Constants.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.graph;
+
+final class Constants {
+
+    static final String ID_ID = "id";
+
+    static final String ID_ATTRIBUTES = "attributes";
+
+    static final String ID_NODE_INPUTS = "inputs";
+
+    static final String ID_NODE_OUTPUTS = "outputs";
+
+    static final String ID_NODE_WIRES = "wires";
+
+    static final String ID_NODE_ELEMENTS = "elements";
+
+    static final String ID_WIRE_UPSTREAM = "source";
+
+    static final String ID_WIRE_DOWNSTREAM = "destination";
+
+    private Constants() {
+        return;
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/graph/Element.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/graph/Element.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.graph;
+
+import java.util.List;
+
+import com.asakusafw.lang.info.Attribute;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+
+/**
+ * An abstract super class of elements on graph.
+ * @since 0.4.2
+ */
+@JsonAutoDetect(
+        creatorVisibility = Visibility.NONE,
+        fieldVisibility = Visibility.NONE,
+        getterVisibility = Visibility.NONE,
+        isGetterVisibility = Visibility.NONE,
+        setterVisibility = Visibility.NONE
+)
+public interface Element {
+
+    /**
+     * Returns the parent element of this.
+     * @return the parent element, or {@code null} if this is root element
+     */
+    Element getParent();
+
+    /**
+     * Returns the attributes of this element.
+     * @return the attributes
+     */
+    List<? extends Attribute> getAttributes();
+
+    /**
+     * Adds an attribute.
+     * @param attribute the attribute
+     * @return this
+     */
+    Element withAttribute(Attribute attribute);
+
+    /**
+     * Adds attributes.
+     * @param attributes the attributes
+     * @return this
+     */
+    Element withAttributes(List<? extends Attribute> attributes);
+
+    /**
+     * Adds attributes.
+     * @param attributes the attributes
+     * @return this
+     */
+    Element withAttributes(Attribute... attributes);
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/graph/ElementId.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/graph/ElementId.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.graph;
+
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+@JsonAutoDetect(
+        creatorVisibility = Visibility.NONE,
+        fieldVisibility = Visibility.NONE,
+        getterVisibility = Visibility.NONE,
+        isGetterVisibility = Visibility.NONE,
+        setterVisibility = Visibility.NONE
+)
+abstract class ElementId {
+
+    private final int value;
+
+    ElementId(int value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    int getValue() {
+        return value;
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode() + value;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof ElementId)) {
+            return false;
+        }
+        ElementId other = (ElementId) obj;
+        return value == other.value;
+    }
+
+    @Override
+    public String toString() {
+        Optional<Class<?>> parent = Optional.ofNullable(getClass().getEnclosingClass());
+        return String.format(
+                "%s(id=%,d)",
+                parent.map(Class::getSimpleName).orElse("?"),
+                value);
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/graph/Input.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/graph/Input.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.graph;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import com.asakusafw.lang.info.Attribute;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents an input of {@link Node}.
+ * @since 0.4.2
+ */
+@JsonAutoDetect(
+        creatorVisibility = Visibility.NONE,
+        fieldVisibility = Visibility.NONE,
+        getterVisibility = Visibility.NONE,
+        isGetterVisibility = Visibility.NONE,
+        setterVisibility = Visibility.NONE
+)
+public class Input extends Port<Input, Output> {
+
+    private final Info info;
+
+    Input(Node parent, Info info) {
+        super(parent);
+        Objects.requireNonNull(info);
+        this.info = info;
+    }
+
+    @Override
+    public Input connect(Output opposite, Consumer<? super Wire> configure) {
+        return connect(opposite, this, configure);
+    }
+
+    @Override
+    public List<Wire> getWires() {
+        return wires(Wire::getDestination);
+    }
+
+    @Override
+    public List<Output> getOpposites() {
+        return opposites(Wire::getDestination, Wire::getSource);
+    }
+
+    @Override
+    Id id() {
+        return info.id;
+    }
+
+    @Override
+    List<Attribute> attributes() {
+        return info.attributes;
+    }
+
+    static class Id extends ElementId {
+        @JsonCreator
+        Id(int value) {
+            super(value);
+        }
+    }
+
+    @JsonAutoDetect(
+            creatorVisibility = Visibility.NONE,
+            fieldVisibility = Visibility.NONE,
+            getterVisibility = Visibility.NONE,
+            isGetterVisibility = Visibility.NONE,
+            setterVisibility = Visibility.NONE
+    )
+    static class Info {
+
+        @JsonProperty(value = Constants.ID_ID, required = true)
+        final Id id;
+
+        @JsonProperty(Constants.ID_ATTRIBUTES)
+        @JsonInclude(Include.NON_EMPTY)
+        final List<Attribute> attributes = new ArrayList<>();
+
+        Info(Id id) {
+            this(id, Collections.emptyList());
+        }
+
+        @JsonCreator
+        Info(
+                @JsonProperty(Constants.ID_ID) Id id,
+                @JsonProperty(Constants.ID_ATTRIBUTES) List<? extends Attribute> attributes) {
+            this.id = id;
+            this.attributes.addAll(Util.normalize(attributes));
+       }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + Objects.hashCode(id);
+            result = prime * result + Objects.hashCode(attributes);
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Info other = (Info) obj;
+            return Objects.equals(id, other.id)
+                    && Objects.equals(attributes, other.attributes);
+        }
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/graph/Node.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/graph/Node.java
@@ -1,0 +1,414 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.graph;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import com.asakusafw.lang.info.Attribute;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonCreator.Mode;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
+/**
+ * Represents a node of graph.
+ * @since 0.4.2
+ */
+@JsonAutoDetect(
+        creatorVisibility = Visibility.NONE,
+        fieldVisibility = Visibility.NONE,
+        getterVisibility = Visibility.NONE,
+        isGetterVisibility = Visibility.NONE,
+        setterVisibility = Visibility.NONE
+)
+public class Node extends AbstractElement<Node> {
+
+    private final Node parent;
+
+    @JsonProperty
+    @JsonUnwrapped
+    private final Info info;
+
+    private final List<Input> inputs = new ArrayList<>();
+
+    private final List<Output> outputs = new ArrayList<>();
+
+    private final List<Node> elements = new ArrayList<>();
+
+    private final List<Wire> wires = new ArrayList<>();
+
+    /**
+     * Creates a new empty instance.
+     */
+    public Node() {
+        this(null, new Info(new Id(0)));
+    }
+
+    @JsonCreator(mode = Mode.DELEGATING)
+    Node(Info info) {
+        this(null, info);
+    }
+
+    Node(Node parent, Info info) {
+        Objects.requireNonNull(info);
+        this.parent = parent;
+        this.info = info;
+        resolve();
+    }
+
+    private void resolve() {
+        inputs.addAll(info.inputs.stream().map(it -> new Input(this, it)).collect(Collectors.toList()));
+        outputs.addAll(info.outputs.stream().map(it -> new Output(this, it)).collect(Collectors.toList()));
+        elements.addAll(info.elements.stream().map(it -> new Node(this, it)).collect(Collectors.toList()));
+        wires.addAll(info.wires.stream().map(it -> new Wire(this, it)).collect(Collectors.toList()));
+    }
+
+    @Override
+    public Node getParent() {
+        return parent;
+    }
+
+    /**
+     * Returns the input ports of this node.
+     * @return the input ports
+     */
+    public List<Input> getInputs() {
+        return Collections.unmodifiableList(inputs);
+    }
+
+    /**
+     * Returns the input port of this node.
+     * @param index the input index
+     * @return the input port
+     */
+    public Input getInput(int index) {
+        Util.require(0 <= index && index < inputs.size(), () -> String.format(
+                "index of input must be [0, %,d): %,d", //$NON-NLS-1$
+                inputs.size(),
+                index));
+        return inputs.get(index);
+    }
+
+    /**
+     * Adds a new input port.
+     * @return the created port
+     */
+    public Input newInput() {
+        Input.Info pInfo = new Input.Info(new Input.Id(info.inputs.size()));
+        info.inputs.add(pInfo);
+        Input result = new Input(this, pInfo);
+        inputs.add(result);
+        assert inputs.size() == info.inputs.size();
+        return result;
+    }
+
+    /**
+     * Adds a new input port.
+     * @param configure configures the created port
+     * @return this
+     */
+    public Node withInput(Consumer<? super Input> configure) {
+        newInput().configure(configure);
+        return this;
+    }
+
+    /**
+     * Returns the output ports of this node.
+     * @return the output ports
+     */
+    public List<Output> getOutputs() {
+        return Collections.unmodifiableList(outputs);
+    }
+
+    /**
+     * Returns the output port of this node.
+     * @param index the output index
+     * @return the output port
+     */
+    public Output getOutput(int index) {
+        Util.require(0 <= index && index < outputs.size(), () -> String.format(
+                "index of output must be [0, %,d): %,d", //$NON-NLS-1$
+                outputs.size(),
+                index));
+        return outputs.get(index);
+    }
+
+    /**
+     * Adds a new output port.
+     * @return the created port
+     */
+    public Output newOutput() {
+        Output.Info pInfo = new Output.Info(new Output.Id(info.outputs.size()));
+        info.outputs.add(pInfo);
+        Output result = new Output(this, pInfo);
+        outputs.add(result);
+        assert outputs.size() == info.outputs.size();
+        return result;
+    }
+
+    /**
+     * Adds a new output port.
+     * @param configure configures the created port
+     * @return this
+     */
+    public Node withOutput(Consumer<? super Output> configure) {
+        newOutput().configure(configure);
+        return this;
+    }
+
+    /**
+     * Returns the element nodes of this node.
+     * @return the element nodes
+     */
+    public List<Node> getElements() {
+        return Collections.unmodifiableList(elements);
+    }
+
+    /**
+     * Returns the element node of this node.
+     * @param index the element index
+     * @return the element node
+     */
+    public Node getElement(int index) {
+        Util.require(0 <= index && index < elements.size(), () -> String.format(
+                "index of element must be [0, %,d): %,d", //$NON-NLS-1$
+                elements.size(),
+                index));
+        return elements.get(index);
+    }
+
+    /**
+     * Adds a new element node.
+     * @return the created port
+     */
+    public Node newElement() {
+        Node.Info pInfo = new Node.Info(new Node.Id(info.elements.size()));
+        info.elements.add(pInfo);
+        Node result = new Node(this, pInfo);
+        elements.add(result);
+        assert elements.size() == info.elements.size();
+        return result;
+    }
+
+    /**
+     * Adds a new node port.
+     * @param configure configures the created port
+     * @return this
+     */
+    public Node withElement(Consumer<? super Node> configure) {
+        newElement().configure(configure);
+        return this;
+    }
+
+    /**
+     * Returns the wires on this node.
+     * @return the wires
+     * @see Input#connect(Output, Consumer)
+     * @see Output#connect(Input, Consumer)
+     */
+    public List<Wire> getWires() {
+        return Collections.unmodifiableList(wires);
+    }
+
+    /**
+     * Returns the wire on this node.
+     * @param index the wire index
+     * @return the wire
+     */
+    public Wire getWire(int index) {
+        Util.require(0 <= index && index < wires.size(), () -> String.format(
+                "index of wire must be [0, %,d): %,d", //$NON-NLS-1$
+                wires.size(),
+                index));
+        return wires.get(index);
+    }
+
+    @Override
+    Id id() {
+        return info.id;
+    }
+
+    @Override
+    List<Attribute> attributes() {
+        return info.attributes;
+    }
+
+    /**
+     * Returns the entity (only for testing).
+     * @return the entity
+     */
+    Info info() {
+        return info;
+    }
+
+    Input resolve(Input.Id id) {
+        return inputs.get(id.getValue());
+    }
+
+    Output resolve(Output.Id id) {
+        return outputs.get(id.getValue());
+    }
+
+    Node resolve(Node.Id id) {
+        return elements.get(id.getValue());
+    }
+
+    Wire resolve(Wire.Id id) {
+        return wires.get(id.getValue());
+    }
+
+    Wire connect(Output upstream, Input downstream) {
+        assert upstream.getParent().getParent() == this;
+        assert downstream.getParent().getParent() == this;
+        Wire.Id wId = new Wire.Id(info.wires.size());
+        Wire.Info wInfo = new Wire.Info(wId,
+                upstream.getParent().id(), upstream.id(),
+                downstream.getParent().id(), downstream.id());
+        info.wires.add(wInfo);
+        Wire result = new Wire(this, wInfo);
+        wires.add(result);
+        assert wires.size() == info.wires.size();
+        return result;
+    }
+
+    @JsonAutoDetect(
+            creatorVisibility = Visibility.NONE,
+            fieldVisibility = Visibility.NONE,
+            getterVisibility = Visibility.NONE,
+            isGetterVisibility = Visibility.NONE,
+            setterVisibility = Visibility.NONE
+    )
+    static class Id extends ElementId {
+        @JsonCreator
+        Id(int value) {
+            super(value);
+        }
+    }
+
+    @JsonAutoDetect(
+            creatorVisibility = Visibility.NONE,
+            fieldVisibility = Visibility.NONE,
+            getterVisibility = Visibility.NONE,
+            isGetterVisibility = Visibility.NONE,
+            setterVisibility = Visibility.NONE
+    )
+    static class Info {
+
+        @JsonProperty(value = Constants.ID_ID, required = true)
+        final Id id;
+
+        @JsonProperty(Constants.ID_NODE_INPUTS)
+        @JsonInclude(Include.NON_EMPTY)
+        final List<Input.Info> inputs = new ArrayList<>();
+
+        @JsonProperty(Constants.ID_NODE_OUTPUTS)
+        @JsonInclude(Include.NON_EMPTY)
+        final List<Output.Info> outputs = new ArrayList<>();
+
+        @JsonProperty(Constants.ID_NODE_WIRES)
+        @JsonInclude(Include.NON_EMPTY)
+        final List<Wire.Info> wires = new ArrayList<>();
+
+        @JsonProperty(Constants.ID_NODE_ELEMENTS)
+        @JsonInclude(Include.NON_EMPTY)
+        final List<Node.Info> elements = new ArrayList<>();
+
+        @JsonProperty(Constants.ID_ATTRIBUTES)
+        @JsonInclude(Include.NON_EMPTY)
+        final List<Attribute> attributes = new ArrayList<>();
+
+        Info(Id id) {
+            this.id = id;
+        }
+
+        @JsonCreator
+        Info(
+                @JsonProperty(Constants.ID_ID) Id id,
+                @JsonProperty(Constants.ID_NODE_INPUTS) List<Input.Info> inputs,
+                @JsonProperty(Constants.ID_NODE_OUTPUTS) List<Output.Info> outputs,
+                @JsonProperty(Constants.ID_NODE_WIRES) List<Wire.Info> wires,
+                @JsonProperty(Constants.ID_NODE_ELEMENTS) List<Node.Info> elements,
+                @JsonProperty(Constants.ID_ATTRIBUTES) List<? extends Attribute> attributes) {
+            this.id = id;
+            this.inputs.addAll(validate(inputs, it -> it.id));
+            this.outputs.addAll(validate(outputs, it -> it.id));
+            this.wires.addAll(validate(wires, it -> it.id));
+            this.elements.addAll(validate(elements, it -> it.id));
+            this.attributes.addAll(Util.normalize(attributes));
+        }
+
+        static <T> List<T> validate(List<T> list, Function<T, ElementId> identifier) {
+            if (list == null || list.isEmpty()) {
+                return Collections.emptyList();
+            }
+            int index = 0;
+            for (T value : list) {
+                ElementId id = identifier.apply(value);
+                if (id.getValue() != index) {
+                    throw new IllegalArgumentException(MessageFormat.format(
+                            "invalid index {0}: {1}",
+                            index, value));
+                }
+                index++;
+            }
+            return list;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + Objects.hashCode(id);
+            result = prime * result + Objects.hashCode(inputs);
+            result = prime * result + Objects.hashCode(outputs);
+            result = prime * result + Objects.hashCode(wires);
+            result = prime * result + Objects.hashCode(elements);
+            result = prime * result + Objects.hashCode(attributes);
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Info other = (Info) obj;
+            return Objects.equals(id, other.id)
+                    && Objects.equals(inputs, other.inputs)
+                    && Objects.equals(outputs, other.outputs)
+                    && Objects.equals(wires, other.wires)
+                    && Objects.equals(elements, other.elements)
+                    && Objects.equals(attributes, other.attributes);
+        }
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/graph/Output.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/graph/Output.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.graph;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import com.asakusafw.lang.info.Attribute;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents an output of node.
+ * @since 0.4.2
+ */
+@JsonAutoDetect(
+        creatorVisibility = Visibility.NONE,
+        fieldVisibility = Visibility.NONE,
+        getterVisibility = Visibility.NONE,
+        isGetterVisibility = Visibility.NONE,
+        setterVisibility = Visibility.NONE
+)
+public class Output extends Port<Output, Input> {
+
+    private final Info info;
+
+    Output(Node parent, Info info) {
+        super(parent);
+        Objects.requireNonNull(info);
+        this.info = info;
+    }
+
+    @Override
+    public Output connect(Input opposite, Consumer<? super Wire> configure) {
+        return connect(this, opposite, configure);
+    }
+
+    @Override
+    public List<Wire> getWires() {
+        return wires(Wire::getSource);
+    }
+
+    @Override
+    public List<Input> getOpposites() {
+        return opposites(Wire::getSource, Wire::getDestination);
+    }
+
+    @Override
+    Id id() {
+        return info.id;
+    }
+
+    @Override
+    List<Attribute> attributes() {
+        return info.attributes;
+    }
+
+    static class Id extends ElementId {
+        @JsonCreator
+        Id(int value) {
+            super(value);
+        }
+    }
+
+    @JsonAutoDetect(
+            creatorVisibility = Visibility.NONE,
+            fieldVisibility = Visibility.NONE,
+            getterVisibility = Visibility.NONE,
+            isGetterVisibility = Visibility.NONE,
+            setterVisibility = Visibility.NONE
+    )
+    static class Info {
+
+        @JsonProperty(value = Constants.ID_ID, required = true)
+        final Id id;
+
+        @JsonProperty(Constants.ID_ATTRIBUTES)
+        @JsonInclude(Include.NON_EMPTY)
+        final List<Attribute> attributes = new ArrayList<>();
+
+        Info(Id id) {
+            this(id, Collections.emptyList());
+        }
+
+        @JsonCreator
+        Info(
+                @JsonProperty(Constants.ID_ID) Id id,
+                @JsonProperty(Constants.ID_ATTRIBUTES) List<? extends Attribute> attributes) {
+            this.id = id;
+            this.attributes.addAll(Util.normalize(attributes));
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + Objects.hashCode(id);
+            result = prime * result + Objects.hashCode(attributes);
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Info other = (Info) obj;
+            return Objects.equals(id, other.id)
+                    && Objects.equals(attributes, other.attributes);
+        }
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/graph/Port.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/graph/Port.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.graph;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+
+/**
+ * An abstract super class of I/O port of {@link Node}.
+ * @param <TSelf> the implementation type
+ * @param <TOpposite> the opposite port type
+ * @since 0.4.2
+ */
+@JsonAutoDetect(
+        creatorVisibility = Visibility.NONE,
+        fieldVisibility = Visibility.NONE,
+        getterVisibility = Visibility.NONE,
+        isGetterVisibility = Visibility.NONE,
+        setterVisibility = Visibility.NONE
+)
+public abstract class Port<
+        TSelf extends Port<TSelf, TOpposite>,
+        TOpposite extends Port<TOpposite, TSelf>> extends AbstractElement<TSelf> {
+
+    private final Node parent;
+
+    Port(Node parent) {
+        Objects.requireNonNull(parent);
+        this.parent = parent;
+    }
+
+    @Override
+    public Node getParent() {
+        return parent;
+    }
+
+    /**
+     * Connects to the given opposite port.
+     * @param opposite the target port
+     * @return this
+     */
+    public TSelf connect(TOpposite opposite) {
+        return connect(opposite, null);
+    }
+
+    /**
+     * Connects to the given opposite port.
+     * @param opposite the target port
+     * @param configure the wire configurator
+     * @return this
+     */
+    public abstract TSelf connect(TOpposite opposite, Consumer<? super Wire> configure);
+
+    /**
+     * Returns the connected wires.
+     * @return the connected wires
+     */
+    public abstract List<Wire> getWires();
+
+    /**
+     * Returns the connected opposites.
+     * @return the connected opposites
+     */
+    public abstract List<TOpposite> getOpposites();
+
+    TSelf connect(Output upstream, Input downstream, Consumer<? super Wire> configure) {
+        Util.require(upstream.getParent().getParent() == downstream.getParent().getParent(), () -> String.format(
+                "both %s and %s must be on the same node",
+                upstream.getParent(),
+                downstream.getParent()));
+        upstream.getParent().getParent().connect(upstream, downstream).configure(configure);
+        return self();
+    }
+
+    List<Wire> wires(Function<? super Wire, ? extends TSelf> extractor) {
+        Node base = getParent().getParent();
+        if (base == null) {
+            return Collections.emptyList();
+        }
+        return base.getWires().stream()
+                .filter(wire -> extractor.apply(wire) == this)
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toList(),
+                        Collections::unmodifiableList));
+    }
+
+    List<TOpposite> opposites(
+            Function<? super Wire, ? extends TSelf> self,
+            Function<? super Wire, ? extends TOpposite> opposite) {
+        Node base = getParent().getParent();
+        if (base == null) {
+            return Collections.emptyList();
+        }
+        return base.getWires().stream()
+                .filter(wire -> self.apply(wire) == this)
+                .map(opposite)
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toList(),
+                        Collections::unmodifiableList));
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/graph/Util.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/graph/Util.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.graph;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+
+final class Util {
+
+    private Util() {
+        return;
+    }
+
+    static <T> List<T> normalize(List<T> list) {
+        if (list == null || list.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return list;
+    }
+
+    static void require(boolean condition, Supplier<String> message) {
+        if (condition == false) {
+            throw new IllegalStateException(message.get());
+        }
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/graph/Wire.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/graph/Wire.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.graph;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.asakusafw.lang.info.Attribute;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a wire that connects between {@link Input} and {@link Output}.
+ * @since 0.4.2
+ */
+@JsonAutoDetect(
+        creatorVisibility = Visibility.NONE,
+        fieldVisibility = Visibility.NONE,
+        getterVisibility = Visibility.NONE,
+        isGetterVisibility = Visibility.NONE,
+        setterVisibility = Visibility.NONE
+)
+public class Wire extends AbstractElement<Wire> {
+
+    private final Node parent;
+
+    private final Info info;
+
+    Wire(Node parent, Wire.Info info) {
+        Objects.requireNonNull(parent);
+        Objects.requireNonNull(info);
+        this.parent = parent;
+        this.info = info;
+    }
+
+    @Override
+    public Node getParent() {
+        return parent;
+    }
+
+    /**
+     * Returns the source output.
+     * @return the source output
+     */
+    public Output getSource() {
+        return parent.resolve(info.upstreamNodeId).resolve(info.upstreamPortId);
+    }
+
+    /**
+     * Returns the destination input.
+     * @return the destination input
+     */
+    public Input getDestination() {
+        return parent.resolve(info.downstreamNodeId).resolve(info.downstreamPortId);
+    }
+
+    @Override
+    Id id() {
+        return info.id;
+    }
+
+    @Override
+    List<Attribute> attributes() {
+        return info.attributes;
+    }
+
+    static class Id extends ElementId {
+        @JsonCreator
+        Id(int value) {
+            super(value);
+        }
+    }
+
+    @JsonAutoDetect(
+            creatorVisibility = Visibility.NONE,
+            fieldVisibility = Visibility.NONE,
+            getterVisibility = Visibility.NONE,
+            isGetterVisibility = Visibility.NONE,
+            setterVisibility = Visibility.NONE
+    )
+    static class Info {
+
+        private static final int INDEX_NODE = 0;
+
+        private static final int INDEX_PORT = 1;
+
+        @JsonProperty(value = Constants.ID_ID, required = true)
+        final Id id;
+
+        final Node.Id upstreamNodeId;
+
+        final Output.Id upstreamPortId;
+
+        final Node.Id downstreamNodeId;
+
+        final Input.Id downstreamPortId;
+
+        @JsonProperty(Constants.ID_ATTRIBUTES)
+        @JsonInclude(Include.NON_EMPTY)
+        final List<Attribute> attributes = new ArrayList<>();
+
+        Info(Wire.Id id,
+                Node.Id upstreamNodeId, Output.Id upstreamPortId,
+                Node.Id downstreamNodeId, Input.Id downstreamPortId) {
+            this.id = id;
+            this.upstreamNodeId = upstreamNodeId;
+            this.upstreamPortId = upstreamPortId;
+            this.downstreamNodeId = downstreamNodeId;
+            this.downstreamPortId = downstreamPortId;
+        }
+
+        @JsonCreator
+        Info(@JsonProperty(Constants.ID_ID) Wire.Id id,
+                @JsonProperty(Constants.ID_WIRE_UPSTREAM) int[] from,
+                @JsonProperty(Constants.ID_WIRE_DOWNSTREAM) int[] to,
+                @JsonProperty(Constants.ID_ATTRIBUTES) List<? extends Attribute> attributes) {
+            this(id,
+                    new Node.Id(from[INDEX_NODE]),
+                    new Output.Id(from[INDEX_PORT]),
+                    new Node.Id(to[INDEX_NODE]),
+                    new Input.Id(to[INDEX_PORT]));
+            this.attributes.addAll(Util.normalize(attributes));
+        }
+
+        @JsonProperty(value = Constants.ID_WIRE_UPSTREAM, required = true)
+        int[] getFrom() {
+            return new int[] { upstreamNodeId.getValue(), upstreamPortId.getValue() };
+        }
+
+        @JsonProperty(value = Constants.ID_WIRE_DOWNSTREAM, required = true)
+        int[] getTo() {
+            return new int[] { downstreamNodeId.getValue(), downstreamPortId.getValue() };
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + Objects.hashCode(id);
+            result = prime * result + Objects.hashCode(upstreamNodeId);
+            result = prime * result + Objects.hashCode(upstreamPortId);
+            result = prime * result + Objects.hashCode(downstreamNodeId);
+            result = prime * result + Objects.hashCode(downstreamPortId);
+            result = prime * result + Objects.hashCode(attributes);
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Info other = (Info) obj;
+            return Objects.equals(id, other.id)
+                    && Objects.equals(upstreamNodeId, other.upstreamNodeId)
+                    && Objects.equals(upstreamPortId, other.upstreamPortId)
+                    && Objects.equals(downstreamNodeId, other.downstreamNodeId)
+                    && Objects.equals(downstreamPortId, other.downstreamPortId)
+                    && Objects.equals(attributes, other.attributes);
+        }
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/graph/package-info.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/graph/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Graph like structure models.
+ */
+package com.asakusafw.lang.info.graph;

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/Constants.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/Constants.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator;
+
+final class Constants {
+
+    static final String ID_ID = "id";
+
+    static final String ID_KIND = "kind";
+
+    static final String ID_CLASS = "class";
+
+    static final String ID_TYPE = "type";
+
+    static final String ID_NAME = "name";
+
+    static final String ID_ROOT = "root";
+
+    static final String ID_SPEC = "spec";
+
+    static final String ID_PARAMETERS = "parameters";
+
+    static final String ID_VALUE = "value";
+
+    static final String ID_CATEGORY = "category";
+
+    static final String ID_ANNOTATION = "annotation";
+
+    static final String ID_METHOD = "method";
+
+    static final String ID_IMPLEMENTATION = "implementation";
+
+    static final String ID_GROUP = "group";
+
+    static final String ID_GRANULARITY = "granularity";
+
+    private Constants() {
+        return;
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/CoreOperatorSpec.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/CoreOperatorSpec.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator;
+
+import java.util.Objects;
+
+import com.asakusafw.lang.info.value.ClassInfo;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Details of a core operator.
+ * @since 0.4.2
+ */
+public final class CoreOperatorSpec implements OperatorSpec {
+
+    static final String KIND = "core";
+
+    @JsonProperty(Constants.ID_CATEGORY)
+    private final CoreOperatorKind category;
+
+    private CoreOperatorSpec(CoreOperatorKind annotation) {
+        this.category = annotation;
+    }
+
+    /**
+     * Returns an instance.
+     * @param category the category
+     * @return the instance
+     */
+    @JsonCreator
+    public static CoreOperatorSpec of(
+            @JsonProperty(Constants.ID_CATEGORY) CoreOperatorKind category) {
+        return new CoreOperatorSpec(category);
+    }
+
+    @Override
+    public OperatorKind getOperatorKind() {
+        return OperatorKind.CORE;
+    }
+
+    /**
+     * Returns the core operator kind.
+     * @return the kind
+     */
+    public CoreOperatorKind getCategory() {
+        return category;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = Objects.hashCode(getOperatorKind());
+        result = prime * result + Objects.hashCode(category);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        CoreOperatorSpec other = (CoreOperatorSpec) obj;
+        return Objects.equals(category, other.category);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Core(%s)", category);
+    }
+
+    /**
+     * Represents a kind of core operator.
+     */
+    public enum CoreOperatorKind {
+
+        /**
+         * Checkpoint operators.
+         */
+        CHECKPOINT("Checkpoint"), //$NON-NLS-1$
+
+        /**
+         * Project operators.
+         */
+        PROJECT("Project"), //$NON-NLS-1$
+
+        /**
+         * Extend operators.
+         */
+        EXTEND("Extend"), //$NON-NLS-1$
+
+        /**
+         * Restructure operators.
+         */
+        RESTRUCTURE("Restructure"), //$NON-NLS-1$
+        ;
+
+        private static final String PREFIX_ANNOTATION_TYPE = "com.asakusafw.vocabulary.operator."; //$NON-NLS-1$
+
+        private final ClassInfo annotationType;
+
+        CoreOperatorKind(String simpleName) {
+            this(ClassInfo.of(PREFIX_ANNOTATION_TYPE + simpleName));
+        }
+
+        CoreOperatorKind(ClassInfo annotationType) {
+            this.annotationType = annotationType;
+        }
+
+        /**
+         * Returns the (pseudo) annotation type for this.
+         * @return the annotation type
+         */
+        public ClassInfo getAnnotationType() {
+            return annotationType;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("@%s", annotationType.getSimpleName());
+        }
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/CustomOperatorSpec.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/CustomOperatorSpec.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Details of a core operator.
+ * @since 0.4.2
+ */
+public final class CustomOperatorSpec implements OperatorSpec {
+
+    static final String KIND = "custom";
+
+    @JsonProperty(Constants.ID_CATEGORY)
+    private final String category;
+
+    private CustomOperatorSpec(String annotation) {
+        this.category = annotation;
+    }
+
+    /**
+     * Returns an instance.
+     * @param category the category
+     * @return the instance
+     */
+    @JsonCreator
+    public static CustomOperatorSpec of(
+            @JsonProperty(Constants.ID_CATEGORY) String category) {
+        return new CustomOperatorSpec(category);
+    }
+
+    @Override
+    public OperatorKind getOperatorKind() {
+        return OperatorKind.CUSTOM;
+    }
+
+    /**
+     * Returns the operator category.
+     * @return the kind
+     */
+    public String getCategory() {
+        return category;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = Objects.hashCode(getOperatorKind());
+        result = prime * result + Objects.hashCode(category);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        CustomOperatorSpec other = (CustomOperatorSpec) obj;
+        return Objects.equals(category, other.category);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Custom(%s)", category);
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/FlowOperatorSpec.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/FlowOperatorSpec.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import com.asakusafw.lang.info.value.ClassInfo;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a flow operator details.
+ * @since 0.4.2
+ */
+public final class FlowOperatorSpec implements OperatorSpec {
+
+    static final String KIND = "flow";
+
+    @JsonIgnore
+    private final ClassInfo descriptionClass;
+
+    private FlowOperatorSpec(ClassInfo descriptionClass) {
+        this.descriptionClass = descriptionClass;
+    }
+
+    @JsonCreator
+    static FlowOperatorSpec restore(
+            @JsonProperty(Constants.ID_CLASS) String descriptionClass) {
+        return of(Optional.ofNullable(descriptionClass)
+                .map(ClassInfo::of)
+                .orElse(null));
+    }
+
+    /**
+     * Returns an instance.
+     * @param descriptionClass the input description (nullable)
+     * @return the instance
+     */
+    public static FlowOperatorSpec of(ClassInfo descriptionClass) {
+        return new FlowOperatorSpec(descriptionClass);
+    }
+
+    @JsonProperty(Constants.ID_CLASS)
+    String getDescriptionClassName() {
+        return Optional.ofNullable(descriptionClass)
+                .map(ClassInfo::getName)
+                .orElse(null);
+    }
+
+    @Override
+    public OperatorKind getOperatorKind() {
+        return OperatorKind.FLOW;
+    }
+
+    /**
+     * Returns the description class.
+     * @return the description class, or {@code null} if it is not defined
+     */
+    public ClassInfo getDescriptionClass() {
+        return descriptionClass;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = Objects.hashCode(getOperatorKind());
+        result = prime * result + Objects.hashCode(descriptionClass);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        FlowOperatorSpec other = (FlowOperatorSpec) obj;
+        return Objects.equals(descriptionClass, other.descriptionClass);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Flow(%s)", descriptionClass);
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/InputAttribute.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/InputAttribute.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator;
+
+import java.util.Objects;
+
+import com.asakusafw.lang.info.Attribute;
+import com.asakusafw.lang.info.value.ClassInfo;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * An {@link Attribute} which represents details of operator inputs.
+ * @since 0.4.2
+ */
+public class InputAttribute implements Attribute, InputInfo {
+
+    @JsonProperty(Constants.ID_NAME)
+    private final String name;
+
+    @JsonIgnore
+    private final ClassInfo dataType;
+
+    @JsonProperty(Constants.ID_GRANULARITY)
+    private final InputGranularity granulatity;
+
+    @JsonProperty(Constants.ID_GROUP)
+    private final InputGroup group;
+
+    /**
+     * Creates a new instance.
+     * @param name the port name
+     * @param dataType the data type
+     * @param granulatity the input granularity
+     * @param group the input group (nullable)
+     */
+    public InputAttribute(String name, ClassInfo dataType, InputGranularity granulatity, InputGroup group) {
+        this.name = name;
+        this.dataType = dataType;
+        this.granulatity = granulatity;
+        this.group = group;
+    }
+
+    @JsonCreator
+    static InputAttribute resolve(
+            @JsonProperty(Constants.ID_NAME) String name,
+            @JsonProperty(Constants.ID_TYPE) String dataType,
+            @JsonProperty(Constants.ID_GRANULARITY) InputGranularity granulatity,
+            @JsonProperty(Constants.ID_GROUP) InputGroup group) {
+        return new InputAttribute(name, ClassInfo.of(dataType), granulatity, group);
+    }
+
+    @JsonProperty(Constants.ID_TYPE)
+    String getDataTypeName() {
+        return dataType.getName();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public ClassInfo getDataType() {
+        return dataType;
+    }
+
+    @Override
+    public InputGranularity getGranulatity() {
+        return granulatity;
+    }
+
+    @Override
+    public InputGroup getGroup() {
+        return group;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Objects.hashCode(name);
+        result = prime * result + Objects.hashCode(dataType);
+        result = prime * result + Objects.hashCode(granulatity);
+        result = prime * result + Objects.hashCode(group);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        InputAttribute other = (InputAttribute) obj;
+        return Objects.equals(name, other.name)
+                && Objects.equals(dataType, other.dataType)
+                && Objects.equals(granulatity, other.granulatity)
+                && Objects.equals(group, other.group);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Input(%s)", name);
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/InputGranularity.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/InputGranularity.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator;
+
+/**
+ * Represents granularity of input.
+ * @since 0.4.2
+ */
+public enum InputGranularity {
+
+    /**
+     * The input handles each record from the upstream.
+     */
+    RECORD,
+
+    /**
+     * The input handles each group from the upstream.
+     */
+    GROUP,
+
+    /**
+     * The input handles whole data from the upstream.
+     */
+    WHOLE,
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/InputGroup.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/InputGroup.java
@@ -1,0 +1,236 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Represents grouping spec.
+ * @since 0.4.2
+ */
+public class InputGroup {
+
+    static final char KEY_PARTITION = '=';
+
+    static final char KEY_ASCENDANT = '+';
+
+    static final char KEY_DESCENDANT = '-';
+
+    @JsonIgnore
+    private final List<String> keys;
+
+    @JsonIgnore
+    private final List<Order> order;
+
+    /**
+     * Creates a new instance.
+     * @param keys the group keys
+     * @param order the ordering information
+     */
+    public InputGroup(List<String> keys, List<Order> order) {
+        this.keys = Util.freeze(keys);
+        this.order = Util.freeze(order);
+    }
+
+    /**
+     * Returns an instance.
+     * @param expressions the grouping expressions
+     * @return the instance
+     */
+    @JsonCreator
+    public static InputGroup parse(List<String> expressions) {
+        List<String> keys = new ArrayList<>();
+        List<Order> order = new ArrayList<>();
+        for (String element : expressions) {
+            assert element.length() >= 1;
+            String operand = element.substring(1);
+            switch (element.charAt(0)) {
+            case KEY_PARTITION:
+                keys.add(operand);
+                break;
+            case KEY_ASCENDANT:
+                order.add(new Order(operand, Direction.ASCENDANT));
+                break;
+            case KEY_DESCENDANT:
+                order.add(new Order(operand, Direction.DESCENDANT));
+                break;
+            default:
+                throw new AssertionError(element);
+            }
+        }
+        return new InputGroup(keys, order);
+    }
+
+    @JsonValue
+    List<String> unparse() {
+        List<String> results = new ArrayList<>();
+        keys.stream()
+            .map(it -> KEY_PARTITION + it)
+            .forEachOrdered(results::add);
+        order.stream()
+            .map(Order::toString)
+            .forEachOrdered(results::add);
+        return results;
+    }
+
+    /**
+     * Returns the keys.
+     * @return the keys
+     */
+    public List<String> getKeys() {
+        return keys;
+    }
+
+    /**
+     * Returns the order.
+     * @return the order
+     */
+    public List<Order> getOrder() {
+        return order;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Objects.hashCode(keys);
+        result = prime * result + Objects.hashCode(order);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        InputGroup other = (InputGroup) obj;
+        return Objects.equals(keys, other.keys)
+                && Objects.equals(order, other.order);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Group%s", unparse());
+    }
+
+    /**
+     * Represents order element.
+     * @since 0.4.2
+     */
+    public static class Order {
+
+        private final String name;
+
+        private final Direction direction;
+
+        /**
+         * Creates a new instance.
+         * @param name the property name
+         * @param direction the property direction
+         */
+        public Order(String name, Direction direction) {
+            this.name = name;
+            this.direction = direction;
+        }
+
+        /**
+         * Returns the name.
+         * @return the name
+         */
+        public String getName() {
+            return name;
+        }
+
+        /**
+         * Returns the direction.
+         * @return the direction
+         */
+        public Direction getDirection() {
+            return direction;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + Objects.hashCode(direction);
+            result = prime * result + Objects.hashCode(name);
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Order other = (Order) obj;
+            return Objects.equals(direction, other.direction)
+                    && Objects.equals(name, other.name);
+        }
+
+        @Override
+        public String toString() {
+            return direction.key + name;
+        }
+    }
+
+    /**
+     * Represents direction.
+     * @since 0.4.2
+     */
+    public enum Direction {
+
+        /**
+         * Ascendant order.
+         */
+        ASCENDANT(KEY_ASCENDANT),
+
+        /**
+         * Descendant order.
+         */
+        DESCENDANT(KEY_DESCENDANT),
+        ;
+
+        final char key;
+
+        Direction(char key) {
+            this.key = key;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(key);
+        }
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/InputInfo.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/InputInfo.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator;
+
+import com.asakusafw.lang.info.value.ClassInfo;
+
+/**
+ * Details of operator inputs.
+ * @since 0.4.2
+ */
+public interface InputInfo {
+
+    /**
+     * Returns the port name.
+     * @return the port name
+     */
+    String getName();
+
+    /**
+     * Returns the data type.
+     * @return the data type
+     */
+    ClassInfo getDataType();
+
+    /**
+     * Returns the input granularity.
+     * @return the input granularity
+     */
+    InputGranularity getGranulatity();
+
+    /**
+     * Returns the input group info.
+     * @return the input group, or {@code null} if it is not defined
+     */
+    InputGroup getGroup();
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/InputOperatorSpec.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/InputOperatorSpec.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import com.asakusafw.lang.info.value.ClassInfo;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents an operator detail of flow inputs.
+ * @since 0.4.2
+ */
+public final class InputOperatorSpec implements OperatorSpec {
+
+    static final String KIND = "input";
+
+    @JsonProperty(Constants.ID_NAME)
+    private final String name;
+
+    @JsonIgnore
+    private final ClassInfo descriptionClass;
+
+    private InputOperatorSpec(String name, ClassInfo descriptionClass) {
+        this.name = name;
+        this.descriptionClass = descriptionClass;
+    }
+
+    @JsonCreator
+    static InputOperatorSpec restore(
+            @JsonProperty(Constants.ID_NAME) String name,
+            @JsonProperty(Constants.ID_CLASS) String descriptionClass) {
+        return of(
+                name,
+                Optional.ofNullable(descriptionClass)
+                    .map(ClassInfo::of)
+                    .orElse(null));
+    }
+
+    /**
+     * Returns an instance.
+     * @param name the port name
+     * @param descriptionClass the input description (nullable)
+     * @return the instance
+     */
+    public static InputOperatorSpec of(String name, ClassInfo descriptionClass) {
+        return new InputOperatorSpec(name, descriptionClass);
+    }
+
+    @JsonProperty(Constants.ID_CLASS)
+    String getDescriptionClassName() {
+        return Optional.ofNullable(descriptionClass)
+                .map(ClassInfo::getName)
+                .orElse(null);
+    }
+
+    @Override
+    public OperatorKind getOperatorKind() {
+        return OperatorKind.INPUT;
+    }
+
+    /**
+     * Returns the name of this port.
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the description class.
+     * @return the description class, or {@code null} if it is not defined
+     */
+    public ClassInfo getDescriptionClass() {
+        return descriptionClass;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = Objects.hashCode(getOperatorKind());
+        result = prime * result + Objects.hashCode(name);
+        result = prime * result + Objects.hashCode(descriptionClass);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        InputOperatorSpec other = (InputOperatorSpec) obj;
+        return Objects.equals(name, other.name)
+                && Objects.equals(descriptionClass, other.descriptionClass);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Input(name=%s, desc=%s)", name, descriptionClass);
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/MarkerOperatorSpec.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/MarkerOperatorSpec.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+/**
+ * Details of marker operator.
+ * @since 0.4.2
+ */
+public final class MarkerOperatorSpec implements OperatorSpec {
+
+    private static final MarkerOperatorSpec INSTANCE = new MarkerOperatorSpec();
+
+    static final String KIND = "marker";
+
+    private MarkerOperatorSpec() {
+        return;
+    }
+
+    /**
+     * Returns an instance.
+     * @return the instance
+     */
+    @JsonCreator
+    public static MarkerOperatorSpec get() {
+        return INSTANCE;
+    }
+
+    @Override
+    public OperatorKind getOperatorKind() {
+        return OperatorKind.MARKER;
+    }
+
+    @Override
+    public String toString() {
+        return "Marker()";
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/OperatorAttribute.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/OperatorAttribute.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import com.asakusafw.lang.info.Attribute;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * An {@link Attribute} which represents details of operators.
+ * @since 0.4.2
+ */
+public class OperatorAttribute implements Attribute, OperatorInfo {
+
+    @JsonProperty(Constants.ID_SPEC)
+    private final OperatorSpec spec;
+
+    @JsonProperty(Constants.ID_PARAMETERS)
+    @JsonInclude(Include.NON_EMPTY)
+    private final List<ParameterInfo> parameters;
+
+    /**
+     * Creates a new instance.
+     * @param spec the operator body information
+     */
+    public OperatorAttribute(OperatorSpec spec) {
+        this(spec, Collections.emptyList());
+    }
+
+    /**
+     * Creates a new instance.
+     * @param spec the operator body information
+     * @param parameters the operator parameters
+     */
+    public OperatorAttribute(OperatorSpec spec, List<? extends ParameterInfo> parameters) {
+        this.spec = spec;
+        this.parameters = Util.freeze(parameters);
+    }
+
+    @JsonCreator
+    static OperatorAttribute restore(
+            @JsonProperty(Constants.ID_SPEC) OperatorSpec spec,
+            @JsonProperty(Constants.ID_PARAMETERS) List<? extends ParameterInfo> parameters) {
+        return new OperatorAttribute(spec, parameters);
+    }
+
+    @Override
+    public OperatorSpec getSpec() {
+        return spec;
+    }
+
+    @Override
+    public List<ParameterInfo> getParameters() {
+        return parameters;
+    }
+
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Objects.hashCode(spec);
+        result = prime * result + Objects.hashCode(parameters);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        OperatorAttribute other = (OperatorAttribute) obj;
+        return Objects.equals(spec, other.spec)
+                && Objects.equals(parameters, other.parameters);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Operator(%s%s)",
+                spec,
+                parameters);
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/OperatorGraphAttribute.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/OperatorGraphAttribute.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator;
+
+import java.util.Objects;
+
+import com.asakusafw.lang.info.Attribute;
+import com.asakusafw.lang.info.graph.Node;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * An {@link Attribute} which represents details of operator graphs.
+ * @since 0.4.2
+ */
+public class OperatorGraphAttribute implements Attribute {
+
+    static final String ID = "operator-graph";
+
+    private final Node root;
+
+    /**
+     * Creates a new instance.
+     * @param root the root node
+     */
+    public OperatorGraphAttribute(Node root) {
+        this.root = root;
+    }
+
+    @JsonCreator
+    static OperatorGraphAttribute restore(
+            @JsonProperty(Constants.ID_ID) String id,
+            @JsonProperty(Constants.ID_ROOT) Node root) {
+        if (Objects.equals(id, ID) == false) {
+            throw new IllegalArgumentException();
+        }
+        return new OperatorGraphAttribute(root);
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    /**
+     * Returns the root node.
+     * @return the root node
+     */
+    public Node getRoot() {
+        return root;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Objects.hashCode(root);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        return Objects.equals(root, ((OperatorGraphAttribute) obj).root);
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/OperatorInfo.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/OperatorInfo.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator;
+
+import java.util.List;
+
+/**
+ * Details of operators.
+ * @since 0.4.2
+ */
+public interface OperatorInfo {
+
+    /**
+     * Returns the operator body.
+     * @return the operator body
+     */
+    OperatorSpec getSpec();
+
+    /**
+     * Returns the parameters.
+     * @return the parameters
+     */
+    List<ParameterInfo> getParameters();
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/OperatorSpec.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/OperatorSpec.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * An abstract super interface of operator details.
+ * @since 0.4.2
+ */
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.EXISTING_PROPERTY,
+        property = Constants.ID_KIND,
+        visible = false
+)
+@JsonSubTypes({
+    @Type(value = CoreOperatorSpec.class, name = CoreOperatorSpec.KIND),
+    @Type(value = UserOperatorSpec.class, name = UserOperatorSpec.KIND),
+    @Type(value = FlowOperatorSpec.class, name = FlowOperatorSpec.KIND),
+    @Type(value = InputOperatorSpec.class, name = InputOperatorSpec.KIND),
+    @Type(value = OutputOperatorSpec.class, name = OutputOperatorSpec.KIND),
+    @Type(value = MarkerOperatorSpec.class, name = MarkerOperatorSpec.KIND),
+    @Type(value = CustomOperatorSpec.class, name = CustomOperatorSpec.KIND),
+})
+public interface OperatorSpec {
+
+    /**
+     * Returns the kind of this operator.
+     * @return the operator kind
+     */
+    @JsonProperty(Constants.ID_KIND)
+    OperatorKind getOperatorKind();
+
+    /**
+     * Represents a kind of {@link OperatorSpec}.
+     * @since 0.4.2
+     */
+    enum OperatorKind {
+
+        /**
+         * Core operators.
+         */
+        @JsonProperty(CoreOperatorSpec.KIND) CORE,
+
+        /**
+         * User operators.
+         */
+        @JsonProperty(UserOperatorSpec.KIND) USER,
+
+        /**
+         * Nested operators.
+         */
+        @JsonProperty(FlowOperatorSpec.KIND) FLOW,
+
+        /**
+         * External inputs.
+         */
+        @JsonProperty(InputOperatorSpec.KIND) INPUT,
+
+        /**
+         * External outputs.
+         */
+        @JsonProperty(OutputOperatorSpec.KIND) OUTPUT,
+
+        /**
+         * Pseudo operators for information.
+         * This will be used only in planning, and must not appear in DSLs.
+         */
+        @JsonProperty(MarkerOperatorSpec.KIND) MARKER,
+
+        /**
+         * Custom operators.
+         * This will be appeared in some optimization phases.
+         */
+        @JsonProperty(CustomOperatorSpec.KIND) CUSTOM,
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/OutputAttribute.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/OutputAttribute.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator;
+
+import java.util.Objects;
+
+import com.asakusafw.lang.info.Attribute;
+import com.asakusafw.lang.info.value.ClassInfo;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * An {@link Attribute} which represents details of operator outputs.
+ * @since 0.4.2
+ */
+public class OutputAttribute implements Attribute, OutputInfo {
+
+    @JsonProperty(Constants.ID_NAME)
+    private final String name;
+
+    @JsonIgnore
+    private final ClassInfo dataType;
+
+    /**
+     * Creates a new instance.
+     * @param name the port name
+     * @param dataType the data type
+     */
+    public OutputAttribute(String name, ClassInfo dataType) {
+        this.name = name;
+        this.dataType = dataType;
+    }
+
+    @JsonCreator
+    static OutputAttribute resolve(
+            @JsonProperty(Constants.ID_NAME) String name,
+            @JsonProperty(Constants.ID_TYPE) String dataType) {
+        return new OutputAttribute(name, ClassInfo.of(dataType));
+    }
+
+    @JsonProperty(Constants.ID_TYPE)
+    String getDataTypeName() {
+        return dataType.getName();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public ClassInfo getDataType() {
+        return dataType;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Objects.hashCode(name);
+        result = prime * result + Objects.hashCode(dataType);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        OutputAttribute other = (OutputAttribute) obj;
+        return Objects.equals(name, other.name)
+                && Objects.equals(dataType, other.dataType);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Output(%s)", name);
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/OutputInfo.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/OutputInfo.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator;
+
+import com.asakusafw.lang.info.value.ClassInfo;
+
+/**
+ * Details of operator outputs.
+ * @since 0.4.2
+ */
+public interface OutputInfo {
+
+    /**
+     * Returns the port name.
+     * @return the port name
+     */
+    String getName();
+
+    /**
+     * Returns the data type.
+     * @return the data type
+     */
+    ClassInfo getDataType();
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/OutputOperatorSpec.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/OutputOperatorSpec.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import com.asakusafw.lang.info.value.ClassInfo;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents an operator detail of flow outputs.
+ * @since 0.4.2
+ */
+public final class OutputOperatorSpec implements OperatorSpec {
+
+    static final String KIND = "output";
+
+    @JsonProperty(Constants.ID_NAME)
+    private final String name;
+
+    @JsonIgnore
+    private final ClassInfo descriptionClass;
+
+    private OutputOperatorSpec(String name, ClassInfo descriptionClass) {
+        this.name = name;
+        this.descriptionClass = descriptionClass;
+    }
+
+    @JsonCreator
+    static OutputOperatorSpec restore(
+            @JsonProperty(Constants.ID_NAME) String name,
+            @JsonProperty(Constants.ID_CLASS) String descriptionClass) {
+        return of(
+                name,
+                Optional.ofNullable(descriptionClass)
+                    .map(ClassInfo::of)
+                    .orElse(null));
+    }
+
+    /**
+     * Returns an instance.
+     * @param name the port name
+     * @param descriptionClass the output description (nullable)
+     * @return the instance
+     */
+    public static OutputOperatorSpec of(String name, ClassInfo descriptionClass) {
+        return new OutputOperatorSpec(name, descriptionClass);
+    }
+
+    @JsonProperty(Constants.ID_CLASS)
+    String getDescriptionClassName() {
+        return Optional.ofNullable(descriptionClass)
+                .map(ClassInfo::getName)
+                .orElse(null);
+    }
+
+    @Override
+    public OperatorKind getOperatorKind() {
+        return OperatorKind.OUTPUT;
+    }
+
+    /**
+     * Returns the name of this port.
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the description class.
+     * @return the description class, or {@code null} if it is not defined
+     */
+    public ClassInfo getDescriptionClass() {
+        return descriptionClass;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = Objects.hashCode(getOperatorKind());
+        result = prime * result + Objects.hashCode(name);
+        result = prime * result + Objects.hashCode(descriptionClass);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        OutputOperatorSpec other = (OutputOperatorSpec) obj;
+        return Objects.equals(name, other.name)
+                && Objects.equals(descriptionClass, other.descriptionClass);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Output(name=%s, desc=%s)", name, descriptionClass);
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/ParameterInfo.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/ParameterInfo.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator;
+
+import java.util.Objects;
+
+import com.asakusafw.lang.info.value.ClassInfo;
+import com.asakusafw.lang.info.value.ValueInfo;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Details of operator parameters.
+ * @since 0.4.2
+ */
+public class ParameterInfo {
+
+    @JsonProperty(Constants.ID_NAME)
+    private final String name;
+
+    @JsonIgnore
+    private final ClassInfo type;
+
+    @JsonProperty(Constants.ID_VALUE)
+    private final ValueInfo value;
+
+    /**
+     * Creates a new instance.
+     * @param name the parameter name
+     * @param type the parameter type
+     * @param value the argument
+     */
+    public ParameterInfo(String name, ClassInfo type, ValueInfo value) {
+        this.name = name;
+        this.type = type;
+        this.value = value;
+    }
+
+    @JsonCreator
+    static ParameterInfo restore(
+            @JsonProperty(Constants.ID_NAME) String name,
+            @JsonProperty(Constants.ID_TYPE) String type,
+            @JsonProperty(Constants.ID_VALUE) ValueInfo value) {
+        return new ParameterInfo(name, ClassInfo.of(type), value);
+    }
+
+    @JsonProperty(Constants.ID_TYPE)
+    String getTypeName() {
+        return type.getName();
+    }
+
+    /**
+     * Returns the parameter name.
+     * @return the parameter name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the parameter type.
+     * @return the parameter type
+     */
+    public ClassInfo getType() {
+        return type;
+    }
+
+    /**
+     * Returns the argument.
+     * @return the argument
+     */
+    public ValueInfo getValue() {
+        return value;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Objects.hashCode(name);
+        result = prime * result + Objects.hashCode(type);
+        result = prime * result + Objects.hashCode(value);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        ParameterInfo other = (ParameterInfo) obj;
+        return Objects.equals(name, other.name)
+                && Objects.equals(type, other.type)
+                && Objects.equals(value, other.value);
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "Parameter(%s:%s:%s)",
+                name,
+                type.getClassName(),
+                value.getObject());
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/UserOperatorSpec.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/UserOperatorSpec.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator;
+
+import java.util.Objects;
+
+import com.asakusafw.lang.info.value.AnnotationInfo;
+import com.asakusafw.lang.info.value.ClassInfo;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Details of user operators.
+ * @since 0.4.2
+ */
+public final class UserOperatorSpec implements OperatorSpec {
+
+    static final String KIND = "user";
+
+    @JsonProperty(Constants.ID_ANNOTATION)
+    private final AnnotationInfo annotation;
+
+    @JsonIgnore
+    private final ClassInfo declaringClass;
+
+    @JsonIgnore
+    private final ClassInfo implementationClass;
+
+    @JsonProperty(Constants.ID_METHOD)
+    private final String methodName;
+
+    private UserOperatorSpec(
+            AnnotationInfo annotation,
+            ClassInfo declaringClass, ClassInfo implementationClass,
+            String methodName) {
+        this.annotation = annotation;
+        this.declaringClass = declaringClass;
+        this.implementationClass = implementationClass;
+        this.methodName = methodName;
+    }
+
+    /**
+     * Returns an instance.
+     * @param annotation the annotation
+     * @param declaringClass the declaring class
+     * @param implementationClass the implementation class
+     * @param methodName the method name
+     * @return the instance
+     */
+    public static UserOperatorSpec of(
+            AnnotationInfo annotation,
+            ClassInfo declaringClass,
+            ClassInfo implementationClass,
+            String methodName) {
+        return new UserOperatorSpec(annotation, declaringClass, implementationClass, methodName);
+    }
+
+    @JsonCreator
+    static UserOperatorSpec restore(
+            @JsonProperty(Constants.ID_ANNOTATION) AnnotationInfo annotation,
+            @JsonProperty(Constants.ID_CLASS) String declaringClass,
+            @JsonProperty(Constants.ID_IMPLEMENTATION) String implementationClass,
+            @JsonProperty(Constants.ID_METHOD) String methodName) {
+        return of(
+                annotation,
+                ClassInfo.of(declaringClass),
+                ClassInfo.of(implementationClass),
+                methodName);
+    }
+
+    @JsonProperty(Constants.ID_CLASS)
+    String getDeclaringClassName() {
+        return declaringClass.getName();
+    }
+
+    @JsonProperty(Constants.ID_IMPLEMENTATION)
+    String getImplementationClassName() {
+        return implementationClass.getName();
+    }
+
+    @Override
+    public OperatorKind getOperatorKind() {
+        return OperatorKind.USER;
+    }
+
+    /**
+     * Returns the operator annotation.
+     * @return the operator annotation
+     */
+    public AnnotationInfo getAnnotation() {
+        return annotation;
+    }
+
+    /**
+     * Returns the operator class.
+     * @return the operator class
+     */
+    public ClassInfo getDeclaringClass() {
+        return declaringClass;
+    }
+
+    /**
+     * Returns the implementation class.
+     * @return the implementation class
+     */
+    public ClassInfo getImplementationClass() {
+        return implementationClass;
+    }
+
+    /**
+     * Returns the operator method name.
+     * @return the operator method name
+     */
+    public String getMethodName() {
+        return methodName;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Objects.hashCode(annotation);
+        result = prime * result + Objects.hashCode(implementationClass);
+        result = prime * result + Objects.hashCode(declaringClass);
+        result = prime * result + Objects.hashCode(methodName);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        UserOperatorSpec other = (UserOperatorSpec) obj;
+        return Objects.equals(annotation, other.annotation)
+                && Objects.equals(declaringClass, other.declaringClass)
+                && Objects.equals(implementationClass, other.implementationClass)
+                && Objects.equals(methodName, other.methodName);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("User(@%s:%s.%s)",
+                annotation.getDeclaringClass().getSimpleName(),
+                declaringClass.getSimpleName(),
+                methodName);
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/Util.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/Util.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+final class Util {
+
+    private Util() {
+        return;
+    }
+
+    static <T> List<T> freeze(Collection<? extends T> elements) {
+        if (elements == null) {
+            return Collections.emptyList();
+        }
+        return Collections.unmodifiableList(new ArrayList<>(elements));
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/package-info.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Asakusa operator DSL information models.
+ */
+package com.asakusafw.lang.info.operator;

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/view/InputView.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/view/InputView.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator.view;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.asakusafw.lang.info.graph.Input;
+import com.asakusafw.lang.info.operator.InputAttribute;
+import com.asakusafw.lang.info.operator.InputGranularity;
+import com.asakusafw.lang.info.operator.InputGroup;
+import com.asakusafw.lang.info.operator.InputInfo;
+import com.asakusafw.lang.info.value.ClassInfo;
+
+/**
+ * A view of operator inputs.
+ * @since 0.4.2
+ */
+public class InputView implements InputInfo {
+
+    private final OperatorGraphView container;
+
+    private final Input entity;
+
+    private final InputInfo info;
+
+    InputView(OperatorGraphView container, Input entity) {
+        this.container = container;
+        this.entity = entity;
+        this.info = Util.extract(entity, InputAttribute.class);
+    }
+
+    /**
+     * Returns the owner of this port.
+     * @return the owner
+     */
+    public OperatorView getOwner() {
+        return container.resolve(entity.getParent());
+    }
+
+    /**
+     * Returns the opposite ports.
+     * @return the opposite ports
+     */
+    public List<OutputView> getOpposites() {
+        return entity.getOpposites().stream()
+                .map(container::resolve)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String getName() {
+        return info.getName();
+    }
+
+    @Override
+    public ClassInfo getDataType() {
+        return info.getDataType();
+    }
+
+    @Override
+    public InputGranularity getGranulatity() {
+        return info.getGranulatity();
+    }
+
+    @Override
+    public InputGroup getGroup() {
+        return info.getGroup();
+    }
+
+    @Override
+    public String toString() {
+        return info.toString();
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/view/OperatorGraphView.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/view/OperatorGraphView.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator.view;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.asakusafw.lang.info.graph.Input;
+import com.asakusafw.lang.info.graph.Node;
+import com.asakusafw.lang.info.graph.Output;
+import com.asakusafw.lang.info.operator.InputOperatorSpec;
+import com.asakusafw.lang.info.operator.OperatorGraphAttribute;
+import com.asakusafw.lang.info.operator.OperatorSpec.OperatorKind;
+import com.asakusafw.lang.info.operator.OutputOperatorSpec;
+
+/**
+ * A view of operator graph.
+ * @since 0.4.2
+ */
+public class OperatorGraphView {
+
+    private final Node root;
+
+    private final Map<Node, OperatorView> vertices = new HashMap<>();
+
+    private final Map<Input, InputView> inputs = new HashMap<>();
+
+    private final Map<Output, OutputView> outputs = new HashMap<>();
+
+    /**
+     * Creates a new instance.
+     * @param graph the source graph
+     */
+    public OperatorGraphView(OperatorGraphAttribute graph) {
+        this.root = graph.getRoot();
+    }
+
+    OperatorGraphView(Node entity) {
+        this.root = entity;
+    }
+
+    /**
+     * Returns the root node.
+     * @return the root node
+     */
+    public Node getRoot() {
+        return root;
+    }
+
+    /**
+     * Returns the element operators.
+     * @return the operators, including inputs and outputs
+     */
+    public Collection<OperatorView> getOperators() {
+        return all().collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the input operators.
+     * @return the input operators
+     */
+    public Map<String, OperatorView> getInputs() {
+        return all()
+                .filter(it -> it.getSpec().getOperatorKind() == OperatorKind.INPUT)
+                .collect(Collectors.toMap(
+                        it -> ((InputOperatorSpec) it.getSpec()).getName(),
+                        Function.identity()));
+    }
+
+    /**
+     * Returns the output operators.
+     * @return the output operators
+     */
+    public Map<String, OperatorView> getOutputs() {
+        return all()
+                .filter(it -> it.getSpec().getOperatorKind() == OperatorKind.OUTPUT)
+                .collect(Collectors.toMap(
+                        it -> ((OutputOperatorSpec) it.getSpec()).getName(),
+                        Function.identity()));
+    }
+
+    private Stream<OperatorView> all() {
+        return root.getElements().stream().map(this::resolve);
+    }
+
+    OperatorView resolve(Node node) {
+        assert node.getParent() == root;
+        return vertices.computeIfAbsent(node, it -> new OperatorView(this, it));
+    }
+
+    InputView resolve(Input port) {
+        assert port.getParent().getParent() == root;
+        return inputs.computeIfAbsent(port, it -> new InputView(this, it));
+    }
+
+    OutputView resolve(Output port) {
+        assert port.getParent().getParent() == root;
+        return outputs.computeIfAbsent(port, it -> new OutputView(this, it));
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/view/OperatorView.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/view/OperatorView.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator.view;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.asakusafw.lang.info.graph.Node;
+import com.asakusafw.lang.info.operator.OperatorAttribute;
+import com.asakusafw.lang.info.operator.OperatorInfo;
+import com.asakusafw.lang.info.operator.OperatorSpec;
+import com.asakusafw.lang.info.operator.ParameterInfo;
+
+/**
+ * A view of operator operators.
+ * @since 0.4.2
+ */
+public class OperatorView implements OperatorInfo {
+
+    private final OperatorGraphView container;
+
+    private final Node entity;
+
+    private final OperatorInfo info;
+
+    private OperatorGraphView nest;
+
+    OperatorView(OperatorGraphView container, Node entity) {
+        this.container = container;
+        this.entity = entity;
+        this.info = Util.extract(entity, OperatorAttribute.class);
+    }
+
+    Node getEntity() {
+        return entity;
+    }
+
+    @Override
+    public OperatorSpec getSpec() {
+        return info.getSpec();
+    }
+
+    /**
+     * Returns views of input ports.
+     * @return the input views
+     */
+    public List<InputView> getInputs() {
+        return entity.getInputs().stream()
+                .map(container::resolve)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns views of output ports.
+     * @return the output views
+     */
+    public List<OutputView> getOutputs() {
+        return entity.getOutputs().stream()
+                .map(container::resolve)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<ParameterInfo> getParameters() {
+        return info.getParameters();
+    }
+
+    /**
+     * Returns {@link OperatorGraphView} of this operator.
+     * @return the flow view
+     */
+    public OperatorGraphView getElementGraph() {
+        if (nest == null) {
+            nest = new OperatorGraphView(entity);
+        }
+        return nest;
+    }
+
+    @Override
+    public String toString() {
+        return info.toString();
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/view/OutputView.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/view/OutputView.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator.view;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.asakusafw.lang.info.graph.Output;
+import com.asakusafw.lang.info.operator.OutputAttribute;
+import com.asakusafw.lang.info.operator.OutputInfo;
+import com.asakusafw.lang.info.value.ClassInfo;
+
+/**
+ * A view of operator outputs.
+ * @since 0.4.2
+ */
+public class OutputView implements OutputInfo {
+
+    private final OperatorGraphView container;
+
+    private final Output entity;
+
+    private final OutputInfo info;
+
+    OutputView(OperatorGraphView container, Output entity) {
+        this.container = container;
+        this.entity = entity;
+        this.info = Util.extract(entity, OutputAttribute.class);
+    }
+
+    /**
+     * Returns the owner of this port.
+     * @return the owner
+     */
+    public OperatorView getOwner() {
+        return container.resolve(entity.getParent());
+    }
+
+    /**
+     * Returns the opposite ports.
+     * @return the opposite ports
+     */
+    public List<InputView> getOpposites() {
+        return entity.getOpposites().stream()
+                .map(container::resolve)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String getName() {
+        return info.getName();
+    }
+
+    @Override
+    public ClassInfo getDataType() {
+        return info.getDataType();
+    }
+
+    @Override
+    public String toString() {
+        return info.toString();
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/view/Util.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/view/Util.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator.view;
+
+import com.asakusafw.lang.info.Attribute;
+import com.asakusafw.lang.info.graph.Element;
+
+final class Util {
+
+    private Util() {
+        return;
+    }
+
+    static <A extends Attribute> A extract(Element element, Class<A> attributeType) {
+        return element.getAttributes().stream()
+                .filter(attributeType::isInstance)
+                .map(attributeType::cast)
+                .findAny()
+                .orElseThrow(IllegalStateException::new);
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/view/package-info.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/view/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Views of operator graphs.
+ */
+package com.asakusafw.lang.info.operator.view;

--- a/info/model/src/main/java/com/asakusafw/lang/info/value/AnnotationInfo.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/value/AnnotationInfo.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.value;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents an annotation.
+ * @since 0.4.2
+ */
+public final class AnnotationInfo implements ValueInfo {
+
+    static final String KIND = "annotation"; //$NON-NLS-1$
+
+    @JsonIgnore
+    private final ClassInfo declaringClass;
+
+    @JsonProperty(Constants.ID_ELEMENTS)
+    @JsonInclude(Include.NON_EMPTY)
+    private final Map<String, ValueInfo> elements;
+
+    private AnnotationInfo(ClassInfo declaringClass, Map<String, ValueInfo> elements) {
+        Objects.requireNonNull(declaringClass);
+        Objects.requireNonNull(elements);
+        this.declaringClass = declaringClass;
+        this.elements = elements;
+    }
+
+    @JsonCreator
+    static AnnotationInfo of(
+            @JsonProperty(Constants.ID_CLASS) String declaringClass,
+            @JsonProperty(Constants.ID_ELEMENTS) Map<String, ? extends ValueInfo> elements) {
+        return of(ClassInfo.of(declaringClass), elements == null ? Collections.emptyMap() : elements);
+    }
+
+    @JsonProperty(Constants.ID_CLASS)
+    String getDeclaringClassName() {
+        return declaringClass.getName();
+    }
+
+    /**
+     * Returns an instance for the annotation.
+     * @param declaringClass the annotation type
+     * @param elements the annotation members
+     * @return the instance
+     */
+    public static AnnotationInfo of(ClassInfo declaringClass, Map<String, ? extends ValueInfo> elements) {
+        return new AnnotationInfo(declaringClass, Collections.unmodifiableMap(new LinkedHashMap<>(elements)));
+    }
+
+    @Override
+    public Kind getKind() {
+        return Kind.ANNOTATION;
+    }
+
+    @Override
+    public String getObject() {
+        StringBuilder buf = new StringBuilder();
+        buf.append('@');
+        buf.append(declaringClass.getName());
+        if (elements.isEmpty() == false) {
+            buf.append('(');
+            ValueInfo value = elements.get("value");
+            if (value != null && elements.size() == 1) {
+                buf.append(value.getObject());
+            } else {
+                buf.append(elements.entrySet().stream()
+                    .map(e -> String.format("%s=%s", e.getKey(), e.getValue().getObject()))
+                    .collect(Collectors.joining(", ")));
+            }
+            buf.append(')');
+        }
+        return buf.toString();
+    }
+
+    /**
+     * Returns the annotation type.
+     * @return the annotation type
+     */
+    public ClassInfo getDeclaringClass() {
+        return declaringClass;
+    }
+
+    /**
+     * Returns the elements.
+     * @return the elements
+     */
+    public Map<String, ValueInfo> getElements() {
+        return elements;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = Objects.hashCode(getKind());
+        result = prime * result + Objects.hashCode(declaringClass);
+        result = prime * result + Objects.hashCode(elements);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof AnnotationInfo)) {
+            return false;
+        }
+        AnnotationInfo other = (AnnotationInfo) obj;
+        return Objects.equals(declaringClass, other.declaringClass)
+                && Objects.equals(elements, other.elements);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s(class=%s, elements={%s})",
+                getKind(),
+                declaringClass,
+                elements);
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/value/BooleanInfo.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/value/BooleanInfo.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.value;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a {@code boolean} value.
+ * @since 0.4.2
+ */
+public final class BooleanInfo implements ValueInfo {
+
+    static final String KIND = "boolean"; //$NON-NLS-1$
+
+    @JsonProperty(Constants.ID_VALUE)
+    private final boolean value;
+
+    private BooleanInfo(boolean value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns an instance for the value.
+     * @param value the value
+     * @return the instance
+     */
+    @JsonCreator
+    public static BooleanInfo of(@JsonProperty(Constants.ID_VALUE) boolean value) {
+        return new BooleanInfo(value);
+    }
+
+    @Override
+    public Kind getKind() {
+        return Kind.BOOLEAN;
+    }
+
+    @Override
+    public Boolean getObject() {
+        return getValue();
+    }
+
+    /**
+     * Returns the value.
+     * @return the value
+     */
+    public boolean getValue() {
+        return value;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = Objects.hashCode(getKind());
+        result = prime * result + Boolean.hashCode(value);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof BooleanInfo)) {
+            return false;
+        }
+        BooleanInfo other = (BooleanInfo) obj;
+        return value == other.value;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s(%s)", getKind(), getObject());
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/value/ByteInfo.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/value/ByteInfo.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.value;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a {@code byte} value.
+ * @since 0.4.2
+ */
+public final class ByteInfo implements NumberInfo {
+
+    static final String KIND = "byte"; //$NON-NLS-1$
+
+    @JsonProperty(Constants.ID_VALUE)
+    private final byte value;
+
+    private ByteInfo(byte value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns an instance for the value.
+     * @param value the value
+     * @return the instance
+     */
+    @JsonCreator
+    public static ByteInfo of(@JsonProperty(Constants.ID_VALUE) byte value) {
+        return new ByteInfo(value);
+    }
+
+    @Override
+    public Kind getKind() {
+        return Kind.BYTE;
+    }
+
+    @Override
+    public Byte getObject() {
+        return getValue();
+    }
+
+    /**
+     * Returns the value.
+     * @return the value
+     */
+    public byte getValue() {
+        return value;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = Objects.hashCode(getKind());
+        result = prime * result + Byte.hashCode(value);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof ByteInfo)) {
+            return false;
+        }
+        ByteInfo other = (ByteInfo) obj;
+        return value == other.value;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s(%s)", getKind(), getObject());
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/value/CharInfo.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/value/CharInfo.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.value;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a {@code char} value.
+ * @since 0.4.2
+ */
+public final class CharInfo implements ValueInfo {
+
+    static final String KIND = "char"; //$NON-NLS-1$
+
+    @JsonProperty(Constants.ID_VALUE)
+    private final char value;
+
+    private CharInfo(char value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns an instance for the value.
+     * @param value the value
+     * @return the instance
+     */
+    @JsonCreator
+    public static CharInfo of(@JsonProperty(Constants.ID_VALUE) char value) {
+        return new CharInfo(value);
+    }
+
+    @Override
+    public Kind getKind() {
+        return Kind.CHAR;
+    }
+
+    @Override
+    public Character getObject() {
+        return getValue();
+    }
+
+    /**
+     * Returns the value.
+     * @return the value
+     */
+    public char getValue() {
+        return value;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = Objects.hashCode(getKind());
+        result = prime * result + Character.hashCode(value);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof CharInfo)) {
+            return false;
+        }
+        CharInfo other = (CharInfo) obj;
+        return value == other.value;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s(%s)", getKind(), getObject());
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/value/ClassInfo.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/value/ClassInfo.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.value;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a {@link Class} value.
+ * @since 0.4.2
+ */
+public final class ClassInfo implements ValueInfo {
+
+    static final String KIND = "class"; //$NON-NLS-1$
+
+    private static final String SUFFIX_ARRAY = "[]";
+
+    @JsonProperty(Constants.ID_NAME)
+    private final String name;
+
+    private ClassInfo(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Returns a class value for the name.
+     * @param name the class name
+     * @return the class
+     */
+    @JsonCreator
+    public static ClassInfo of(
+            @JsonProperty(Constants.ID_NAME) String name) {
+        return new ClassInfo(name);
+    }
+
+    /**
+     * Returns the class value.
+     * @param aClass the target class
+     * @return the class info
+     */
+    public static ClassInfo of(Class<?> aClass) {
+        int dims = 0;
+        Class<?> current = aClass;
+        while (current.isArray()) {
+            current = current.getComponentType();
+            dims++;
+        }
+        if (dims == 0) {
+            return of(current.getName());
+        } else {
+            StringBuilder buf = new StringBuilder();
+            buf.append(current.getName());
+            for (int i = 0; i < dims; i++) {
+                buf.append(SUFFIX_ARRAY);
+            }
+            return of(buf.toString());
+        }
+    }
+
+    @Override
+    public Kind getKind() {
+        return Kind.CLASS;
+    }
+
+    @Override
+    public String getObject() {
+        return getName();
+    }
+
+    /**
+     * Returns the name.
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the fully qualified class name.
+     * @return the fully qualified class name
+     */
+    @JsonIgnore
+    public String getClassName() {
+        return name.replace('$', '.');
+    }
+
+    /**
+     * Returns the binary name.
+     * @return the binary name
+     */
+    @JsonIgnore
+    public String getBinaryName() {
+        return name;
+    }
+
+    /**
+     * Returns the class simple name.
+     * @return the class simple name
+     */
+    @JsonIgnore
+    public String getSimpleName() {
+        int index = Math.max(name.lastIndexOf('.'), name.lastIndexOf('$'));
+        if (index < 0) {
+            return name;
+        }
+        return name.substring(index + 1);
+    }
+
+    /**
+     * Returns the array type of this.
+     * @return the array type
+     */
+    @JsonIgnore
+    public ClassInfo getArrayType() {
+        return ClassInfo.of(name + SUFFIX_ARRAY);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = Objects.hashCode(getKind());
+        result = prime * result + Objects.hashCode(name);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof ClassInfo)) {
+            return false;
+        }
+        ClassInfo other = (ClassInfo) obj;
+        return Objects.equals(name, other.name);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s(%s)", getKind(), getObject());
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/value/Constants.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/value/Constants.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.value;
+
+final class Constants {
+
+    static final String ID_KIND = "kind";
+
+    static final String ID_CLASS = "class";
+
+    static final String ID_NAME = "name";
+
+    static final String ID_VALUE = "value";
+
+    static final String ID_ELEMENTS = "elements";
+
+    private Constants() {
+        return;
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/value/DoubleInfo.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/value/DoubleInfo.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.value;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a {@code double} value.
+ * @since 0.4.2
+ */
+public final class DoubleInfo implements NumberInfo {
+
+    static final String KIND = "double"; //$NON-NLS-1$
+
+    @JsonProperty(Constants.ID_VALUE)
+    private final double value;
+
+    private DoubleInfo(double value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns an instance for the value.
+     * @param value the value
+     * @return the instance
+     */
+    @JsonCreator
+    public static DoubleInfo of(@JsonProperty(Constants.ID_VALUE) double value) {
+        return new DoubleInfo(value);
+    }
+
+    @Override
+    public Kind getKind() {
+        return Kind.DOUBLE;
+    }
+
+    @Override
+    public Double getObject() {
+        return getValue();
+    }
+
+    /**
+     * Returns the value.
+     * @return the value
+     */
+    public double getValue() {
+        return value;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = Objects.hashCode(getKind());
+        result = prime * result + Double.hashCode(value);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof DoubleInfo)) {
+            return false;
+        }
+        DoubleInfo other = (DoubleInfo) obj;
+        return value == other.value;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s(%s)", getKind(), getObject());
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/value/EnumInfo.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/value/EnumInfo.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.value;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents an {@link Enum} constant.
+ * @since 0.4.2
+ */
+public final class EnumInfo implements ValueInfo {
+
+    static final String KIND = "enum"; //$NON-NLS-1$
+
+    static final char NAME_SEPARATOR = '.';
+
+    @JsonIgnore
+    private final ClassInfo declaringClass;
+
+    @JsonProperty(Constants.ID_NAME)
+    private final String name;
+
+    private EnumInfo(ClassInfo declaringClass, String name) {
+        this.declaringClass = declaringClass;
+        this.name = name;
+    }
+
+    @JsonCreator
+    static EnumInfo of(
+            @JsonProperty(Constants.ID_CLASS) String declaringClassName,
+            @JsonProperty(Constants.ID_NAME) String name) {
+        return of(ClassInfo.of(declaringClassName), name);
+    }
+
+    @JsonProperty(Constants.ID_CLASS)
+    String getDeclaringClassName() {
+        return declaringClass.getName();
+    }
+
+    /**
+     * Returns an instance for the enum constant.
+     * @param declaringClass the declaring class of the constant
+     * @param name the name of the constant
+     * @return the instance
+     */
+    public static EnumInfo of(ClassInfo declaringClass, String name) {
+        return new EnumInfo(declaringClass, name);
+    }
+
+    /**
+     * Returns an instance for the enum constant.
+     * @param value the value
+     * @return the instance
+     */
+    public static EnumInfo of(Enum<?> value) {
+        return of(ClassInfo.of(value.getDeclaringClass()), value.name());
+    }
+
+    @Override
+    public Kind getKind() {
+        return Kind.ENUM;
+    }
+
+    @Override
+    public String getObject() {
+        return declaringClass.getName() + NAME_SEPARATOR + name;
+    }
+
+    /**
+     * Returns the declaring class.
+     * @return the declaring class
+     */
+    public ClassInfo getDeclaringClass() {
+        return declaringClass;
+    }
+
+    /**
+     * Returns the name.
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = Objects.hashCode(getKind());
+        result = prime * result + Objects.hashCode(declaringClass);
+        result = prime * result + Objects.hashCode(name);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof EnumInfo)) {
+            return false;
+        }
+        EnumInfo other = (EnumInfo) obj;
+        return Objects.equals(declaringClass, other.declaringClass)
+                && Objects.equals(name, other.name);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s(%s)", getKind(), getObject());
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/value/FloatInfo.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/value/FloatInfo.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.value;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a {@code float} value.
+ * @since 0.4.2
+ */
+public final class FloatInfo implements NumberInfo {
+
+    static final String KIND = "float"; //$NON-NLS-1$
+
+    @JsonProperty(Constants.ID_VALUE)
+    private final float value;
+
+    private FloatInfo(float value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns an instance for the value.
+     * @param value the value
+     * @return the instance
+     */
+    @JsonCreator
+    public static FloatInfo of(@JsonProperty(Constants.ID_VALUE) float value) {
+        return new FloatInfo(value);
+    }
+
+    @Override
+    public Kind getKind() {
+        return Kind.FLOAT;
+    }
+
+    @Override
+    public Float getObject() {
+        return getValue();
+    }
+
+    /**
+     * Returns the value.
+     * @return the value
+     */
+    public float getValue() {
+        return value;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = Objects.hashCode(getKind());
+        result = prime * result + Float.hashCode(value);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof FloatInfo)) {
+            return false;
+        }
+        FloatInfo other = (FloatInfo) obj;
+        return value == other.value;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s(%s)", getKind(), getObject());
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/value/IntInfo.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/value/IntInfo.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.value;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a {@code int} value.
+ * @since 0.4.2
+ */
+public final class IntInfo implements NumberInfo {
+
+    static final String KIND = "int"; //$NON-NLS-1$
+
+    @JsonProperty(Constants.ID_VALUE)
+    private final int value;
+
+    private IntInfo(int value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns an instance for the value.
+     * @param value the value
+     * @return the instance
+     */
+    @JsonCreator
+    public static IntInfo of(@JsonProperty(Constants.ID_VALUE) int value) {
+        return new IntInfo(value);
+    }
+
+    @Override
+    public Kind getKind() {
+        return Kind.INT;
+    }
+
+    @Override
+    public Integer getObject() {
+        return getValue();
+    }
+
+    /**
+     * Returns the value.
+     * @return the value
+     */
+    public int getValue() {
+        return value;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = Objects.hashCode(getKind());
+        result = prime * result + Integer.hashCode(value);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof IntInfo)) {
+            return false;
+        }
+        IntInfo other = (IntInfo) obj;
+        return value == other.value;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s(%s)", getKind(), getObject());
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/value/ListInfo.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/value/ListInfo.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.value;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a list of {@link ValueInfo}.
+ * @since 0.4.2
+ */
+public final class ListInfo implements ValueInfo {
+
+    static final String KIND = "list"; //$NON-NLS-1$
+
+    private static final ListInfo EMPTY = new ListInfo(Collections.emptyList());
+
+    @JsonProperty(Constants.ID_ELEMENTS)
+    @JsonInclude(Include.NON_EMPTY)
+    private final List<ValueInfo> elements;
+
+    private ListInfo(List<ValueInfo> elements) {
+        Objects.requireNonNull(elements);
+        this.elements = elements;
+    }
+
+    /**
+     * Returns an instance represents the given list.
+     * @param elements the element values
+     * @return the instance
+     */
+    @JsonCreator
+    public static ListInfo of(
+            @JsonProperty(Constants.ID_ELEMENTS) List<? extends ValueInfo> elements) {
+        if (elements == null || elements.isEmpty()) {
+            return EMPTY;
+        } else {
+            return new ListInfo(Collections.unmodifiableList(new ArrayList<>(elements)));
+        }
+    }
+
+    /**
+     * Returns an instance represents the given list.
+     * @param elements the element values
+     * @return the instance
+     */
+    public static ListInfo of(ValueInfo... elements) {
+        return of(Arrays.asList(elements));
+    }
+
+    @Override
+    public Kind getKind() {
+        return Kind.LIST;
+    }
+
+    @Override
+    public List<String> getObject() {
+        return getElements().stream()
+                .map(ValueInfo::getObject)
+                .map(String::valueOf)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the element values.
+     * @return the element values
+     */
+    public List<ValueInfo> getElements() {
+        return elements;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = Objects.hashCode(getKind());
+        result = prime * result + Objects.hashCode(getElements());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof ListInfo)) {
+            return false;
+        }
+        ListInfo other = (ListInfo) obj;
+        return Objects.equals(elements, other.elements);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s(%s)", getKind(), getObject());
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/value/LongInfo.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/value/LongInfo.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.value;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a {@code long} value.
+ * @since 0.4.2
+ */
+public final class LongInfo implements NumberInfo {
+
+    static final String KIND = "long"; //$NON-NLS-1$
+
+    @JsonProperty(Constants.ID_VALUE)
+    private final long value;
+
+    private LongInfo(long value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns an instance for the value.
+     * @param value the value
+     * @return the instance
+     */
+    @JsonCreator
+    public static LongInfo of(@JsonProperty(Constants.ID_VALUE) long value) {
+        return new LongInfo(value);
+    }
+
+    @Override
+    public Kind getKind() {
+        return Kind.LONG;
+    }
+
+    @Override
+    public Long getObject() {
+        return getValue();
+    }
+
+    /**
+     * Returns the value.
+     * @return the value
+     */
+    public long getValue() {
+        return value;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Objects.hashCode(getKind());
+        result = prime * result + Long.hashCode(value);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof LongInfo)) {
+            return false;
+        }
+        LongInfo other = (LongInfo) obj;
+        return value == other.value;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s(%s)", getKind(), getObject());
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/value/NullInfo.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/value/NullInfo.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.value;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+/**
+ * Represents {@code null}.
+ * @since 0.4.2
+ */
+public final class NullInfo implements ValueInfo {
+
+    static final String KIND = "null"; //$NON-NLS-1$
+
+    private static final NullInfo INSTANCE = new NullInfo();
+
+    private NullInfo() {
+        return;
+    }
+
+    /**
+     * Returns the instance.
+     * @return the instance
+     */
+    @JsonCreator
+    public static NullInfo get() {
+        return INSTANCE;
+    }
+
+    @Override
+    public Kind getKind() {
+        return Kind.NULL;
+    }
+
+    @Override
+    public Object getObject() {
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return KIND;
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/value/NumberInfo.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/value/NumberInfo.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.value;
+
+/**
+ * Represents a {@link Number} value.
+ * @since 0.4.2
+ */
+public interface NumberInfo extends ValueInfo {
+
+    @Override
+    Number getObject();
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/value/ShortInfo.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/value/ShortInfo.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.value;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a {@code short} value.
+ * @since 0.4.2
+ */
+public final class ShortInfo implements NumberInfo {
+
+    static final String KIND = "short"; //$NON-NLS-1$
+
+    @JsonProperty(Constants.ID_VALUE)
+    private final short value;
+
+    private ShortInfo(short value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns an instance for the value.
+     * @param value the value
+     * @return the instance
+     */
+    @JsonCreator
+    public static ShortInfo of(@JsonProperty(Constants.ID_VALUE) short value) {
+        return new ShortInfo(value);
+    }
+
+    @Override
+    public Kind getKind() {
+        return Kind.SHORT;
+    }
+
+    @Override
+    public Short getObject() {
+        return getValue();
+    }
+
+    /**
+     * Returns the value.
+     * @return the value
+     */
+    public short getValue() {
+        return value;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Objects.hashCode(getKind());
+        result = prime * result + Short.hashCode(value);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof ShortInfo)) {
+            return false;
+        }
+        ShortInfo other = (ShortInfo) obj;
+        return value == other.value;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s(%s)", getKind(), getObject());
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/value/StringInfo.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/value/StringInfo.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.value;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a {@code String} value.
+ * @since 0.4.2
+ */
+public final class StringInfo implements ValueInfo {
+
+    static final String KIND = "string"; //$NON-NLS-1$
+
+    @JsonProperty(Constants.ID_VALUE)
+    private final String value;
+
+    private StringInfo(String value) {
+        Objects.requireNonNull(value);
+        this.value = value;
+    }
+
+    /**
+     * Returns an instance for the value.
+     * @param value the value
+     * @return the instance
+     */
+    @JsonCreator
+    public static StringInfo of(@JsonProperty(Constants.ID_VALUE) String value) {
+        Objects.requireNonNull(value);
+        return new StringInfo(value);
+    }
+
+    @Override
+    public Kind getKind() {
+        return Kind.STRING;
+    }
+
+    @Override
+    public String getObject() {
+        return getValue();
+    }
+
+    /**
+     * Returns the value.
+     * @return the value
+     */
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Objects.hashCode(getKind());
+        result = prime * result + Objects.hashCode(value);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof StringInfo)) {
+            return false;
+        }
+        StringInfo other = (StringInfo) obj;
+        return Objects.equals(value, other.value);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s(%s)", getKind(), getObject());
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/value/UnknownInfo.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/value/UnknownInfo.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.value;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents an unknown value.
+ * @since 0.4.2
+ */
+public final class UnknownInfo implements ValueInfo {
+
+    static final String KIND = "unknown"; //$NON-NLS-1$
+
+    @JsonIgnore
+    private final ClassInfo declaringClass;
+
+    @JsonProperty(Constants.ID_VALUE)
+    private final String value;
+
+    private UnknownInfo(ClassInfo declaringClass, String value) {
+        this.declaringClass = declaringClass;
+        this.value = value;
+    }
+
+    @JsonCreator
+    static UnknownInfo of(
+            @JsonProperty(Constants.ID_CLASS) String declaringClass,
+            @JsonProperty(Constants.ID_VALUE) String value) {
+        return of(ClassInfo.of(declaringClass), value);
+    }
+
+    /**
+     * Returns an instance for the given unknown value.
+     * @param declaringClass class of the value
+     * @param value string representation of the value
+     * @return the instance
+     */
+    public static UnknownInfo of(ClassInfo declaringClass, String value) {
+        return new UnknownInfo(declaringClass, value);
+    }
+
+    /**
+     * Returns an instance for the value.
+     * @param value the target value
+     * @return the instance
+     */
+    public static UnknownInfo of(Object value) {
+        Objects.requireNonNull(value);
+        return of(ClassInfo.of(value.getClass()), String.valueOf(value));
+    }
+
+    @JsonProperty(Constants.ID_CLASS)
+    String getDeclaringClassName() {
+        return declaringClass.getName();
+    }
+
+    @Override
+    public Kind getKind() {
+        return Kind.UNKNOWN;
+    }
+
+    @Override
+    public String getObject() {
+        return getValue();
+    }
+
+    /**
+     * Returns the value.
+     * @return the value
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Returns the value class.
+     * @return the value class
+     */
+    public ClassInfo getDeclaringClass() {
+        return declaringClass;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s(%s)", getKind(), getObject());
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/value/Util.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/value/Util.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.value;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+final class Util {
+
+    private Util() {
+        return;
+    }
+
+    private static final Map<Class<?>, Function<Object, ValueInfo>> CONVERTERS;
+    static {
+        Map<Class<?>, Function<Object, ValueInfo>> map = new HashMap<>();
+        converter(map, BooleanInfo::of, Boolean.class);
+        converter(map, ByteInfo::of, Byte.class);
+        converter(map, ShortInfo::of, Short.class);
+        converter(map, IntInfo::of, Integer.class);
+        converter(map, LongInfo::of, Long.class);
+        converter(map, FloatInfo::of, Float.class);
+        converter(map, DoubleInfo::of, Double.class);
+        converter(map, CharInfo::of, Character.class);
+        converter(map, StringInfo::of, String.class);
+        converter(map, ClassInfo::of, Class.class);
+        CONVERTERS = map;
+    }
+
+    private static <T> void converter(
+            Map<Class<?>, Function<Object, ValueInfo>> map,
+            Function<T, ValueInfo> converter,
+            Class<T> target) {
+        map.put(target, it -> converter.apply(target.cast(it)));
+    }
+
+    static ValueInfo convert(Object value) {
+        if (value == null) {
+            return NullInfo.get();
+        }
+        Function<Object, ValueInfo> converter = CONVERTERS.get(value.getClass());
+        if (converter != null) {
+            return converter.apply(value);
+        } else if (value instanceof Iterable<?>) {
+            List<ValueInfo> elements = new ArrayList<>();
+            ((Iterable<?>) value).forEach(it -> elements.add(convert(it)));
+            return ListInfo.of(elements);
+        } else if (value.getClass().isArray()) {
+            ValueInfo[] elements = new ValueInfo[Array.getLength(value)];
+            for (int i = 0; i < elements.length; i++) {
+                elements[i] = convert(Array.get(value, i));
+            }
+            return ListInfo.of(Arrays.asList(elements));
+        } else if (value instanceof Enum<?>) {
+            return EnumInfo.of((Enum<?>) value);
+        } else if (value instanceof Annotation) {
+            return convert0((Annotation) value);
+        } else {
+            return UnknownInfo.of(value);
+        }
+    }
+
+    private static ValueInfo convert0(Annotation annotation) {
+        try {
+            Class<? extends Annotation> declaring = annotation.annotationType();
+            Map<String, ValueInfo> elements = new LinkedHashMap<>();
+            for (Method method : declaring.getMethods()) {
+                if (Modifier.isStatic(method.getModifiers())) {
+                    continue;
+                }
+                if (method.getDeclaringClass() != declaring || method.isSynthetic()) {
+                    continue;
+                }
+                if (method.getParameterTypes().length != 0) {
+                    continue;
+                }
+                Object v = method.invoke(annotation);
+                elements.put(method.getName(), convert(v));
+            }
+            return AnnotationInfo.of(ClassInfo.of(declaring), elements);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalArgumentException(MessageFormat.format(
+                    "failed to analyze annotation: {0}", //$NON-NLS-1$
+                    annotation), e);
+        }
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/value/ValueInfo.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/value/ValueInfo.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.value;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Represents a value.
+ * @since 0.4.2
+ */
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.EXISTING_PROPERTY,
+        property = Constants.ID_KIND,
+        visible = false
+)
+@JsonSubTypes({
+    @Type(value = UnknownInfo.class, name = UnknownInfo.KIND),
+    @Type(value = NullInfo.class, name = NullInfo.KIND),
+    @Type(value = BooleanInfo.class, name = BooleanInfo.KIND),
+    @Type(value = ByteInfo.class, name = ByteInfo.KIND),
+    @Type(value = ShortInfo.class, name = ShortInfo.KIND),
+    @Type(value = IntInfo.class, name = IntInfo.KIND),
+    @Type(value = LongInfo.class, name = LongInfo.KIND),
+    @Type(value = FloatInfo.class, name = FloatInfo.KIND),
+    @Type(value = DoubleInfo.class, name = DoubleInfo.KIND),
+    @Type(value = CharInfo.class, name = CharInfo.KIND),
+    @Type(value = StringInfo.class, name = StringInfo.KIND),
+    @Type(value = ClassInfo.class, name = ClassInfo.KIND),
+    @Type(value = ListInfo.class, name = ListInfo.KIND),
+    @Type(value = EnumInfo.class, name = EnumInfo.KIND),
+    @Type(value = AnnotationInfo.class, name = AnnotationInfo.KIND),
+})
+public interface ValueInfo {
+
+    /**
+     * Returns the type of this value.
+     * @return the type
+     */
+    @JsonProperty(Constants.ID_KIND)
+    Kind getKind();
+
+    /**
+     * Returns the value as {@link Object}.
+     * @return the value, or its string representation
+     */
+    @JsonIgnore
+    Object getObject();
+
+    /**
+     * Returns {@link ValueInfo} for the given value.
+     * @param value the target value
+     * @return the corresponded {@link ValueInfo}
+     */
+    static ValueInfo of(Object value) {
+        return Util.convert(value);
+    }
+
+    /**
+     * Represents a type of {@link ValueInfo}.
+     * @since 0.4.2
+     */
+    enum Kind {
+
+        /**
+         * unknown kind.
+         */
+        @JsonProperty(UnknownInfo.KIND) UNKNOWN,
+
+        /**
+         * null kind.
+         */
+        @JsonProperty(NullInfo.KIND) NULL,
+
+        /**
+         * boolean kind.
+         */
+        @JsonProperty(BooleanInfo.KIND) BOOLEAN,
+
+        /**
+         * byte kind.
+         */
+        @JsonProperty(ByteInfo.KIND) BYTE,
+
+        /**
+         * short kind.
+         */
+        @JsonProperty(ShortInfo.KIND) SHORT,
+
+        /**
+         * int kind.
+         */
+        @JsonProperty(IntInfo.KIND) INT,
+
+        /**
+         * long kind.
+         */
+        @JsonProperty(LongInfo.KIND) LONG,
+
+        /**
+         * float kind.
+         */
+        @JsonProperty(FloatInfo.KIND) FLOAT,
+
+        /**
+         * double kind.
+         */
+        @JsonProperty(DoubleInfo.KIND) DOUBLE,
+
+        /**
+         * char kind.
+         */
+        @JsonProperty(CharInfo.KIND) CHAR,
+
+        /**
+         * string kind.
+         */
+        @JsonProperty(StringInfo.KIND) STRING,
+
+        /**
+         * class kind.
+         */
+        @JsonProperty(ClassInfo.KIND) CLASS,
+
+        /**
+         * value list kind.
+         */
+        @JsonProperty(ListInfo.KIND) LIST,
+
+        /**
+         * enum kind.
+         */
+        @JsonProperty(EnumInfo.KIND) ENUM,
+
+        /**
+         * annotation kind.
+         */
+        @JsonProperty(AnnotationInfo.KIND) ANNOTATION,
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/value/package-info.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/value/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Wrapped values.
+ */
+package com.asakusafw.lang.info.value;

--- a/info/model/src/test/java/com/asakusafw/lang/info/graph/NodeTest.java
+++ b/info/model/src/test/java/com/asakusafw/lang/info/graph/NodeTest.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.graph;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.asakusafw.lang.info.InfoSerDe;
+import com.asakusafw.lang.info.MockAttribute;
+
+/**
+ * Test for {@link Node}.
+ */
+public class NodeTest {
+
+    /**
+     * simple case.
+     */
+    @Test
+    public void simple() {
+        checkRestore(new Node());
+    }
+
+    /**
+     * w/ attributes.
+     */
+    @Test
+    public void attributes() {
+        checkRestore(new Node()
+                .withAttribute(new MockAttribute("A"))
+                .withAttribute(new MockAttribute("B"))
+                .withAttribute(new MockAttribute("C")));
+    }
+
+    /**
+     * w/ inputs.
+     */
+    @Test
+    public void inputs() {
+        checkRestore(new Node()
+                .withInput(it -> it.withAttribute(new MockAttribute("A")))
+                .withInput(it -> it.withAttribute(new MockAttribute("B")))
+                .withInput(it -> it.withAttribute(new MockAttribute("C"))));
+    }
+
+    /**
+     * w/ outputs.
+     */
+    @Test
+    public void outputs() {
+        checkRestore(new Node()
+                .withOutput(it -> it.withAttribute(new MockAttribute("A")))
+                .withOutput(it -> it.withAttribute(new MockAttribute("B")))
+                .withOutput(it -> it.withAttribute(new MockAttribute("C"))));
+    }
+
+    /**
+     * w/ elements.
+     */
+    @Test
+    public void elements() {
+        checkRestore(new Node()
+                .withElement(it -> it.withAttribute(new MockAttribute("A")))
+                .withElement(it -> it.withAttribute(new MockAttribute("B")))
+                .withElement(it -> it.withAttribute(new MockAttribute("C"))));
+    }
+
+    /**
+     * w/ wires.
+     */
+    @Test
+    public void wires() {
+        Node result = checkRestore(new Node().configure(root -> {
+            Node a = root.newElement();
+            Output aOut = a.newOutput();
+            Node b = root.newElement().withInput(it -> it
+                    .connect(aOut, w -> w.withAttribute(new MockAttribute("A"))));
+            Node c = root.newElement().withInput(it -> it
+                    .connect(aOut, w -> w.withAttribute(new MockAttribute("B"))));
+            root.newElement().withInput(it -> it
+                    .connect(b.newOutput(), w -> w.withAttribute(new MockAttribute("C")))
+                    .connect(c.newOutput(), w -> w.withAttribute(new MockAttribute("D"))));
+        }));
+        result.getElements().forEach(n -> assertThat(n.getParent(), is(result)));
+        result.getElements().forEach(n -> n.getInputs().forEach(p -> assertThat(p.getParent(), is(n))));
+        result.getElements().forEach(n -> n.getOutputs().forEach(p -> assertThat(p.getParent(), is(n))));
+        result.getWires().forEach(w -> assertThat(w.getParent(), is(result)));
+
+
+        Node a = result.getElement(0);
+        Node b = result.getElement(1);
+        Node c = result.getElement(2);
+        Node d = result.getElement(3);
+
+        Wire ab = result.getWire(0);
+        Wire ac = result.getWire(1);
+        Wire bd = result.getWire(2);
+        Wire cd = result.getWire(3);
+
+        Output aOut = a.getOutput(0);
+        Output bOut = b.getOutput(0);
+        Output cOut = c.getOutput(0);
+
+        Input bIn = b.getInput(0);
+        Input cIn = c.getInput(0);
+        Input dIn = d.getInput(0);
+
+        assertThat(aOut.getWires(), contains(ab, ac));
+        assertThat(bOut.getWires(), contains(bd));
+        assertThat(cOut.getWires(), contains(cd));
+
+        assertThat(aOut.getOpposites(), contains(bIn, cIn));
+        assertThat(bOut.getOpposites(), contains(dIn));
+        assertThat(cOut.getOpposites(), contains(dIn));
+
+        assertThat(bIn.getWires(), contains(ab));
+        assertThat(cIn.getWires(), contains(ac));
+        assertThat(dIn.getWires(), contains(bd, cd));
+
+        assertThat(bIn.getOpposites(), contains(aOut));
+        assertThat(cIn.getOpposites(), contains(aOut));
+        assertThat(dIn.getOpposites(), contains(bOut, cOut));
+    }
+
+    private static Node checkRestore(Node node) {
+        Node result = InfoSerDe.checkRestore(Node.class, node, (a, b) -> a.info().equals(b.info()));
+        InfoSerDe.checkRestore(Node.class, node, (a, b) -> a.info().hashCode() == b.info().hashCode());
+        return result;
+    }
+}

--- a/info/model/src/test/java/com/asakusafw/lang/info/graph/NodeTestUtil.java
+++ b/info/model/src/test/java/com/asakusafw/lang/info/graph/NodeTestUtil.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.graph;
+
+/**
+ *
+ * @since 0.4.2
+ */
+public final class NodeTestUtil {
+
+    private NodeTestUtil() {
+        return;
+    }
+
+    /**
+     * Returns whether or not the contents of both nodes are equivalent.
+     * @param a the first node
+     * @param b the second node
+     * @return {@code true} if they are equivalent, {@code false} otherwise
+     */
+    public static boolean contentEquals(Node a, Node b) {
+        return a.info().equals(b.info());
+    }
+}

--- a/info/model/src/test/java/com/asakusafw/lang/info/operator/InputAttributeTest.java
+++ b/info/model/src/test/java/com/asakusafw/lang/info/operator/InputAttributeTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import com.asakusafw.lang.info.Attribute;
+import com.asakusafw.lang.info.InfoSerDe;
+import com.asakusafw.lang.info.value.ClassInfo;
+
+/**
+ * Test for {@link InputAttribute}.
+ * @since 0.4.2
+ */
+public class InputAttributeTest {
+
+    /**
+     * simple case.
+     */
+    @Test
+    public void simple() {
+        InfoSerDe.checkRestore(
+                Attribute.class,
+                new InputAttribute(
+                        "testing",
+                        ClassInfo.of("com.example.Data"),
+                        InputGranularity.RECORD,
+                        null));
+    }
+
+    /**
+     * w/ grouping info.
+     */
+    @Test
+    public void group() {
+        InfoSerDe.checkRestore(
+                Attribute.class,
+                new InputAttribute(
+                        "testing",
+                        ClassInfo.of("com.example.Data"),
+                        InputGranularity.GROUP,
+                        InputGroup.parse(Arrays.asList("=key", "+order"))));
+    }
+}

--- a/info/model/src/test/java/com/asakusafw/lang/info/operator/OperatorAttributeTest.java
+++ b/info/model/src/test/java/com/asakusafw/lang/info/operator/OperatorAttributeTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import com.asakusafw.lang.info.Attribute;
+import com.asakusafw.lang.info.InfoSerDe;
+import com.asakusafw.lang.info.operator.CoreOperatorSpec.CoreOperatorKind;
+import com.asakusafw.lang.info.value.ClassInfo;
+import com.asakusafw.lang.info.value.ValueInfo;
+
+/**
+ * Test for {@link OperatorAttribute}.
+ */
+public class OperatorAttributeTest {
+
+    /**
+     * simple case.
+     */
+    @Test
+    public void simple() {
+        InfoSerDe.checkRestore(
+                Attribute.class,
+                new OperatorAttribute(
+                        CoreOperatorSpec.of(CoreOperatorKind.CHECKPOINT),
+                        Arrays.asList(new ParameterInfo(
+                                "a",
+                                ClassInfo.of("int"),
+                                ValueInfo.of(100)))));
+    }
+}

--- a/info/model/src/test/java/com/asakusafw/lang/info/operator/OperatorGraphAttributeTest.java
+++ b/info/model/src/test/java/com/asakusafw/lang/info/operator/OperatorGraphAttributeTest.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator;
+
+import org.junit.Test;
+
+import com.asakusafw.lang.info.Attribute;
+import com.asakusafw.lang.info.InfoSerDe;
+import com.asakusafw.lang.info.graph.Node;
+import com.asakusafw.lang.info.graph.NodeTestUtil;
+
+/**
+ * Test for {@link OperatorGraphAttribute}.
+ */
+public class OperatorGraphAttributeTest {
+
+    /**
+     * simple case.
+     */
+    @Test
+    public void simple() {
+        InfoSerDe.checkRestore(
+                Attribute.class,
+                new OperatorGraphAttribute(
+                        new Node()),
+                (a, b) -> NodeTestUtil.contentEquals(a.getRoot(), b.getRoot()));
+    }
+}

--- a/info/model/src/test/java/com/asakusafw/lang/info/operator/OperatorSpecTest.java
+++ b/info/model/src/test/java/com/asakusafw/lang/info/operator/OperatorSpecTest.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator;
+
+import java.util.Collections;
+
+import org.junit.Test;
+
+import com.asakusafw.lang.info.InfoSerDe;
+import com.asakusafw.lang.info.operator.CoreOperatorSpec.CoreOperatorKind;
+import com.asakusafw.lang.info.value.AnnotationInfo;
+import com.asakusafw.lang.info.value.ClassInfo;
+
+/**
+ * Test for {@link OperatorSpec}.
+ */
+public class OperatorSpecTest {
+
+    /**
+     * core operators.
+     */
+    @Test
+    public void core() {
+        InfoSerDe.checkRestore(
+                OperatorSpec.class,
+                CoreOperatorSpec.of(CoreOperatorKind.CHECKPOINT));
+    }
+
+    /**
+     * user operators.
+     */
+    @Test
+    public void user() {
+        InfoSerDe.checkRestore(
+                OperatorSpec.class,
+                UserOperatorSpec.of(
+                        AnnotationInfo.of(
+                                ClassInfo.of("com.example.MockOp"),
+                                Collections.emptyMap()),
+                        ClassInfo.of("com.example.Op"),
+                        ClassInfo.of("com.example.OpImpl"),
+                        "testing"));
+    }
+
+    /**
+     * flow operators.
+     */
+    @Test
+    public void flow() {
+        InfoSerDe.checkRestore(
+                OperatorSpec.class,
+                FlowOperatorSpec.of(ClassInfo.of("com.example.Flow")));
+    }
+
+    /**
+     * input operators.
+     */
+    @Test
+    public void input() {
+        InfoSerDe.checkRestore(
+                OperatorSpec.class,
+                InputOperatorSpec.of("port", ClassInfo.of("com.example.Port")));
+        InfoSerDe.checkRestore(
+                OperatorSpec.class,
+                InputOperatorSpec.of("port", null));
+    }
+
+    /**
+     * output operators.
+     */
+    @Test
+    public void output() {
+        InfoSerDe.checkRestore(
+                OperatorSpec.class,
+                OutputOperatorSpec.of("port", ClassInfo.of("com.example.Port")));
+        InfoSerDe.checkRestore(
+                OperatorSpec.class,
+                OutputOperatorSpec.of("port", null));
+    }
+
+    /**
+     * marker operators.
+     */
+    @Test
+    public void marker() {
+        InfoSerDe.checkRestore(
+                OperatorSpec.class,
+                MarkerOperatorSpec.get());
+    }
+
+    /**
+     * custom operators.
+     */
+    @Test
+    public void custom() {
+        InfoSerDe.checkRestore(
+                OperatorSpec.class,
+                CustomOperatorSpec.of("testing"));
+    }
+}

--- a/info/model/src/test/java/com/asakusafw/lang/info/operator/OutputAttributeTest.java
+++ b/info/model/src/test/java/com/asakusafw/lang/info/operator/OutputAttributeTest.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator;
+
+import org.junit.Test;
+
+import com.asakusafw.lang.info.Attribute;
+import com.asakusafw.lang.info.InfoSerDe;
+import com.asakusafw.lang.info.value.ClassInfo;
+
+/**
+ * Test for {@link OutputAttribute}.
+ * @since 0.4.2
+ */
+public class OutputAttributeTest {
+
+    /**
+     * simple case.
+     */
+    @Test
+    public void simple() {
+        InfoSerDe.checkRestore(
+                Attribute.class,
+                new OutputAttribute(
+                        "testing",
+                        ClassInfo.of("com.example.Data")));
+    }
+}

--- a/info/model/src/test/java/com/asakusafw/lang/info/operator/view/OperatorGraphViewTest.java
+++ b/info/model/src/test/java/com/asakusafw/lang/info/operator/view/OperatorGraphViewTest.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator.view;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.util.Collections;
+
+import org.junit.Test;
+
+import com.asakusafw.lang.info.graph.Node;
+import com.asakusafw.lang.info.graph.NodeTestUtil;
+import com.asakusafw.lang.info.operator.CoreOperatorSpec;
+import com.asakusafw.lang.info.operator.CoreOperatorSpec.CoreOperatorKind;
+import com.asakusafw.lang.info.operator.CustomOperatorSpec;
+import com.asakusafw.lang.info.operator.InputAttribute;
+import com.asakusafw.lang.info.operator.InputGranularity;
+import com.asakusafw.lang.info.operator.InputOperatorSpec;
+import com.asakusafw.lang.info.operator.OperatorAttribute;
+import com.asakusafw.lang.info.operator.OperatorGraphAttribute;
+import com.asakusafw.lang.info.operator.OutputAttribute;
+import com.asakusafw.lang.info.operator.OutputOperatorSpec;
+import com.asakusafw.lang.info.value.ClassInfo;
+
+/**
+ * Test for {@link OperatorGraphView}.
+ */
+public class OperatorGraphViewTest {
+
+    /**
+     * simple case.
+     */
+    @Test
+    public void simple() {
+        Node root = new Node();
+        OperatorGraphView view = new OperatorGraphView(new OperatorGraphAttribute(root));
+        assertThat(view.getOperators(), is(empty()));
+    }
+
+    /**
+     * w/ operator.
+     */
+    @Test
+    public void operator() {
+        Node root = new Node();
+        Node op = root.newElement()
+                .withAttribute(new OperatorAttribute(
+                        CoreOperatorSpec.of(CoreOperatorKind.CHECKPOINT), Collections.emptyList()))
+                .withInput(it -> it.withAttribute(new InputAttribute(
+                        "in",
+                        ClassInfo.of("com.example.Data"),
+                        InputGranularity.RECORD,
+                        null)))
+                .withOutput(it -> it.withAttribute(new OutputAttribute(
+                        "out",
+                        ClassInfo.of("com.example.Data"))));
+
+        OperatorGraphView view = new OperatorGraphView(new OperatorGraphAttribute(root));
+        assertThat(view.getOperators(), hasSize(1));
+        assertThat(view.getInputs().keySet(), is(empty()));
+        assertThat(view.getOutputs().keySet(), is(empty()));
+
+        OperatorView v = view.getOperators().stream().findAny().get();
+        NodeTestUtil.contentEquals(v.getEntity(), op);
+
+        assertThat(v.getInputs(), hasSize(1));
+        v.getInputs().forEach(it -> assertThat(it.getOwner(), is(v)));
+        v.getInputs().forEach(it -> assertThat(it.getOpposites(), is(empty())));
+        assertThat(v.getInputs().get(0).getName(), is("in"));
+
+        assertThat(v.getOutputs(), hasSize(1));
+        assertThat(v.getOutputs().get(0).getName(), is("out"));
+        v.getOutputs().forEach(it -> assertThat(it.getOwner(), is(v)));
+        v.getOutputs().forEach(it -> assertThat(it.getOpposites(), is(empty())));
+    }
+
+    /**
+     * w/ io.
+     */
+    @Test
+    public void io() {
+        Node root = new Node();
+        Node n0 = root.newElement()
+                .withAttribute(new OperatorAttribute(
+                        InputOperatorSpec.of(
+                                "in",
+                                ClassInfo.of("com.example.Input")), Collections.emptyList()));
+        Node n1 = root.newElement()
+                .withAttribute(new OperatorAttribute(
+                        OutputOperatorSpec.of(
+                                "out",
+                                ClassInfo.of("com.example.Output")), Collections.emptyList()));
+        n1.newInput()
+                .withAttribute(new InputAttribute(
+                        "p",
+                        ClassInfo.of("com.example.Data"),
+                        InputGranularity.RECORD,
+                        null))
+                .connect(n0.newOutput()
+                        .withAttribute(new OutputAttribute(
+                                "p",
+                                ClassInfo.of("com.example.Data"))));
+
+
+        OperatorGraphView view = new OperatorGraphView(new OperatorGraphAttribute(root));
+        assertThat(view.getOperators(), hasSize(2));
+        assertThat(view.getInputs().keySet(), containsInAnyOrder("in"));
+        assertThat(view.getOutputs().keySet(), containsInAnyOrder("out"));
+
+        OperatorView v0 = view.getInputs().get("in");
+        OperatorView v1 = view.getOutputs().get("out");
+
+        assertThat(v0.getOutputs(), hasSize(1));
+        assertThat(v1.getInputs(), hasSize(1));
+        assertThat(v0.getOutputs().get(0).getOpposites(), contains(v1.getInputs().get(0)));
+    }
+
+    /**
+     * w/ nested graph.
+     */
+    @Test
+    public void nest() {
+        Node root = new Node();
+        Node n1 = root.newElement().withAttribute(new OperatorAttribute(
+                CustomOperatorSpec.of("parent"), Collections.emptyList()));
+        n1.newElement().withAttribute(new OperatorAttribute(
+                CustomOperatorSpec.of("child"), Collections.emptyList()));
+
+        OperatorGraphView view = new OperatorGraphView(new OperatorGraphAttribute(root));
+        assertThat(view.getOperators(), hasSize(1));
+        assertThat(view.getInputs().keySet(), is(empty()));
+        assertThat(view.getOutputs().keySet(), is(empty()));
+
+        OperatorView parent = view.getOperators().stream().findAny().get();
+        assertThat(((CustomOperatorSpec) parent.getSpec()).getCategory(), is("parent"));
+
+        OperatorGraphView inner = parent.getElementGraph();
+        assertThat(inner.getOperators(), hasSize(1));
+        assertThat(inner.getInputs().keySet(), is(empty()));
+        assertThat(inner.getOutputs().keySet(), is(empty()));
+
+        OperatorView child = inner.getOperators().stream().findAny().get();
+        assertThat(((CustomOperatorSpec) child.getSpec()).getCategory(), is("child"));
+    }
+}

--- a/info/model/src/test/java/com/asakusafw/lang/info/value/ValueInfoTest.java
+++ b/info/model/src/test/java/com/asakusafw/lang/info/value/ValueInfoTest.java
@@ -1,0 +1,339 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.value;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+import com.asakusafw.lang.info.InfoSerDe;
+
+/**
+ * Test for {@link ValueInfo}.
+ */
+public class ValueInfoTest {
+
+    /**
+     * Test information collector.
+     */
+    @Rule
+    public final TestWatcher collector = new TestWatcher() {
+        @Override
+        protected void starting(org.junit.runner.Description d) {
+            ValueInfoTest.this.description = d;
+        }
+    };
+
+    Description description;
+
+    /**
+     * test for {@code null} values.
+     */
+    @Test
+    public void null_json() {
+        checkRestore(NullInfo.get());
+    }
+
+    /**
+     * test for {@code unknown} values.
+     */
+    @Test
+    public void unknown_json() {
+        ValueInfo restored = InfoSerDe.deserialize(ValueInfo.class,
+                InfoSerDe.serialize(ValueInfo.class, UnknownInfo.of(new Object())));
+        assertThat(restored, is(instanceOf(UnknownInfo.class)));
+        assertThat(((UnknownInfo) restored).getDeclaringClass(), is(ClassInfo.of(Object.class)));
+    }
+
+    /**
+     * test for {@code boolean} values.
+     */
+    @Test
+    public void boolean_json() {
+        checkRestore(BooleanInfo.of(false));
+        checkRestore(BooleanInfo.of(true));
+    }
+
+    /**
+     * test for {@code byte} values.
+     */
+    @Test
+    public void byte_json() {
+        checkRestore(ByteInfo.of((byte) 100));
+    }
+
+    /**
+     * test for {@code short} values.
+     */
+    @Test
+    public void short_json() {
+        checkRestore(ShortInfo.of((short) 100));
+    }
+
+    /**
+     * test for {@code int} values.
+     */
+    @Test
+    public void int_json() {
+        checkRestore(IntInfo.of(100));
+    }
+
+    /**
+     * test for {@code long} values.
+     */
+    @Test
+    public void long_json() {
+        checkRestore(LongInfo.of(100));
+    }
+
+    /**
+     * test for {@code float} values.
+     */
+    @Test
+    public void float_json() {
+        checkRestore(FloatInfo.of(100));
+    }
+
+    /**
+     * test for {@code double} values.
+     */
+    @Test
+    public void double_json() {
+        checkRestore(DoubleInfo.of(100));
+    }
+
+    /**
+     * test for {@code char} values.
+     */
+    @Test
+    public void chare_json() {
+        checkRestore(CharInfo.of('A'));
+    }
+
+    /**
+     * test for {@code String} values.
+     */
+    @Test
+    public void string_json() {
+        checkRestore(StringInfo.of("Hello, world!"));
+    }
+
+    /**
+     * test for {@code Class} values.
+     */
+    @Test
+    public void class_json() {
+        checkRestore(ClassInfo.of(Thread.class));
+    }
+
+    /**
+     * test for {@code List} values.
+     */
+    @Test
+    public void list_json() {
+        checkRestore(ListInfo.of(Arrays.asList(
+                IntInfo.of(1),
+                LongInfo.of(2),
+                StringInfo.of("3"))));
+    }
+
+    /**
+     * test for {@code Enum} values.
+     */
+    @Test
+    public void enum_json() {
+        checkRestore(EnumInfo.of(ValueInfo.Kind.UNKNOWN));
+    }
+
+    /**
+     * test for {@code Annotation} values.
+     */
+    @Test
+    public void annotation_json() {
+        Map<String, ValueInfo> elements = new LinkedHashMap<>();
+        elements.put("expected", ClassInfo.of(IllegalAccessException.class));
+        elements.put("timeout", LongInfo.of(0));
+        checkRestore(AnnotationInfo.of(ClassInfo.of(Test.class), elements));
+    }
+
+    /**
+     * test for {@code null} values.
+     */
+    @Test
+    public void null_convert() {
+        assertThat(ValueInfo.of(null), is(NullInfo.get()));
+    }
+
+    /**
+     * test for {@code unknown} values.
+     */
+    @Test
+    public void unknown_convert() {
+        ValueInfo info = ValueInfo.of(new Object());
+        assertThat(info, is(instanceOf(UnknownInfo.class)));
+        assertThat(((UnknownInfo) info).getDeclaringClass(), is(ClassInfo.of(Object.class)));
+    }
+
+    /**
+     * test for {@code boolean} values.
+     */
+    @Test
+    public void boolean_convert() {
+        assertThat(ValueInfo.of(true), is(BooleanInfo.of(true)));
+    }
+
+    /**
+     * test for {@code byte} values.
+     */
+    @Test
+    public void byte_convert() {
+        assertThat(ValueInfo.of((byte) 100), is(ByteInfo.of((byte) 100)));
+    }
+
+    /**
+     * test for {@code short} values.
+     */
+    @Test
+    public void short_convert() {
+        assertThat(ValueInfo.of((short) 100), is(ShortInfo.of((short) 100)));
+    }
+
+    /**
+     * test for {@code int} values.
+     */
+    @Test
+    public void int_convert() {
+        assertThat(ValueInfo.of(100), is(IntInfo.of(100)));
+    }
+
+    /**
+     * test for {@code long} values.
+     */
+    @Test
+    public void long_convert() {
+        assertThat(ValueInfo.of((long) 100), is(LongInfo.of(100)));
+    }
+
+    /**
+     * test for {@code float} values.
+     */
+    @Test
+    public void float_convert() {
+        assertThat(ValueInfo.of((float) 100), is(FloatInfo.of(100)));
+    }
+
+    /**
+     * test for {@code double} values.
+     */
+    @Test
+    public void double_convert() {
+        assertThat(ValueInfo.of((double) 100), is(DoubleInfo.of(100)));
+    }
+
+    /**
+     * test for {@code char} values.
+     */
+    @Test
+    public void char_convert() {
+        assertThat(ValueInfo.of('A'), is(CharInfo.of('A')));
+    }
+
+    /**
+     * test for {@code String} values.
+     */
+    @Test
+    public void string_convert() {
+        assertThat(ValueInfo.of("Hello, world!"), is(StringInfo.of("Hello, world!")));
+    }
+
+    /**
+     * test for {@code Class} values.
+     */
+    @Test
+    public void class_convert() {
+        assertThat(ValueInfo.of(System.class), is(ClassInfo.of(System.class)));
+    }
+
+    /**
+     * test for {@code Class} values.
+     */
+    @Test
+    public void class_primitive() {
+        assertThat(ClassInfo.of(int.class).getName(), is("int"));
+    }
+
+    /**
+     * test for {@code Class} values.
+     */
+    @Test
+    public void class_array() {
+        assertThat(ClassInfo.of(String[][].class).getName(), is("java.lang.String[][]"));
+    }
+
+    /**
+     * test for {@code List} values.
+     */
+    @Test
+    public void list_convert_array() {
+        assertThat(
+                ValueInfo.of(new int[] { 1, 2, 3 }),
+                is(ListInfo.of(IntInfo.of(1), IntInfo.of(2), IntInfo.of(3))));
+    }
+
+    /**
+     * test for {@code List} values.
+     */
+    @Test
+    public void list_convert_list() {
+        assertThat(
+                ValueInfo.of(Arrays.asList(1, 2, 3)),
+                is(ListInfo.of(IntInfo.of(1), IntInfo.of(2), IntInfo.of(3))));
+    }
+
+    /**
+     * test for {@code Enum} values.
+     */
+    @Test
+    public void enum_convert() {
+        assertThat(ValueInfo.of(ValueInfo.Kind.UNKNOWN), is(EnumInfo.of(ValueInfo.Kind.UNKNOWN)));
+    }
+
+    /**
+     * test for {@code Annotation} values.
+     */
+    @Test
+    public void annotation_convert() {
+        Test annotation = description.getAnnotation(Test.class);
+        AnnotationInfo info = (AnnotationInfo) ValueInfo.of(annotation);
+
+        assertThat(info.getObject(), info.getDeclaringClass(), is(ClassInfo.of(Test.class)));
+        assertThat(info.getElements(), hasEntry("expected", ClassInfo.of(annotation.expected())));
+        assertThat(info.getElements(), hasEntry("timeout", LongInfo.of(annotation.timeout())));
+    }
+
+    private static void checkRestore(ValueInfo info) {
+        InfoSerDe.checkRestore(ValueInfo.class, info);
+        InfoSerDe.checkRestore(info.getClass(), info);
+    }
+}

--- a/info/pom.xml
+++ b/info/pom.xml
@@ -17,5 +17,6 @@
     <module>api</module>
     <module>directio</module>
     <module>windgate</module>
+    <module>cli</module>
   </modules>
 </project>

--- a/info/windgate/src/main/java/com/asakusafw/lang/info/windgate/WindGateInputInfo.java
+++ b/info/windgate/src/main/java/com/asakusafw/lang/info/windgate/WindGateInputInfo.java
@@ -29,6 +29,7 @@ public class WindGateInputInfo extends WindGatePortInfo {
     /**
      * Creates a new instance.
      * @param name the port name
+     * @param descriptionClass the description class
      * @param profileName the profile name
      * @param resourceName the resource name
      * @param configuration the driver configuration
@@ -36,10 +37,11 @@ public class WindGateInputInfo extends WindGatePortInfo {
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     public WindGateInputInfo(
             @JsonProperty(ID_NAME) String name,
+            @JsonProperty(ID_DESCRIPTION) String descriptionClass,
             @JsonProperty(ID_PROFILE_NAME) String profileName,
             @JsonProperty(ID_RESOURCE_NAME) String resourceName,
             @JsonProperty(ID_CONFIGURATION) Map<String, String> configuration) {
-        super(name, profileName, resourceName, configuration);
+        super(name, descriptionClass, profileName, resourceName, configuration);
     }
 
     @Override

--- a/info/windgate/src/main/java/com/asakusafw/lang/info/windgate/WindGateOutputInfo.java
+++ b/info/windgate/src/main/java/com/asakusafw/lang/info/windgate/WindGateOutputInfo.java
@@ -29,6 +29,7 @@ public class WindGateOutputInfo extends WindGatePortInfo {
     /**
      * Creates a new instance.
      * @param name the port name
+     * @param descriptionClass the description class
      * @param profileName the profile name
      * @param resourceName the resource name
      * @param configuration the driver configuration
@@ -36,10 +37,11 @@ public class WindGateOutputInfo extends WindGatePortInfo {
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     public WindGateOutputInfo(
             @JsonProperty(ID_NAME) String name,
+            @JsonProperty(ID_DESCRIPTION) String descriptionClass,
             @JsonProperty(ID_PROFILE_NAME) String profileName,
             @JsonProperty(ID_RESOURCE_NAME) String resourceName,
             @JsonProperty(ID_CONFIGURATION) Map<String, String> configuration) {
-        super(name, profileName, resourceName, configuration);
+        super(name, descriptionClass, profileName, resourceName, configuration);
     }
 
     @Override

--- a/info/windgate/src/main/java/com/asakusafw/lang/info/windgate/WindGatePortInfo.java
+++ b/info/windgate/src/main/java/com/asakusafw/lang/info/windgate/WindGatePortInfo.java
@@ -28,6 +28,8 @@ public abstract class WindGatePortInfo {
 
     static final String ID_NAME = "name";
 
+    static final String ID_DESCRIPTION = "description";
+
     static final String ID_PROFILE_NAME = "profile";
 
     static final String ID_RESOURCE_NAME = "resource";
@@ -35,6 +37,8 @@ public abstract class WindGatePortInfo {
     static final String ID_CONFIGURATION = "configuration";
 
     private final String name;
+
+    private final String descriptionClass;
 
     private final String profileName;
 
@@ -45,16 +49,19 @@ public abstract class WindGatePortInfo {
     /**
      * Creates a new instance.
      * @param name the port name
+     * @param descriptionClass the description class
      * @param profileName the profile name
      * @param resourceName the resource name
      * @param configuration the driver configuration
      */
     protected WindGatePortInfo(
             String name,
+            String descriptionClass,
             String profileName,
             String resourceName,
             Map<String, String> configuration) {
         this.name = name;
+        this.descriptionClass = descriptionClass;
         this.profileName = profileName;
         this.resourceName = resourceName;
         this.configuration = Util.freeze(configuration);
@@ -67,6 +74,15 @@ public abstract class WindGatePortInfo {
     @JsonProperty(ID_NAME)
     public String getName() {
         return name;
+    }
+
+    /**
+     * Returns the description class name.
+     * @return the description class name
+     */
+    @JsonProperty(ID_DESCRIPTION)
+    public String getDescriptionClass() {
+        return descriptionClass;
     }
 
     /**
@@ -101,6 +117,7 @@ public abstract class WindGatePortInfo {
         final int prime = 31;
         int result = 1;
         result = prime * result + Objects.hashCode(name);
+        result = prime * result + Objects.hashCode(descriptionClass);
         result = prime * result + Objects.hashCode(profileName);
         result = prime * result + Objects.hashCode(resourceName);
         result = prime * result + Objects.hashCode(configuration);
@@ -120,6 +137,7 @@ public abstract class WindGatePortInfo {
         }
         WindGatePortInfo other = (WindGatePortInfo) obj;
         return Objects.equals(name, other.name)
+                && Objects.equals(descriptionClass, other.descriptionClass)
                 && Objects.equals(profileName, other.profileName)
                 && Objects.equals(resourceName, other.resourceName)
                 && Objects.equals(configuration, other.configuration);

--- a/info/windgate/src/test/java/com/asakusafw/lang/info/windgate/WindGateInputInfoTest.java
+++ b/info/windgate/src/test/java/com/asakusafw/lang/info/windgate/WindGateInputInfoTest.java
@@ -36,6 +36,7 @@ public class WindGateInputInfoTest {
                 WindGateInputInfo.class,
                 new WindGateInputInfo(
                         "test-name",
+                        "com.example.WGD",
                         "test-profile",
                         "test-resource",
                         Arrays.stream(new String[][] {

--- a/info/windgate/src/test/java/com/asakusafw/lang/info/windgate/WindGateIoAttributeTest.java
+++ b/info/windgate/src/test/java/com/asakusafw/lang/info/windgate/WindGateIoAttributeTest.java
@@ -38,6 +38,7 @@ public class WindGateIoAttributeTest {
                 new WindGateIoAttribute(
                         Arrays.asList(new WindGateInputInfo(
                                 "test-name",
+                                "com.example.WGI",
                                 "test-profile",
                                 "test-resource",
                                 Arrays.stream(new String[][] {
@@ -47,6 +48,7 @@ public class WindGateIoAttributeTest {
                                 }).collect(Collectors.toMap(it -> it[0], it -> it[1])))),
                         Arrays.asList(new WindGateOutputInfo(
                                 "test-name",
+                                "com.example.WGO",
                                 "test-profile",
                                 "test-resource",
                                 Arrays.stream(new String[][] {

--- a/info/windgate/src/test/java/com/asakusafw/lang/info/windgate/WindGateOutputInfoTest.java
+++ b/info/windgate/src/test/java/com/asakusafw/lang/info/windgate/WindGateOutputInfoTest.java
@@ -36,6 +36,7 @@ public class WindGateOutputInfoTest {
                 WindGateOutputInfo.class,
                 new WindGateOutputInfo(
                         "test-name",
+                        "com.example.WGI",
                         "test-profile",
                         "test-resource",
                         Arrays.stream(new String[][] {

--- a/pom.xml
+++ b/pom.xml
@@ -60,9 +60,10 @@
     <asakusafw-sdk.version>0.9.2-SNAPSHOT</asakusafw-sdk.version>
     <hadoop.version>2.7.3</hadoop.version>
     <commons-cli.version>1.2</commons-cli.version>
+    <airline.version>0.7</airline.version>
     <asm.version>5.1</asm.version>
     <gson.version>2.7</gson.version>
-    <jackson.version>2.8.3</jackson.version>
+    <jackson.version>2.8.8</jackson.version>
     <h2.version>1.4.192</h2.version>
     <slf4j.version>1.7.21</slf4j.version>
     <logback.version>1.1.7</logback.version>
@@ -730,6 +731,11 @@ encoding/<project>=UTF-8
         <groupId>commons-cli</groupId>
         <artifactId>commons-cli</artifactId>
         <version>${commons-cli.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.airlift</groupId>
+        <artifactId>airline</artifactId>
+        <version>${airline.version}</version>
       </dependency>
       <dependency>
         <groupId>com.h2database</groupId>


### PR DESCRIPTION
## Summary

This PR introduces `batch-info.json` viewer tool.

## Background, Problem or Goal of the patch

`batch-info.json` file has been introduced as incubating feature (`asakusafw.sdk.incubating = true`) since #113. The introduced tool enables to display various DSL information from the file.

## Design of the fix, or a new feature

To build this commit, you can obtain a executable fat jar in `info/cli/target/asakusa-info-cli-*-exec.jar`. It provides the following information:

* list of batch applications
* list of batch parameters
* list of jobflows
* list of external I/O
* list of operators
* jobflow dependency graph as Graphviz DOT script
* operator graph as Graphviz DOT script

Please type `java -jar <info/cli/target/asakusa-info-cli-*-exec.jar> help` to see a usage of the tool.

## Related Issue, Pull Request or Code

* #113 