### PR TITLE
Add execution plan information into `batch-info.json`.

### DIFF
--- a/compiler-project/extension-info/pom.xml
+++ b/compiler-project/extension-info/pom.xml
@@ -22,6 +22,11 @@
       <artifactId>asakusa-info-api</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency> <!-- default implementation -->
+      <groupId>${project.groupId}</groupId>
+      <artifactId>asakusa-compiler-extension-operator</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>

--- a/compiler-project/extension-info/src/main/resources/META-INF/services/com.asakusafw.lang.info.api.AttributeCollector
+++ b/compiler-project/extension-info/src/main/resources/META-INF/services/com.asakusafw.lang.info.api.AttributeCollector
@@ -1,2 +1,1 @@
 com.asakusafw.lang.compiler.extension.info.ParameterListAttributeCollector
-com.asakusafw.lang.compiler.extension.info.OperatorGraphAttributeCollector

--- a/compiler-project/extension-operator/.gitignore
+++ b/compiler-project/extension-operator/.gitignore
@@ -1,0 +1,8 @@
+/.gradle
+/build
+/target
+/.project
+/.classpath
+/.settings
+/bin
+

--- a/compiler-project/extension-operator/pom.xml
+++ b/compiler-project/extension-operator/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <name>Asakusa DSL Compiler Extension for Operator Information</name>
+  <artifactId>asakusa-compiler-extension-operator</artifactId>
+  <parent>
+    <artifactId>project</artifactId>
+    <groupId>com.asakusafw.lang.compiler</groupId>
+    <version>0.4.2-SNAPSHOT</version>
+  </parent>
+
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.asakusafw.lang.info</groupId>
+      <artifactId>asakusa-info-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.asakusafw.lang.info</groupId>
+      <artifactId>asakusa-info-api</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/compiler-project/extension-operator/src/main/java/com/asakusafw/lang/compiler/operator/info/OperatorGraphAttributeCollector.java
+++ b/compiler-project/extension-operator/src/main/java/com/asakusafw/lang/compiler/operator/info/OperatorGraphAttributeCollector.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.compiler.operator.info;
+
+import com.asakusafw.lang.compiler.model.graph.Jobflow;
+import com.asakusafw.lang.info.api.AttributeCollector;
+import com.asakusafw.lang.info.graph.Node;
+import com.asakusafw.lang.info.operator.OperatorGraphAttribute;
+
+/**
+ * Collects {@link OperatorGraphAttribute}.
+ * @since 0.4.2
+ */
+public class OperatorGraphAttributeCollector implements AttributeCollector {
+
+    @Override
+    public void process(Context context, Jobflow jobflow) {
+        Node root = new Node();
+        new OperatorGraphConverter().process(jobflow.getOperatorGraph(), root);
+        context.putAttribute(new OperatorGraphAttribute(root));
+    }
+}

--- a/compiler-project/extension-operator/src/main/java/com/asakusafw/lang/compiler/operator/info/PlanAttributeCollector.java
+++ b/compiler-project/extension-operator/src/main/java/com/asakusafw/lang/compiler/operator/info/PlanAttributeCollector.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.compiler.operator.info;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.lang.compiler.model.graph.Jobflow;
+import com.asakusafw.lang.info.api.AttributeCollector;
+import com.asakusafw.lang.info.plan.PlanAttribute;
+
+/**
+ * Collects {@link PlanAttribute} from previously compiled jobflow packages.
+ * @since 0.4.2
+ * @see PlanAttributeStore
+ */
+public class PlanAttributeCollector implements AttributeCollector {
+
+    static final Logger LOG = LoggerFactory.getLogger(PlanAttributeCollector.class);
+
+    @Override
+    public void process(Context context, Jobflow jobflow) {
+        PlanAttributeStore.load(context).ifPresent(context::putAttribute);
+    }
+}

--- a/compiler-project/extension-operator/src/main/java/com/asakusafw/lang/compiler/operator/info/PlanAttributeStore.java
+++ b/compiler-project/extension-operator/src/main/java/com/asakusafw/lang/compiler/operator/info/PlanAttributeStore.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.compiler.operator.info;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.text.MessageFormat;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.lang.compiler.api.JobflowProcessor;
+import com.asakusafw.lang.compiler.common.Location;
+import com.asakusafw.lang.info.api.AttributeCollector;
+import com.asakusafw.lang.info.plan.PlanAttribute;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Save/restore {@link PlanAttribute}.
+ * @since 0.4.2
+ */
+public final class PlanAttributeStore {
+
+    static final Logger LOG = LoggerFactory.getLogger(PlanAttributeCollector.class);
+
+    static final Location SERIALIZE_LOCATION = Location.of("asakusafw-info/plan.json");
+
+    private PlanAttributeStore() {
+        return;
+    }
+
+    /**
+     * Adds {@link PlanAttribute} into the current jobflow.
+     * @param context the current processing context
+     * @param attribute the target attribute
+     */
+    public static void save(JobflowProcessor.Context context, PlanAttribute attribute) {
+        try (OutputStream output = context.addResourceFile(SERIALIZE_LOCATION)) {
+            LOG.debug("saving execution plan info");
+            ObjectMapper mapper = new ObjectMapper()
+                    .setSerializationInclusion(Include.NON_NULL);
+            mapper.writerFor(PlanAttribute.class).writeValue(output, attribute);
+        } catch (Exception e) {
+            LOG.warn(MessageFormat.format(
+                    "error occurred while saving execution plan information: {0}",
+                    SERIALIZE_LOCATION), e);
+        }
+    }
+
+    /**
+     * Restores {@link PlanAttribute} which previously saved.
+     * @param context the current collecting context
+     * @return the restored attribute, or {@code empty} if not saved
+     */
+    public static Optional<PlanAttribute> load(AttributeCollector.Context context) {
+        try (InputStream input = context.findResourceFile(SERIALIZE_LOCATION)) {
+            if (input != null) {
+                LOG.debug("loading execution plan info");
+                ObjectMapper mapper = new ObjectMapper();
+                return Optional.ofNullable(mapper.readerFor(PlanAttribute.class).readValue(input));
+            }
+        } catch (Exception e) {
+            LOG.warn(MessageFormat.format(
+                    "error occurred while loading execution plan information: {0}",
+                    SERIALIZE_LOCATION), e);
+        }
+        return Optional.empty();
+    }
+
+}

--- a/compiler-project/extension-operator/src/main/java/com/asakusafw/lang/compiler/operator/info/Util.java
+++ b/compiler-project/extension-operator/src/main/java/com/asakusafw/lang/compiler/operator/info/Util.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.lang.compiler.extension.info;
+package com.asakusafw.lang.compiler.operator.info;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.asakusafw.lang.compiler.model.PropertyName;
 import com.asakusafw.lang.compiler.model.description.AnnotationDescription;
 import com.asakusafw.lang.compiler.model.description.ArrayDescription;
 import com.asakusafw.lang.compiler.model.description.ArrayTypeDescription;
@@ -33,6 +34,10 @@ import com.asakusafw.lang.compiler.model.description.SerializableValueDescriptio
 import com.asakusafw.lang.compiler.model.description.TypeDescription;
 import com.asakusafw.lang.compiler.model.description.UnknownValueDescription;
 import com.asakusafw.lang.compiler.model.description.ValueDescription;
+import com.asakusafw.lang.compiler.model.graph.Group;
+import com.asakusafw.lang.compiler.model.graph.OperatorInput;
+import com.asakusafw.lang.info.operator.InputGranularity;
+import com.asakusafw.lang.info.operator.InputGroup;
 import com.asakusafw.lang.info.value.AnnotationInfo;
 import com.asakusafw.lang.info.value.ClassInfo;
 import com.asakusafw.lang.info.value.EnumInfo;
@@ -125,5 +130,42 @@ final class Util {
         return UnknownInfo.of(
                 convert(value.getValueType()),
                 value.getLabel());
+    }
+
+    static InputGranularity translate(OperatorInput.InputUnit kind) {
+        switch (kind) {
+        case RECORD:
+            return InputGranularity.RECORD;
+        case GROUP:
+            return InputGranularity.GROUP;
+        case WHOLE:
+            return InputGranularity.WHOLE;
+        default:
+            throw new AssertionError(kind);
+        }
+    }
+
+    static InputGroup translate(Group group) {
+        if (group == null) {
+            return null;
+        }
+        return new InputGroup(
+                group.getGrouping().stream()
+                    .map(PropertyName::toName)
+                    .collect(Collectors.toList()),
+                group.getOrdering().stream()
+                    .map(it -> new InputGroup.Order(it.getPropertyName().toName(), translate(it.getDirection())))
+                    .collect(Collectors.toList()));
+    }
+
+    private static InputGroup.Direction translate(Group.Direction kind) {
+        switch (kind) {
+        case ASCENDANT:
+            return InputGroup.Direction.ASCENDANT;
+        case DESCENDANT:
+            return InputGroup.Direction.DESCENDANT;
+        default:
+            throw new AssertionError(kind);
+        }
     }
 }

--- a/compiler-project/extension-operator/src/main/java/com/asakusafw/lang/compiler/operator/info/package-info.java
+++ b/compiler-project/extension-operator/src/main/java/com/asakusafw/lang/compiler/operator/info/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Asakusa operator information collectors.
+ */
+package com.asakusafw.lang.compiler.operator.info;

--- a/compiler-project/extension-operator/src/main/resources/META-INF/services/com.asakusafw.lang.info.api.AttributeCollector
+++ b/compiler-project/extension-operator/src/main/resources/META-INF/services/com.asakusafw.lang.info.api.AttributeCollector
@@ -1,0 +1,2 @@
+com.asakusafw.lang.compiler.operator.info.OperatorGraphAttributeCollector
+com.asakusafw.lang.compiler.operator.info.PlanAttributeCollector

--- a/compiler-project/pom.xml
+++ b/compiler-project/pom.xml
@@ -42,6 +42,7 @@
     <module>extension-directio</module>
     <module>extension-windgate</module>
     <module>extension-hive</module>
+    <module>extension-operator</module>
     <module>extension-yaess</module>
     <module>extension-cleanup</module>
     <module>extension-redirector</module>

--- a/dag/compiler/extension-windgate/src/main/java/com/asakusafw/dag/compiler/extension/windgate/WindGateJdbcPortDriver.java
+++ b/dag/compiler/extension-windgate/src/main/java/com/asakusafw/dag/compiler/extension/windgate/WindGateJdbcPortDriver.java
@@ -44,6 +44,7 @@ import com.asakusafw.dag.compiler.jdbc.windgate.WindGateJdbcModel;
 import com.asakusafw.dag.compiler.jdbc.windgate.WindGateJdbcOutputModel;
 import com.asakusafw.dag.compiler.jdbc.windgate.WindGateJdbcOutputProcessorGenerator;
 import com.asakusafw.dag.compiler.model.build.GraphInfoBuilder;
+import com.asakusafw.dag.compiler.model.build.ResolvedEdgeInfo;
 import com.asakusafw.dag.compiler.model.build.ResolvedInputInfo;
 import com.asakusafw.dag.compiler.model.build.ResolvedVertexInfo;
 import com.asakusafw.dag.compiler.model.plan.VertexSpec;
@@ -226,10 +227,15 @@ public class WindGateJdbcPortDriver implements ExternalPortDriver {
         });
         ResolvedInputInfo input = new ResolvedInputInfo(
                 JdbcOutputProcessor.INPUT_NAME,
-                descriptors.newOneToOneEdge(Descriptions.classOf(UnionRecord.class), serdeSupplier));
+                new ResolvedEdgeInfo(
+                        descriptors.newOneToOneEdge(Descriptions.classOf(UnionRecord.class), serdeSupplier),
+                        ResolvedEdgeInfo.Movement.ONE_TO_ONE,
+                        Descriptions.classOf(UnionRecord.class),
+                        null));
         ResolvedVertexInfo info = new ResolvedVertexInfo(
                 getOutputId(profileName),
                 descriptors.newVertex(proc),
+                String.format("JDBC(%s)", profileName),
                 ports.stream()
                     .map(outputOwners::get)
                     .filter(v -> isEmptyOutput(v) == false)
@@ -269,6 +275,7 @@ public class WindGateJdbcPortDriver implements ExternalPortDriver {
             ResolvedVertexInfo barrier = new ResolvedVertexInfo(
                     getBarrierId(profileName),
                     descriptors.newVertex(Descriptions.classOf(VoidVertexProcessor.class)),
+                    null,
                     Collections.emptyMap(),
                     Collections.emptyMap(),
                     upstreams);

--- a/dag/compiler/flow/pom.xml
+++ b/dag/compiler/flow/pom.xml
@@ -28,6 +28,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.asakusafw.lang.compiler</groupId>
+      <artifactId>asakusa-compiler-extension-operator</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime</artifactId>
     </dependency>

--- a/dag/compiler/flow/src/main/java/com/asakusafw/dag/compiler/flow/DataFlowUtil.java
+++ b/dag/compiler/flow/src/main/java/com/asakusafw/dag/compiler/flow/DataFlowUtil.java
@@ -35,6 +35,7 @@ import com.asakusafw.dag.compiler.internalio.InternalInputAdapterGenerator;
 import com.asakusafw.dag.compiler.internalio.InternalOutputPrepareGenerator;
 import com.asakusafw.dag.compiler.model.ClassData;
 import com.asakusafw.dag.compiler.model.build.GraphInfoBuilder;
+import com.asakusafw.dag.compiler.model.build.ResolvedEdgeInfo;
 import com.asakusafw.dag.compiler.model.build.ResolvedInputInfo;
 import com.asakusafw.dag.compiler.model.build.ResolvedVertexInfo;
 import com.asakusafw.dag.compiler.model.plan.Implementation;
@@ -325,10 +326,15 @@ public final class DataFlowUtil {
         SubPlan.Input entry = getOutputSource(vertex);
         ResolvedInputInfo input = new ResolvedInputInfo(
                 InternalOutputPrepare.INPUT_NAME,
-                descriptors.newOneToOneEdge(port.getDataType()));
+                new ResolvedEdgeInfo(
+                        descriptors.newOneToOneEdge(port.getDataType()),
+                        ResolvedEdgeInfo.Movement.ONE_TO_ONE,
+                        port.getDataType(),
+                        null));
         ResolvedVertexInfo info = new ResolvedVertexInfo(
                 vertex.getId(),
                 descriptors.newVertex(vertexClass),
+                String.valueOf(port),
                 Collections.singletonMap(entry, input),
                 Collections.emptyMap());
         register(target, vertex, info, vertexClass);

--- a/dag/compiler/model/src/main/java/com/asakusafw/dag/compiler/model/build/GraphInfoBuilder.java
+++ b/dag/compiler/model/src/main/java/com/asakusafw/dag/compiler/model/build/GraphInfoBuilder.java
@@ -16,6 +16,8 @@
 package com.asakusafw.dag.compiler.model.build;
 
 import java.text.MessageFormat;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +36,7 @@ import com.asakusafw.lang.utils.common.Invariants;
 /**
  * Builds {@link GraphInfo}.
  * @since 0.4.0
+ * @version 0.4.2
  */
 public class GraphInfoBuilder {
 
@@ -114,6 +117,15 @@ public class GraphInfoBuilder {
      */
     public ResolvedOutputInfo get(SubPlan.Output port) {
         return outputMap.get(port);
+    }
+
+    /**
+     * Returns the all vertices.
+     * @return the vertices
+     * @since 0.4.2
+     */
+    public Collection<ResolvedVertexInfo> getVertices() {
+        return Collections.unmodifiableCollection(vertices.values());
     }
 
     /**

--- a/dag/compiler/model/src/main/java/com/asakusafw/dag/compiler/model/build/ResolvedEdgeInfo.java
+++ b/dag/compiler/model/src/main/java/com/asakusafw/dag/compiler/model/build/ResolvedEdgeInfo.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dag.compiler.model.build;
+
+import com.asakusafw.dag.api.model.EdgeDescriptor;
+import com.asakusafw.lang.compiler.model.description.TypeDescription;
+import com.asakusafw.lang.compiler.model.graph.Group;
+
+/**
+ * Represents a resolved edge.
+ * @since 0.4.2
+ */
+public class ResolvedEdgeInfo {
+
+    private final EdgeDescriptor descriptor;
+
+    private final Movement movement;
+
+    private final TypeDescription dataType;
+
+    private final Group group;
+
+    /**
+     * Creates a new instance.
+     * @param descriptor the actual descriptor
+     * @param movement the movement type
+     * @param dataType the data type
+     * @param group the grouping information
+     */
+    public ResolvedEdgeInfo(
+            EdgeDescriptor descriptor, Movement movement, TypeDescription dataType, Group group) {
+        this.descriptor = descriptor;
+        this.movement = movement;
+        this.dataType = dataType;
+        this.group = group;
+    }
+
+    /**
+     * Returns the platform dependent descriptor.
+     * @return the descriptor
+     */
+    public EdgeDescriptor getDescriptor() {
+        return descriptor;
+    }
+
+    /**
+     * Returns the data exchange type.
+     * @return the data exchange type
+     */
+    public Movement getMovement() {
+        return movement;
+    }
+
+    /**
+     * Returns the data type.
+     * @return the data type, or {@code null} if it is not defined
+     */
+    public TypeDescription getDataType() {
+        return dataType;
+    }
+
+    /**
+     * Returns the grouping information.
+     * @return the grouping information, or {@code null} if it is not defined
+     */
+    public Group getGroup() {
+        return group;
+    }
+
+    /**
+     * Represents data exchange operation type.
+     * @since 0.4.2
+     */
+    public enum Movement {
+
+        /**
+         * Distributes nothing to successors.
+         */
+        NOTHING,
+
+        /**
+         * Distributes each fragment to successors.
+         */
+        ONE_TO_ONE,
+
+        /**
+         * Distributes all fragments into each successor.
+         */
+        BROADCAST,
+
+        /**
+         * Builds a sequence of sorted record groups from the fragments, and distributes them to successors.
+         */
+        SCATTER_GATHER,
+
+        /**
+         * Aggregates record groups and distributes them to successors.
+         */
+        AGGREGATE,
+    }
+}

--- a/dag/compiler/model/src/main/java/com/asakusafw/dag/compiler/model/build/ResolvedInputInfo.java
+++ b/dag/compiler/model/src/main/java/com/asakusafw/dag/compiler/model/build/ResolvedInputInfo.java
@@ -29,7 +29,7 @@ public class ResolvedInputInfo {
 
     private final String tag;
 
-    private final EdgeDescriptor descriptor;
+    private final ResolvedEdgeInfo edgeInfo;
 
     private final ClassDescription mapperType;
 
@@ -40,57 +40,59 @@ public class ResolvedInputInfo {
     /**
      * Creates a new instance.
      * @param id the input ID
-     * @param descriptor the descriptor
+     * @param edgeInfo the edge information
      */
-    public ResolvedInputInfo(String id, EdgeDescriptor descriptor) {
-        this(id, null, descriptor, null, null, null);
+    public ResolvedInputInfo(String id, ResolvedEdgeInfo edgeInfo) {
+        this(id, null, edgeInfo, null, null, null);
     }
 
     /**
      * Creates a new instance.
      * @param id the input ID
-     * @param descriptor the descriptor
+     * @param edgeInfo the edge information
      * @param mapperType the mapper type (nullable)
      * @param copierType the copier type (nullable)
      * @param combinerType the combiner type (nullable)
      */
     public ResolvedInputInfo(
-            String id, EdgeDescriptor descriptor,
+            String id,
+            ResolvedEdgeInfo edgeInfo,
             ClassDescription mapperType,
             ClassDescription copierType,
             ClassDescription combinerType) {
-        this(id, null, descriptor, mapperType, copierType, combinerType);
+        this(id, null, edgeInfo, mapperType, copierType, combinerType);
     }
 
     /**
      * Creates a new instance.
      * @param id the input ID
      * @param tag the optional port tag (nullable)
-     * @param descriptor the descriptor
+     * @param edgeInfo the edge information
      */
-    public ResolvedInputInfo(String id, String tag, EdgeDescriptor descriptor) {
-        this(id, descriptor, null, null, null);
+    public ResolvedInputInfo(String id, String tag, ResolvedEdgeInfo edgeInfo) {
+        this(id, tag, edgeInfo, null, null, null);
     }
 
     /**
      * Creates a new instance.
      * @param id the input ID
      * @param tag the optional port tag
-     * @param descriptor the descriptor
+     * @param edgeInfo the edge information
      * @param mapperType the mapper type (nullable)
      * @param copierType the copier type (nullable)
      * @param combinerType the combiner type (nullable)
      */
     public ResolvedInputInfo(
-            String id, String tag, EdgeDescriptor descriptor,
+            String id, String tag,
+            ResolvedEdgeInfo edgeInfo,
             ClassDescription mapperType,
             ClassDescription copierType,
             ClassDescription combinerType) {
         Arguments.requireNonNull(id);
-        Arguments.requireNonNull(descriptor);
+        Arguments.requireNonNull(edgeInfo);
         this.id = id;
         this.tag = tag;
-        this.descriptor = descriptor;
+        this.edgeInfo = edgeInfo;
         this.mapperType = mapperType;
         this.copierType = copierType;
         this.combinerType = combinerType;
@@ -113,11 +115,19 @@ public class ResolvedInputInfo {
     }
 
     /**
+     * Returns the edge information.
+     * @return the edge information
+     */
+    public ResolvedEdgeInfo getEdgeInfo() {
+        return edgeInfo;
+    }
+
+    /**
      * Returns the descriptor.
      * @return the descriptor
      */
     public EdgeDescriptor getDescriptor() {
-        return descriptor;
+        return edgeInfo.getDescriptor();
     }
 
     /**

--- a/dag/compiler/model/src/main/java/com/asakusafw/dag/compiler/model/build/ResolvedVertexInfo.java
+++ b/dag/compiler/model/src/main/java/com/asakusafw/dag/compiler/model/build/ResolvedVertexInfo.java
@@ -34,6 +34,8 @@ public class ResolvedVertexInfo {
 
     private final VertexDescriptor descriptor;
 
+    private final String label;
+
     private final Map<SubPlan.Input, ResolvedInputInfo> inputs;
 
     private final Map<SubPlan.Output, ResolvedOutputInfo> outputs;
@@ -44,21 +46,24 @@ public class ResolvedVertexInfo {
      * Creates a new instance.
      * @param id the vertex ID
      * @param descriptor the vertex descriptor
+     * @param label the vertex label (nullable)
      * @param inputs the inputs
      * @param outputs the outputs
      */
     public ResolvedVertexInfo(
             String id,
             VertexDescriptor descriptor,
+            String label,
             Map<? extends SubPlan.Input, ? extends ResolvedInputInfo> inputs,
             Map<? extends SubPlan.Output, ? extends ResolvedOutputInfo> outputs) {
-        this(id, descriptor, inputs, outputs, Collections.emptySet());
+        this(id, descriptor, label, inputs, outputs, Collections.emptySet());
     }
 
     /**
      * Creates a new instance.
      * @param id the vertex ID
      * @param descriptor the vertex descriptor
+     * @param label the vertex label (nullable)
      * @param inputs the inputs
      * @param outputs the outputs
      * @param implicitDependencies the implicit dependency targets
@@ -66,6 +71,7 @@ public class ResolvedVertexInfo {
     public ResolvedVertexInfo(
             String id,
             VertexDescriptor descriptor,
+            String label,
             Map<? extends SubPlan.Input, ? extends ResolvedInputInfo> inputs,
             Map<? extends SubPlan.Output, ? extends ResolvedOutputInfo> outputs,
             Collection<? extends ResolvedVertexInfo> implicitDependencies) {
@@ -76,6 +82,7 @@ public class ResolvedVertexInfo {
         Arguments.requireNonNull(implicitDependencies);
         this.id = id;
         this.descriptor = descriptor;
+        this.label = label;
         this.inputs = Arguments.freeze(inputs);
         this.outputs = Arguments.freeze(outputs);
         this.implicitDependencies = Arguments.copyToSet(implicitDependencies);
@@ -95,6 +102,14 @@ public class ResolvedVertexInfo {
      */
     public VertexDescriptor getDescriptor() {
         return descriptor;
+    }
+
+    /**
+     * Returns the label.
+     * @return the label, or {@code null} if it is not defined
+     */
+    public String getLabel() {
+        return label;
     }
 
     /**

--- a/info/api/src/main/java/com/asakusafw/lang/info/api/AttributeCollector.java
+++ b/info/api/src/main/java/com/asakusafw/lang/info/api/AttributeCollector.java
@@ -15,7 +15,11 @@
  */
 package com.asakusafw.lang.info.api;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 import com.asakusafw.lang.compiler.api.CompilerOptions;
+import com.asakusafw.lang.compiler.common.Location;
 import com.asakusafw.lang.compiler.model.graph.Batch;
 import com.asakusafw.lang.compiler.model.graph.Jobflow;
 import com.asakusafw.lang.info.Attribute;
@@ -47,6 +51,7 @@ public interface AttributeCollector {
     /**
      * Represents a context object for {@link AttributeCollector}.
      * @since 0.4.1
+     * @version 0.4.2
      */
     public interface Context {
 
@@ -67,5 +72,14 @@ public interface AttributeCollector {
          * @param attribute the attribute to add
          */
         void putAttribute(Attribute attribute);
+
+        /**
+         * Returns a resource from the current output.
+         * @param location the resource location in the target package
+         * @return the jobflow resource, or {@code null} if it does not exist
+         * @throws IOException if failed to open the file
+         * @since 0.4.2
+         */
+        InputStream findResourceFile(Location location) throws IOException;
     }
 }

--- a/info/api/src/test/java/com/asakusafw/lang/info/api/MockAttributeCollectorContext.java
+++ b/info/api/src/test/java/com/asakusafw/lang/info/api/MockAttributeCollectorContext.java
@@ -15,10 +15,13 @@
  */
 package com.asakusafw.lang.info.api;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
 import com.asakusafw.lang.compiler.api.CompilerOptions;
+import com.asakusafw.lang.compiler.common.Location;
 import com.asakusafw.lang.compiler.model.graph.Batch;
 import com.asakusafw.lang.compiler.model.graph.Jobflow;
 import com.asakusafw.lang.info.Attribute;
@@ -68,6 +71,11 @@ public class MockAttributeCollectorContext implements AttributeCollector.Context
     @Override
     public void putAttribute(Attribute attribute) {
         attributes.add(attribute);
+    }
+
+    @Override
+    public InputStream findResourceFile(Location location) throws IOException {
+        throw new IllegalStateException();
     }
 
     /**

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/BaseCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/BaseCommand.java
@@ -77,6 +77,7 @@ public abstract class BaseCommand implements Runnable {
                 return s;
             }
         } catch (IOException e) {
+
             LOG.error("error occurred while processing command", e);
             return Status.PROCESS_ERROR;
         }

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/DrawEngine.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/DrawEngine.java
@@ -1,0 +1,392 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.cli;
+
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import com.asakusafw.lang.info.cli.Drawer.Shape;
+import com.asakusafw.lang.info.operator.CoreOperatorSpec;
+import com.asakusafw.lang.info.operator.CustomOperatorSpec;
+import com.asakusafw.lang.info.operator.FlowOperatorSpec;
+import com.asakusafw.lang.info.operator.InputGranularity;
+import com.asakusafw.lang.info.operator.InputGroup;
+import com.asakusafw.lang.info.operator.InputOperatorSpec;
+import com.asakusafw.lang.info.operator.MarkerOperatorSpec;
+import com.asakusafw.lang.info.operator.OperatorSpec.OperatorKind;
+import com.asakusafw.lang.info.operator.OutputOperatorSpec;
+import com.asakusafw.lang.info.operator.UserOperatorSpec;
+import com.asakusafw.lang.info.operator.view.InputView;
+import com.asakusafw.lang.info.operator.view.OperatorGraphView;
+import com.asakusafw.lang.info.operator.view.OperatorView;
+import com.asakusafw.lang.info.operator.view.OutputView;
+import com.asakusafw.lang.info.plan.PlanInputSpec;
+import com.asakusafw.lang.info.plan.PlanOutputSpec;
+import com.asakusafw.lang.info.plan.PlanVertexSpec;
+import com.asakusafw.lang.info.value.ClassInfo;
+
+class DrawEngine {
+
+    private final Set<Feature> features;
+
+    private final Drawer drawer = new Drawer();
+
+    private final boolean showPort;
+
+    DrawEngine(Collection<Feature> features) {
+        this.features = EnumSet.noneOf(Feature.class);
+        this.features.addAll(features);
+        this.showPort = features.stream().anyMatch(it -> it.showPort);
+    }
+
+    void draw(
+            PrintWriter writer, OperatorGraphView root,
+            int limitDepth, Optional<String> label,
+            Consumer<? super Drawer> extension) {
+        drawer.add(root.getRoot(), Shape.GRAPH, label);
+        analyzeGraph(root, 1, limitDepth);
+        Optional.ofNullable(extension).ifPresent(it -> it.accept(drawer));
+        drawer.dump(writer, root.getRoot());
+    }
+
+    void draw(
+            PrintWriter writer, OperatorGraphView root,
+            int limitDepth, List<String> label,
+            Consumer<? super Drawer> extension) {
+        drawer.add(root.getRoot(), Shape.GRAPH, label);
+        analyzeGraph(root, 1, limitDepth);
+        Optional.ofNullable(extension).ifPresent(it -> it.accept(drawer));
+        drawer.dump(writer, root.getRoot());
+    }
+
+    private void analyzeGraph(OperatorGraphView graph, int currentDepth, int limitDepth) {
+        for (OperatorView operator : graph.getOperators()) {
+            if (operator.getSpec().getOperatorKind() == OperatorKind.FLOW
+                    && currentDepth < limitDepth) {
+                analyzeFlowGraph(operator, (FlowOperatorSpec) operator.getSpec());
+                analyzeGraph(operator.getElementGraph(), currentDepth + 1, limitDepth);
+            } else if (operator.getSpec().getOperatorKind() == OperatorKind.PLAN_VERTEX
+                    && operator.getElementGraph().getOperators().isEmpty() == false
+                    && currentDepth < limitDepth) {
+                analyzePlanVertex(operator, (PlanVertexSpec) operator.getSpec());
+                analyzeGraph(operator.getElementGraph(), currentDepth + 1, limitDepth);
+            } else {
+                analyzeOperator(operator);
+            }
+            for (OutputView upstream : operator.getOutputs()) {
+                for (InputView downstream : upstream.getOpposites()) {
+                    drawer.connect(upstream.getEntity(), downstream.getEntity());
+                }
+            }
+        }
+        Map<String, OperatorView> vertices = graph.getOperators(OperatorKind.PLAN_VERTEX).stream()
+                .collect(Collectors.toMap(
+                        it -> ((PlanVertexSpec) it.getSpec()).getName(),
+                        Function.identity()));
+        vertices.values().forEach(downstream -> ((PlanVertexSpec) downstream.getSpec()).getDependencies().stream()
+                .map(vertices::get)
+                .filter(it -> it != null)
+                .forEach(upstream -> drawer.connect(upstream.getEntity(), downstream.getEntity())));
+    }
+
+    private void analyzeFlowGraph(OperatorView operator, FlowOperatorSpec spec) {
+        drawer.add(operator.getEntity(), Shape.GRAPH, Optional.ofNullable(spec.getDescriptionClass())
+                .map(ClassInfo::getSimpleName));
+
+        OperatorGraphView graph = operator.getElementGraph();
+        Map<String, OperatorView> inputs = graph.getOperatorMap(OperatorKind.INPUT);
+        operator.getInputs().forEach(it -> drawer.redirect(it.getEntity(), inputs.get(it.getName()).getEntity()));
+        Map<String, OperatorView> outputs = graph.getOperatorMap(OperatorKind.OUTPUT);
+        operator.getOutputs().forEach(it -> drawer.redirect(it.getEntity(), outputs.get(it.getName()).getEntity()));
+    }
+
+    private void analyzePlanVertex(OperatorView operator, PlanVertexSpec spec) {
+        drawer.add(operator.getEntity(), Shape.GRAPH, spec.getName());
+
+        OperatorGraphView graph = operator.getElementGraph();
+        Map<String, OperatorView> inputs = graph.getOperatorMap(OperatorKind.PLAN_INPUT);
+        operator.getInputs().forEach(it -> drawer.redirect(it.getEntity(), inputs.get(it.getName()).getEntity()));
+        Map<String, OperatorView> outputs = graph.getOperatorMap(OperatorKind.PLAN_OUTPUT);
+        operator.getOutputs().forEach(it -> drawer.redirect(it.getEntity(), outputs.get(it.getName()).getEntity()));
+    }
+
+    private void analyzeOperator(OperatorView operator) {
+        switch (operator.getSpec().getOperatorKind()) {
+        case CORE:
+            addCoreVertex(operator, (CoreOperatorSpec) operator.getSpec());
+            break;
+        case USER:
+            addUserVertex(operator, (UserOperatorSpec) operator.getSpec());
+            break;
+        case INPUT:
+            addInputVertex(operator, (InputOperatorSpec) operator.getSpec());
+            break;
+        case OUTPUT:
+            addOutputVertex(operator, (OutputOperatorSpec) operator.getSpec());
+            break;
+        case FLOW:
+            addFlowVertex(operator, (FlowOperatorSpec) operator.getSpec());
+            break;
+        case MARKER:
+            addMarkerVertex(operator, (MarkerOperatorSpec) operator.getSpec());
+            break;
+        case CUSTOM:
+            addCustomVertex(operator, (CustomOperatorSpec) operator.getSpec());
+            break;
+        case PLAN_VERTEX:
+            addPlanVertex(operator, (PlanVertexSpec) operator.getSpec());
+            break;
+        case PLAN_INPUT:
+            addPlanInput(operator, (PlanInputSpec) operator.getSpec());
+            break;
+        case PLAN_OUTPUT:
+            addPlanOutput(operator, (PlanOutputSpec) operator.getSpec());
+            break;
+        default:
+            throw new AssertionError();
+        }
+    }
+
+    private void addCoreVertex(OperatorView operator, CoreOperatorSpec spec) {
+        List<String> body = new ArrayList<>();
+        body.add('@' + spec.getCategory().getAnnotationType().getSimpleName());
+        body.addAll(analyzeBody(operator));
+        if (showPort) {
+            analyzeOperatorAsRecord(operator, body);
+        } else {
+            drawer.add(operator.getEntity(), Shape.BOX, body);
+        }
+    }
+
+    private void addUserVertex(OperatorView operator, UserOperatorSpec spec) {
+        List<String> body = new ArrayList<>();
+        body.add('@' + spec.getAnnotation().getDeclaringClass().getSimpleName());
+        body.add(spec.getDeclaringClass().getSimpleName());
+        body.add(spec.getMethodName());
+        body.addAll(analyzeBody(operator));
+        if (showPort) {
+            analyzeOperatorAsRecord(operator, body);
+        } else {
+            drawer.add(operator.getEntity(), Shape.BOX, body);
+        }
+    }
+
+    private void addInputVertex(OperatorView operator, InputOperatorSpec spec) {
+        List<String> body = new ArrayList<>();
+        Optional.ofNullable(spec.getDescriptionClass())
+            .ifPresent(it -> body.add("@Import"));
+        body.add(spec.getName());
+        if (features.contains(Feature.PORT_TYPE)) {
+            operator.getOutputs().stream()
+                .findAny()
+                .map(OutputView::getDataType)
+                .map(ClassInfo::getSimpleName)
+                .ifPresent(body::add);
+        }
+        if (features.contains(Feature.EXTERNAL_IO_CLASS)) {
+            Optional.ofNullable(spec.getDescriptionClass())
+                .map(ClassInfo::getSimpleName)
+                .ifPresent(body::add);
+        }
+        body.addAll(analyzeBody(operator));
+        drawer.add(operator.getEntity(), Shape.INPUT, body);
+    }
+
+    private void addOutputVertex(OperatorView operator, OutputOperatorSpec spec) {
+        List<String> body = new ArrayList<>();
+        Optional.ofNullable(spec.getDescriptionClass())
+            .ifPresent(it -> body.add("@Export"));
+        body.add(spec.getName());
+        if (features.contains(Feature.PORT_TYPE)) {
+            operator.getInputs().stream()
+                .findAny()
+                .map(InputView::getDataType)
+                .map(ClassInfo::getSimpleName)
+                .ifPresent(body::add);
+        }
+        if (features.contains(Feature.EXTERNAL_IO_CLASS)) {
+            Optional.ofNullable(spec.getDescriptionClass())
+                .map(ClassInfo::getSimpleName)
+                .ifPresent(body::add);
+        }
+        body.addAll(analyzeBody(operator));
+        drawer.add(operator.getEntity(), Shape.OUTPUT, body);
+    }
+
+    private void addFlowVertex(OperatorView operator, FlowOperatorSpec spec) {
+        List<String> body = new ArrayList<>();
+        body.add("@FlowPart");
+        Optional.ofNullable(spec.getDescriptionClass())
+            .map(ClassInfo::getSimpleName)
+            .ifPresent(body::add);
+        body.addAll(analyzeBody(operator));
+        if (showPort) {
+            analyzeOperatorAsRecord(operator, body);
+        } else {
+            drawer.add(operator.getEntity(), Shape.BOX, body);
+        }
+    }
+
+    private void addMarkerVertex(OperatorView operator, MarkerOperatorSpec spec) {
+        drawer.add(operator.getEntity(), Shape.POINT, Collections.emptyList());
+    }
+
+    private void addCustomVertex(OperatorView operator, CustomOperatorSpec spec) {
+        List<String> body = new ArrayList<>();
+        body.add(spec.getCategory());
+        body.addAll(analyzeBody(operator));
+        if (showPort) {
+            analyzeOperatorAsRecord(operator, body);
+        } else {
+            drawer.add(operator.getEntity(), Shape.ROUNDED_BOX, body);
+        }
+    }
+
+    private void addPlanVertex(OperatorView operator, PlanVertexSpec spec) {
+        List<String> body = new ArrayList<>();
+        body.add(spec.getName());
+        Optional.ofNullable(spec.getLabel()).ifPresent(body::add);
+        drawer.add(operator.getEntity(), Shape.ROUNDED_BOX, body);
+    }
+
+    private void addPlanInput(OperatorView operator, PlanInputSpec spec) {
+        List<String> body = analyzePlanInput(operator, spec);
+        body.addAll(analyzeBody(operator));
+        drawer.add(operator.getEntity(), Shape.ROUNDED_BOX, body);
+    }
+
+    private List<String> analyzePlanInput(OperatorView operator, PlanInputSpec spec) {
+        List<String> body = new ArrayList<>();
+        body.add(spec.getExchange().toString());
+        if (features.contains(Feature.EDGE_TYPE)) {
+            operator.getInputs().stream()
+                .findAny()
+                .map(InputView::getDataType)
+                .map(ClassInfo::getSimpleName)
+                .ifPresent(body::add);
+        }
+        if (features.contains(Feature.EDGE_KEY)) {
+            Optional.ofNullable(spec.getGroup())
+                .map(InputGroup::toString)
+                .ifPresent(body::add);
+        }
+        return body;
+    }
+
+    private void addPlanOutput(OperatorView operator, PlanOutputSpec spec) {
+        List<String> body = analyzePlanOutput(operator, spec);
+        body.addAll(analyzeBody(operator));
+        drawer.add(operator.getEntity(), Shape.ROUNDED_BOX, body);
+    }
+
+    private List<String> analyzePlanOutput(OperatorView operator, PlanOutputSpec spec) {
+        List<String> body = new ArrayList<>();
+        body.add(spec.getExchange().toString());
+        if (features.contains(Feature.EDGE_TYPE)) {
+            operator.getInputs().stream()
+                .findAny()
+                .map(InputView::getDataType)
+                .map(ClassInfo::getSimpleName)
+                .ifPresent(body::add);
+        }
+        if (features.contains(Feature.EDGE_KEY)) {
+            Optional.ofNullable(spec.getGroup())
+                .map(InputGroup::toString)
+                .ifPresent(body::add);
+        }
+        return body;
+    }
+
+    private void analyzeOperatorAsRecord(OperatorView operator, List<String> body) {
+        drawer.add(operator.getEntity(), Shape.RECORD, body);
+        operator.getInputs().forEach(this::analyzeMemberInput);
+        operator.getOutputs().forEach(this::analyzeMemberOutput);
+    }
+
+    private List<String> analyzeBody(OperatorView operator) {
+        List<String> results = new ArrayList<>();
+        if (features.contains(Feature.ARGUMENT)) {
+            operator.getParameters().stream()
+                .map(it -> String.format("%s: %s", it.getName(), it.getValue().getObject()))
+                .forEachOrdered(results::add);
+        }
+        return results;
+    }
+
+    private void analyzeMemberInput(InputView port) {
+        List<String> results = new ArrayList<>();
+        if (features.contains(Feature.PORT_NAME)) {
+            results.add(port.getName());
+        }
+        if (features.contains(Feature.PORT_TYPE)) {
+            results.add(port.getDataType().getSimpleName());
+        }
+        if (features.contains(Feature.PORT_KEY)) {
+            Optional.ofNullable(port.getGranulatity())
+                .map(InputGranularity::toString)
+                .ifPresent(results::add);
+            Optional.ofNullable(port.getGroup())
+                .map(InputGroup::toString)
+                .ifPresent(results::add);
+        }
+        drawer.add(port.getEntity(), results);
+    }
+
+    private void analyzeMemberOutput(OutputView port) {
+        List<String> results = new ArrayList<>();
+        if (features.contains(Feature.PORT_NAME)) {
+            results.add(port.getName());
+        }
+        if (features.contains(Feature.PORT_TYPE)) {
+            results.add(port.getDataType().getSimpleName());
+        }
+        drawer.add(port.getEntity(), results);
+    }
+
+    enum Feature {
+
+        ARGUMENT(false),
+
+        EXTERNAL_IO_CLASS(false),
+
+        PORT_NAME(true),
+
+        PORT_TYPE(true),
+
+        PORT_KEY(true),
+
+        EDGE_TYPE(false),
+
+        EDGE_KEY(false),
+        ;
+
+        final boolean showPort;
+
+        Feature(boolean showPort) {
+            this.showPort = showPort;
+        }
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/DrawOperatorCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/DrawOperatorCommand.java
@@ -15,38 +15,26 @@
  */
 package com.asakusafw.lang.info.cli;
 
-import static com.asakusafw.lang.info.cli.DrawUtil.*;
-
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.text.MessageFormat;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
+import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
-import java.util.stream.Collectors;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import com.asakusafw.lang.info.BatchInfo;
 import com.asakusafw.lang.info.JobflowInfo;
-import com.asakusafw.lang.info.operator.CoreOperatorSpec;
-import com.asakusafw.lang.info.operator.CustomOperatorSpec;
+import com.asakusafw.lang.info.cli.DrawEngine.Feature;
 import com.asakusafw.lang.info.operator.FlowOperatorSpec;
-import com.asakusafw.lang.info.operator.InputGroup;
-import com.asakusafw.lang.info.operator.InputOperatorSpec;
-import com.asakusafw.lang.info.operator.MarkerOperatorSpec;
 import com.asakusafw.lang.info.operator.OperatorGraphAttribute;
 import com.asakusafw.lang.info.operator.OperatorSpec.OperatorKind;
-import com.asakusafw.lang.info.operator.OutputOperatorSpec;
-import com.asakusafw.lang.info.operator.UserOperatorSpec;
-import com.asakusafw.lang.info.operator.view.InputView;
 import com.asakusafw.lang.info.operator.view.OperatorGraphView;
 import com.asakusafw.lang.info.operator.view.OperatorView;
-import com.asakusafw.lang.info.operator.view.OutputView;
 import com.asakusafw.lang.info.value.ClassInfo;
 
 import io.airlift.airline.Command;
@@ -74,7 +62,7 @@ public class DrawOperatorCommand extends SingleJobflowInfoCommand {
     @Option(
             name = { "--flow-part", },
             title = "class name",
-            description = "only displays in the ",
+            description = "only displays in the flow-part",
             arity = 1,
             required = false)
     String flowPart;
@@ -132,10 +120,11 @@ public class DrawOperatorCommand extends SingleJobflowInfoCommand {
         OperatorGraphView graph = jobflow.findAttribute(OperatorGraphAttribute.class)
                 .map(OperatorGraphView::new)
                 .orElseThrow(() -> new IllegalStateException("there are no available operators"));
-        String label = Optional.ofNullable(jobflow.getDescriptionClass())
-                .map(ClassInfo::of)
-                .map(ClassInfo::getSimpleName)
-                .orElse(jobflow.getId());
+        List<String> label = new ArrayList<>();
+        label.add(Optional.ofNullable(jobflow.getDescriptionClass())
+                    .map(ClassInfo::of)
+                    .map(ClassInfo::getSimpleName)
+                    .orElse(jobflow.getId()));
         if (flowPart != null) {
             OperatorView fp = findFlowPart(graph)
                     .orElseThrow(() -> new IOException(MessageFormat.format(
@@ -144,11 +133,37 @@ public class DrawOperatorCommand extends SingleJobflowInfoCommand {
                                 .orElse(jobflow.getId()),
                             flowPart)));
             graph = fp.getElementGraph();
-            label = Optional.of(((FlowOperatorSpec) fp.getSpec()).getDescriptionClass())
+            FlowOperatorSpec spec = (FlowOperatorSpec) fp.getSpec();
+            Optional.of(spec.getDescriptionClass())
                     .map(ClassInfo::getSimpleName)
-                    .orElse(null);
+                    .ifPresent(label::add);
         }
-        new Engine(writer, graph).print(label);
+        Set<Feature> features = extractFeatures();
+        DrawEngine engine = new DrawEngine(features);
+        engine.draw(writer, graph, limitDepth, label, null);
+    }
+
+    private Set<Feature> extractFeatures() {
+        if (showAll) {
+            return EnumSet.allOf(Feature.class);
+        }
+        Set<DrawEngine.Feature> results = EnumSet.noneOf(Feature.class);
+        if (showArgument) {
+            results.add(Feature.ARGUMENT);
+        }
+        if (showExternalIo) {
+            results.add(Feature.EXTERNAL_IO_CLASS);
+        }
+        if (showPortName) {
+            results.add(Feature.PORT_NAME);
+        }
+        if (showPortKey) {
+            results.add(Feature.PORT_KEY);
+        }
+        if (showPortType) {
+            results.add(Feature.PORT_TYPE);
+        }
+        return results;
     }
 
     private Optional<OperatorView> findFlowPart(OperatorGraphView graph) {
@@ -169,390 +184,6 @@ public class DrawOperatorCommand extends SingleJobflowInfoCommand {
     }
 
     private static Stream<OperatorView> getFlowParts(OperatorGraphView graph) {
-        return graph.getOperators().stream().filter(it -> it.getSpec() instanceof FlowOperatorSpec);
-    }
-
-    private class Engine {
-
-        private final PrintWriter writer;
-
-        private final OperatorGraphView root;
-
-        private final Map<Object, Id> ids = new HashMap<>();
-
-        private int idCount = 0;
-
-        private final boolean record;
-
-        Engine(PrintWriter writer, OperatorGraphView graph) {
-            this.writer = writer;
-            this.root = graph;
-            this.record = showAll || showPortName || showPortType || showPortType;
-            computeIds(root, 1);
-        }
-
-        private void computeIds(OperatorGraphView graph, int currentDepth) {
-            for (OperatorView operator : graph.getOperators()) {
-                switch (operator.getSpec().getOperatorKind()) {
-                case INPUT:
-                case OUTPUT:
-                case MARKER:
-                    addSimpleIds(operator);
-                    break;
-                case FLOW:
-                    if (currentDepth < limitDepth) {
-                        computeIds(operator.getElementGraph(), currentDepth + 1);
-                        addFlowIds(operator);
-                    } else {
-                        addGeneralIds(operator);
-                    }
-                    break;
-                default:
-                    addGeneralIds(operator);
-                    break;
-                }
-            }
-        }
-
-        private void addSimpleIds(OperatorView operator) {
-            ids.put(operator, getNextId());
-        }
-
-        private void addGeneralIds(OperatorView operator) {
-            if (record == false) {
-                addSimpleIds(operator);
-                return;
-            }
-            Id id = getNextId();
-            ids.put(operator, id);
-            int index = 0;
-            for (InputView port : operator.getInputs()) {
-                ids.put(port, new Id(id, index++));
-            }
-            for (OutputView port : operator.getOutputs()) {
-                ids.put(port, new Id(id, index++));
-            }
-        }
-
-        private void addFlowIds(OperatorView operator) {
-            OperatorGraphView graph = operator.getElementGraph();
-            ids.put(operator, getNextId());
-
-            Map<String, OperatorView> inputs = graph.getInputs();
-            operator.getInputs().stream().forEach(it -> ids.put(
-                    it,
-                    Optional.ofNullable(inputs.get(it.getName()))
-                        .flatMap(v -> Optional.ofNullable(ids.get(v)))
-                        .orElseThrow(IllegalStateException::new)));
-
-            Map<String, OperatorView> outputs = graph.getOutputs();
-            operator.getOutputs().stream().forEach(it -> ids.put(
-                    it,
-                    Optional.ofNullable(outputs.get(it.getName()))
-                        .flatMap(v -> Optional.ofNullable(ids.get(v)))
-                        .orElseThrow(IllegalStateException::new)));
-        }
-
-        private Id getNextId() {
-            return new Id(null, idCount++);
-        }
-
-        String getId(OperatorView operator) {
-            return Optional.ofNullable(ids.get(operator))
-                    .map(Id::asSimple)
-                    .orElseThrow(IllegalStateException::new);
-        }
-
-        String getSimpleId(InputView port) {
-            return Optional.ofNullable(ids.get(port))
-                    .map(Id::asSimple)
-                    .orElseThrow(IllegalStateException::new);
-        }
-
-        String getSimpleId(OutputView port) {
-            return Optional.ofNullable(ids.get(port))
-                    .map(Id::asSimple)
-                    .orElseThrow(IllegalStateException::new);
-        }
-
-        String getQualifiedId(InputView port) {
-            return Optional.ofNullable(ids.get(port))
-                    .map(Id::asQualified)
-                    .orElseGet(() -> getId(port.getOwner()));
-        }
-
-        String getQualifiedId(OutputView port) {
-            return Optional.ofNullable(ids.get(port))
-                    .map(Id::asQualified)
-                    .orElseGet(() -> getId(port.getOwner()));
-        }
-
-        void print(String label) {
-            writer.println("digraph {");
-            Optional.ofNullable(label)
-                .ifPresent(it -> writer.printf("label=%s;%n", literal(it)));
-            printVertices(root, 1);
-            printEdges(root, 1);
-            writer.println("}");
-        }
-
-        private void printVertices(OperatorGraphView graph, int currentDepth) {
-            for (OperatorView operator : graph.getOperators()) {
-                if (operator.getSpec().getOperatorKind() == OperatorKind.FLOW
-                        && currentDepth < limitDepth) {
-                    FlowOperatorSpec spec = (FlowOperatorSpec) operator.getSpec();
-                    writer.printf("subgraph cluster_%s {%n", getId(operator));
-                    Optional.ofNullable(spec.getDescriptionClass())
-                        .map(ClassInfo::getSimpleName)
-                        .ifPresent(it -> writer.printf("label=%s;%n", literal(it)));
-                    printVertices(operator.getElementGraph(), currentDepth + 1);
-                    writer.println("}");
-                } else {
-                    printVertex(operator);
-                }
-            }
-        }
-
-        private void printVertex(OperatorView operator) {
-            switch (operator.getSpec().getOperatorKind()) {
-            case CORE:
-                printCoreVertex(operator, (CoreOperatorSpec) operator.getSpec());
-                break;
-            case USER:
-                printUserVertex(operator, (UserOperatorSpec) operator.getSpec());
-                break;
-            case INPUT:
-                printInputVertex(operator, (InputOperatorSpec) operator.getSpec());
-                break;
-            case OUTPUT:
-                printOutputVertex(operator, (OutputOperatorSpec) operator.getSpec());
-                break;
-            case FLOW:
-                addFlowVertex(operator, (FlowOperatorSpec) operator.getSpec());
-                break;
-            case MARKER:
-                addMarkerVertex(operator, (MarkerOperatorSpec) operator.getSpec());
-                break;
-            case CUSTOM:
-                addCustomVertex(operator, (CustomOperatorSpec) operator.getSpec());
-                break;
-            default:
-                addGeneralIds(operator);
-                break;
-            }
-        }
-
-        private void printCoreVertex(OperatorView operator, CoreOperatorSpec spec) {
-            List<String> body = new ArrayList<>();
-            body.add('@' + spec.getCategory().getAnnotationType().getSimpleName());
-            body.addAll(analyzeBody(operator));
-            if (record) {
-                printRecord(operator, body);
-            } else {
-                printGeneralVertex(operator, "box", body);
-            }
-        }
-
-        private void printUserVertex(OperatorView operator, UserOperatorSpec spec) {
-            List<String> body = new ArrayList<>();
-            body.add('@' + spec.getAnnotation().getDeclaringClass().getSimpleName());
-            body.add(spec.getDeclaringClass().getSimpleName());
-            body.add(spec.getMethodName());
-            body.addAll(analyzeBody(operator));
-            if (record) {
-                printRecord(operator, body);
-            } else {
-                printGeneralVertex(operator, "box", body);
-            }
-        }
-
-        private void printInputVertex(OperatorView operator, InputOperatorSpec spec) {
-            List<String> body = new ArrayList<>();
-            Optional.ofNullable(spec.getDescriptionClass())
-                .ifPresent(it -> body.add("@Import"));
-            body.add(spec.getName());
-            if (showAll || showPortType) {
-                operator.getOutputs().stream()
-                    .findAny()
-                    .map(OutputView::getDataType)
-                    .map(ClassInfo::getSimpleName)
-                    .ifPresent(body::add);
-            }
-            if (showAll || showExternalIo) {
-                Optional.ofNullable(spec.getDescriptionClass())
-                    .map(ClassInfo::getSimpleName)
-                    .ifPresent(body::add);
-            }
-            body.addAll(analyzeBody(operator));
-            printGeneralVertex(operator, "invhouse", body);
-        }
-
-        private void printOutputVertex(OperatorView operator, OutputOperatorSpec spec) {
-            List<String> body = new ArrayList<>();
-            Optional.ofNullable(spec.getDescriptionClass())
-                .ifPresent(it -> body.add("@Export"));
-            body.add(spec.getName());
-            if (showAll || showPortType) {
-                operator.getInputs().stream()
-                    .findAny()
-                    .map(InputView::getDataType)
-                    .map(ClassInfo::getSimpleName)
-                    .ifPresent(body::add);
-            }
-            if (showAll || showExternalIo) {
-                Optional.ofNullable(spec.getDescriptionClass())
-                    .map(ClassInfo::getSimpleName)
-                    .ifPresent(body::add);
-            }
-            body.addAll(analyzeBody(operator));
-            printGeneralVertex(operator, "invhouse", body);
-        }
-
-        private void addFlowVertex(OperatorView operator, FlowOperatorSpec spec) {
-            List<String> body = new ArrayList<>();
-            body.add("@FlowPart");
-            Optional.ofNullable(spec.getDescriptionClass())
-                .map(ClassInfo::getSimpleName)
-                .ifPresent(body::add);
-            body.addAll(analyzeBody(operator));
-            if (record) {
-                printRecord(operator, body);
-            } else {
-                printGeneralVertex(operator, "box", body);
-            }
-        }
-
-        private void addMarkerVertex(OperatorView operator, MarkerOperatorSpec spec) {
-            List<String> body = new ArrayList<>();
-            body.add("(marker)");
-            body.addAll(analyzeBody(operator));
-            printGeneralVertex(operator, "box", body);
-        }
-
-        private void addCustomVertex(OperatorView operator, CustomOperatorSpec spec) {
-            List<String> body = new ArrayList<>();
-            body.add(spec.getCategory());
-            body.addAll(analyzeBody(operator));
-            if (record) {
-                printRecord(operator, body);
-            } else {
-                printGeneralVertex(operator, "box", body);
-            }
-        }
-
-        private void printRecord(OperatorView operator, List<String> body) {
-            String label = String.format(
-                    "{{%s}|%s|{%s}}",
-                    operator.getInputs().stream()
-                        .map(it -> String.format("<%s>%s",
-                                getSimpleId(it),
-                                analyzeInput(it).stream()
-                                    .map(DrawUtil::escapeForRecord)
-                                    .collect(Collectors.joining("\n"))))
-                        .collect(Collectors.joining("|")),
-                    body.stream()
-                        .map(DrawUtil::escapeForRecord)
-                        .collect(Collectors.joining("\n")),
-                    operator.getOutputs().stream()
-                        .map(it -> String.format("<%s>%s",
-                                getSimpleId(it),
-                                analyzeOutput(it).stream()
-                                    .map(DrawUtil::escapeForRecord)
-                                    .collect(Collectors.joining("\n"))))
-                        .collect(Collectors.joining("|")));
-            printGeneralVertex(operator, "record", Collections.singletonList(label));
-        }
-
-        private List<String> analyzeBody(OperatorView operator) {
-            List<String> results = new ArrayList<>();
-            if (showAll || showArgument) {
-                operator.getParameters().stream()
-                    .map(it -> String.format("%s: %s", it.getName(), it.getValue().getObject()))
-                    .forEachOrdered(results::add);
-            }
-            return results;
-        }
-
-        private List<String> analyzeInput(InputView port) {
-            List<String> results = new ArrayList<>();
-            if (showAll || showPortName) {
-                results.add(port.getName());
-            }
-            if (showAll || showPortType) {
-                results.add(port.getDataType().getSimpleName());
-            }
-            if (showAll || showPortKey) {
-                results.add(port.getGranulatity().toString());
-                Optional.ofNullable(port.getGroup())
-                    .map(InputGroup::toString)
-                    .ifPresent(results::add);
-            }
-            return results;
-        }
-
-        private List<String> analyzeOutput(OutputView port) {
-            List<String> results = new ArrayList<>();
-            if (showAll || showPortName) {
-                results.add(port.getName());
-            }
-            if (showAll || showPortType) {
-                results.add(port.getDataType().getSimpleName());
-            }
-            return results;
-        }
-
-        private void printGeneralVertex(OperatorView operator, String shape, List<String> label) {
-            writer.printf("%s [shape=%s, label=%s];%n",
-                    getId(operator),
-                    literal(shape),
-                    literal(String.join("\n", label)));
-        }
-
-        private void printEdges(OperatorGraphView graph, int currentDepth) {
-            for (OperatorView operator : graph.getOperators()) {
-                printEdge(operator);
-                if (operator.getSpec().getOperatorKind() == OperatorKind.FLOW
-                        && currentDepth < limitDepth) {
-                    printEdges(operator.getElementGraph(), currentDepth + 1);
-                }
-            }
-        }
-
-        private void printEdge(OperatorView operator) {
-            // NOTE: we only put upstream -> downstream edges
-            for (OutputView out : operator.getOutputs()) {
-                String upstream = getQualifiedId(out);
-                for (InputView in : out.getOpposites()) {
-                    String downstream = getQualifiedId(in);
-                    writer.printf("%s -> %s;%n",
-                            upstream,
-                            downstream);
-                }
-            }
-        }
-    }
-
-    private static class Id {
-
-        final Id parent;
-
-        final int value;
-
-        Id(Id parent, int value) {
-            this.parent = parent;
-            this.value = value;
-        }
-
-        String asSimple() {
-            return '_' + Integer.toString(value, 36);
-        }
-
-        String asQualified() {
-            if (parent == null) {
-                return asSimple();
-            } else {
-                return parent.asSimple() + ':' + asSimple();
-            }
-        }
+        return graph.getOperators(OperatorKind.FLOW).stream();
     }
 }

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/DrawPlanCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/DrawPlanCommand.java
@@ -1,0 +1,184 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.cli;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import com.asakusafw.lang.info.BatchInfo;
+import com.asakusafw.lang.info.JobflowInfo;
+import com.asakusafw.lang.info.cli.DrawEngine.Feature;
+import com.asakusafw.lang.info.operator.OperatorSpec.OperatorKind;
+import com.asakusafw.lang.info.operator.view.OperatorGraphView;
+import com.asakusafw.lang.info.operator.view.OperatorView;
+import com.asakusafw.lang.info.plan.PlanAttribute;
+import com.asakusafw.lang.info.plan.PlanVertexSpec;
+import com.asakusafw.lang.info.value.ClassInfo;
+
+import io.airlift.airline.Command;
+import io.airlift.airline.Option;
+
+/**
+ * A command for generating DOT script about operator graphs.
+ * @since 0.4.2
+ */
+@Command(
+        name = "plan",
+        description = "Generates execution plan as Graphviz DOT script",
+        hidden = false
+)
+public class DrawPlanCommand extends SingleJobflowInfoCommand {
+
+    @Option(
+            name = { "--vertex", },
+            title = "vertex name",
+            description = "only displays elements in the plan vertex",
+            arity = 1,
+            required = false)
+    String vertex;
+
+    @Option(
+            name = { "--show-operator", },
+            title = "display operator",
+            description = "display operators in vertices",
+            arity = 0,
+            required = false)
+    boolean showOperator = false;
+
+    @Option(
+            name = { "--show-argument", },
+            title = "display operator argument",
+            description = "display operator argument",
+            arity = 0,
+            required = false)
+    boolean showArgument = false;
+
+    @Option(
+            name = { "--show-io", },
+            title = "display external I/O class",
+            description = "display external I/O class",
+            arity = 0,
+            required = false)
+    boolean showExternalIo = false;
+
+    @Option(
+            name = { "--show-name", },
+            title = "display port name",
+            description = "display port name",
+            arity = 0,
+            required = false)
+    boolean showPortName = false;
+
+    @Option(
+            name = { "--show-type", },
+            title = "display data type",
+            description = "display data type",
+            arity = 0,
+            required = false)
+    boolean showType = false;
+
+    @Option(
+            name = { "--show-key", },
+            title = "display group key",
+            description = "display group key",
+            arity = 0,
+            required = false)
+    boolean showKey = false;
+
+    @Option(
+            name = { "--show-all", "-a", },
+            title = "display all information",
+            description = "display all information",
+            arity = 0,
+            required = false)
+    boolean showAll = false;
+
+    @Override
+    protected void process(PrintWriter writer, BatchInfo batch, JobflowInfo jobflow) throws IOException {
+        OperatorGraphView graph = jobflow.findAttribute(PlanAttribute.class)
+                .map(OperatorGraphView::new)
+                .orElseThrow(() -> new IllegalStateException("there are no available execution plans"));
+        List<String> label = new ArrayList<>();
+        label.add(Optional.ofNullable(jobflow.getDescriptionClass())
+                .map(ClassInfo::of)
+                .map(ClassInfo::getSimpleName)
+                .orElse(jobflow.getId()));
+        int depth;
+        if (vertex == null) {
+            depth = showOperator
+                    || showArgument
+                    || showExternalIo
+                    || showPortName
+                    || showType
+                    || showKey
+                    || showAll ? 2 : 1;
+        } else  {
+            OperatorView v = graph.getOperators(OperatorKind.PLAN_VERTEX).stream()
+                    .filter(it -> ((PlanVertexSpec) it.getSpec()).getName().equals(vertex))
+                    .findFirst()
+                    .orElseThrow(() -> new IOException(MessageFormat.format(
+                            "there are no vertex named \"{1}\" in jobflow {0}",
+                            Optional.ofNullable(jobflow.getDescriptionClass())
+                                .orElse(jobflow.getId()),
+                            vertex)));
+            graph = v.getElementGraph();
+            if (graph.getOperators().isEmpty()) {
+                throw new IOException(MessageFormat.format(
+                        "there are no available operators in vertex \"{1}\" in jobflow {0}",
+                        Optional.ofNullable(jobflow.getDescriptionClass())
+                            .orElse(jobflow.getId()),
+                        vertex));
+            }
+            PlanVertexSpec spec = (PlanVertexSpec) v.getSpec();
+            label.add(spec.getName());
+            depth = 1;
+        }
+        Set<Feature> features = extractFeatures();
+        DrawEngine engine = new DrawEngine(features);
+        engine.draw(writer, graph, depth, label, null);
+    }
+
+    private Set<Feature> extractFeatures() {
+        if (showAll) {
+            return EnumSet.allOf(Feature.class);
+        }
+        Set<DrawEngine.Feature> results = EnumSet.noneOf(Feature.class);
+        if (showArgument) {
+            results.add(Feature.ARGUMENT);
+        }
+        if (showExternalIo) {
+            results.add(Feature.EXTERNAL_IO_CLASS);
+        }
+        if (showPortName) {
+            results.add(Feature.PORT_NAME);
+        }
+        if (showType) {
+            results.add(Feature.PORT_TYPE);
+            results.add(Feature.EDGE_TYPE);
+        }
+        if (showKey) {
+            results.add(Feature.PORT_KEY);
+            results.add(Feature.EDGE_KEY);
+        }
+        return results;
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/Drawer.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/Drawer.java
@@ -1,0 +1,372 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.cli;
+
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.asakusafw.lang.info.graph.Element;
+import com.asakusafw.lang.info.graph.Input;
+import com.asakusafw.lang.info.graph.Node;
+import com.asakusafw.lang.info.graph.Output;
+import com.asakusafw.lang.info.graph.Port;
+
+class Drawer {
+
+    private final Map<Element, Draw> elements = new HashMap<>();
+
+    private final List<Connect> connections = new ArrayList<>();
+
+    private int nodeCount = 0;
+
+    Drawer add(Node node, Shape shape, List<String> label) {
+        if (elements.containsKey(node)) {
+            throw new IllegalStateException();
+        }
+        Shape s = shape;
+        if (s == Shape.GRAPH && node.getElements().isEmpty()) {
+            s = Shape.BOX;
+        }
+        elements.put(node, new Draw(new Id(nodeCount++), s, label, null));
+        return this;
+    }
+
+    Drawer add(Node node, Shape shape, String label) {
+        return add(node, shape, Collections.singletonList(label));
+    }
+
+    Drawer add(Node node, Shape shape, Optional<String> label) {
+        return add(node, shape, label.map(Collections::singletonList).orElse(Collections.emptyList()));
+    }
+
+    Drawer add(Input port, String label) {
+        return add(port, Collections.singletonList(label));
+    }
+
+    Drawer add(Input port, List<String> label) {
+        int index = port.getParent().getInputs().indexOf(port);
+        return addPort(index, port, label);
+    }
+
+    Drawer add(Output port, String label) {
+        return add(port, Collections.singletonList(label));
+    }
+
+    Drawer add(Output port, List<String> label) {
+        int index = port.getParent().getInputs().size() + port.getParent().getOutputs().indexOf(port);
+        return addPort(index, port, label);
+    }
+
+    Drawer addPort(int index, Port<?, ?> port, List<String> label) {
+        if (elements.containsKey(port)) {
+            throw new IllegalStateException();
+        }
+        elements.put(port, new Draw(new Id(index), Shape.MEMBER, label, null));
+        return this;
+    }
+
+    Drawer redirect(Element from, Element to) {
+        if (elements.containsKey(from)) {
+            throw new IllegalStateException();
+        }
+        elements.put(from, new Draw(new Id(-1), Shape.REDIRECT, Collections.emptyList(), to));
+        return this;
+    }
+
+    Drawer connect(Element from, Element to) {
+        connections.add(new Connect(from, to));
+        return this;
+    }
+
+    void dump(PrintWriter writer, Node root) {
+        validateNode(root);
+        Draw draw = elements.get(root);
+        if (draw.shape != Shape.GRAPH) {
+            throw new IllegalStateException();
+        }
+        writer.println("digraph {");
+        writer.println("compound = true;");
+        if (draw.label.isEmpty() == false) {
+            writer.printf("label = %s;%n", literal(draw.label));
+        }
+        dumpVertices(writer, root);
+        dumpEdges(writer);
+        writer.println("}");
+    }
+
+    private void validateNode(Node node) {
+        Draw draw = elements.get(node);
+        if (draw == null) {
+            throw new IllegalStateException();
+        }
+        switch (draw.shape) {
+        case GRAPH:
+            node.getElements().forEach(this::validateNode);
+            node.getInputs().forEach(this::validateNonMember);
+            node.getOutputs().forEach(this::validateNonMember);
+            break;
+        case RECORD:
+            node.getInputs().forEach(this::validateMember);
+            node.getOutputs().forEach(this::validateMember);
+            break;
+        case REDIRECT:
+        case MEMBER:
+            throw new IllegalStateException();
+        default:
+            node.getInputs().forEach(this::validateNonMember);
+            node.getOutputs().forEach(this::validateNonMember);
+            break;
+        }
+    }
+
+    private void validateMember(Port<?, ?> port) {
+        Draw draw = elements.get(port);
+        if (draw == null || draw.shape != Shape.MEMBER) {
+            throw new IllegalStateException();
+        }
+    }
+
+    private void validateNonMember(Port<?, ?> port) {
+        Draw draw = elements.get(port);
+        if (draw != null && draw.shape != Shape.REDIRECT) {
+            throw new IllegalStateException();
+        }
+    }
+
+    private void dumpVertices(PrintWriter writer, Node graph) {
+        for (Node element : graph.getElements()) {
+            Draw draw = elements.get(element);
+            switch (draw.shape) {
+            case POINT:
+            case BOX:
+            case INPUT:
+            case OUTPUT:
+            case ROUNDED_BOX:
+                writer.printf("%s [shape=%s, style=%s, label=%s];%n",
+                        getSimpleId(draw),
+                        literal(draw.shape.symbol),
+                        literal(draw.shape.style),
+                        literal(draw.label));
+                break;
+            case RECORD:
+                writer.printf("%s [shape=%s, label=%s];%n",
+                        getSimpleId(draw),
+                        literal(draw.shape.symbol),
+                        literal(Stream.of(
+                                analyzeRecordMembers(element.getInputs()),
+                                draw.label.stream()
+                                    .map(Drawer::escapeForRecord)
+                                    .collect(Collectors.joining("\n")),
+                                analyzeRecordMembers(element.getOutputs()))
+                                .collect(Collectors.joining("|", "{", "}"))));
+                break;
+            case GRAPH:
+                writer.printf("subgraph %s {%n", toClusterId(element).get());
+                if (draw.label.isEmpty() == false) {
+                    writer.printf("label = %s;%n", literal(draw.label));
+                }
+                dumpVertices(writer, element);
+                writer.println("}");
+                break;
+            default:
+                throw new IllegalStateException(draw.shape.toString());
+            }
+        }
+    }
+
+    private String analyzeRecordMembers(List<? extends Port<?, ?>> ports) {
+        return ports.stream()
+                .map(elements::get)
+                .map(draw -> String.format("<%s>%s", getSimpleId(draw), draw.label.stream()
+                        .map(Drawer::escapeForRecord)
+                        .collect(Collectors.joining("\n"))))
+                .collect(Collectors.joining("|", "{", "}"));
+    }
+
+    private void dumpEdges(PrintWriter writer) {
+        for (Connect c : connections) {
+            String upstream = toQualifiedId(c.source, false);
+            String downstream = toQualifiedId(c.destination, true);
+
+            List<String> attributes = new ArrayList<>();
+            toClusterId(c.source)
+                .map(it -> "ltail=" + it)
+                .ifPresent(attributes::add);
+            toClusterId(c.destination)
+                .map(it -> "lhead=" + it)
+                .ifPresent(attributes::add);
+
+            if (attributes.isEmpty()) {
+                writer.printf("%s -> %s;%n", upstream, downstream);
+            } else {
+                writer.printf("%s -> %s [%s];%n", upstream, downstream, String.join(", ", attributes));
+            }
+        }
+    }
+
+    private String getSimpleId(Element element) {
+        return getSimpleId(elements.get(element));
+    }
+
+    private String getSimpleId(Draw draw) {
+        if (draw == null) {
+            throw new IllegalStateException();
+        } else if (draw.shape == Shape.REDIRECT) {
+            return getSimpleId(draw.destination);
+        } else {
+            return '_' + Integer.toString(draw.id.value, 36);
+        }
+    }
+
+    private String toQualifiedId(Element element, boolean incoming) {
+        Draw draw = elements.get(element);
+        if (element instanceof Port<?, ?>) {
+            if (draw == null) {
+                return getSimpleId(element.getParent());
+            } else if (draw.shape == Shape.REDIRECT) {
+                return toQualifiedId(draw.destination, incoming);
+            } else if (draw.shape == Shape.MEMBER) {
+                return String.format(
+                        "%s:%s",
+                        getSimpleId(element.getParent()),
+                        getSimpleId(draw));
+            } else {
+                throw new IllegalStateException();
+            }
+        } else if (element instanceof Node) {
+            if (draw == null) {
+                throw new IllegalStateException();
+            } else if (draw.shape == Shape.GRAPH) {
+                // use element ID instead of graph ID
+                Node node = (Node) element;
+                return node.getElements().stream()
+                        .filter(it -> (incoming ? it.getInputs() : it.getOutputs()).stream()
+                                .allMatch(p -> p.getOpposites().isEmpty()))
+                        .map(elements::get)
+                        .map(this::getSimpleId)
+                        .findAny()
+                        .orElseGet(() -> node.getElements().stream()
+                                .map(elements::get)
+                                .map(this::getSimpleId)
+                                .findAny()
+                                .get());
+            } else {
+                return getSimpleId(draw);
+            }
+        } else {
+            return getSimpleId(draw);
+        }
+    }
+
+    private Optional<String> toClusterId(Element element) {
+        return Optional.ofNullable(elements.get(element))
+                .filter(d -> d.shape == Shape.GRAPH)
+                .map(it -> "cluster" + getSimpleId(it));
+    }
+
+    static String escapeForRecord(CharSequence string) {
+        return DrawUtil.escapeForRecord(string);
+    }
+
+    private static String literal(List<String> label) {
+        return literal(String.join("\n", label));
+    }
+
+    private static String literal(String string) {
+        return DrawUtil.literal(string);
+    }
+
+    private static class Draw {
+
+        final Id id;
+
+        final Shape shape;
+
+        final List<String> label;
+
+        final Element destination;
+
+        Draw(Id id, Shape shape, List<String> label, Element destination) {
+            this.id = id;
+            this.shape = shape;
+            this.label = label;
+            this.destination = destination;
+        }
+    }
+
+    private static class Connect {
+
+        final Element source;
+
+        final Element destination;
+
+        Connect(Element source, Element destination) {
+            this.source = source;
+            this.destination = destination;
+        }
+    }
+
+    private static class Id {
+
+        final int value;
+
+        Id(int value) {
+            this.value = value;
+        }
+    }
+
+    enum Shape {
+
+        POINT("point"),
+
+        BOX("box"),
+
+        ROUNDED_BOX("box", "rounded"),
+
+        INPUT("invhouse"),
+
+        OUTPUT("invhouse"),
+
+        RECORD("record"),
+
+        GRAPH(null),
+
+        MEMBER(null),
+
+        REDIRECT(null),
+        ;
+
+        final String symbol;
+
+        final String style;
+
+        Shape(String symbol) {
+            this(symbol, "solid");
+        }
+
+        Shape(String symbol, String style) {
+            this.symbol = symbol;
+            this.style = style;
+        }
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/Info.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/Info.java
@@ -59,6 +59,7 @@ public final class Info {
             .withCommand(ListParameterCommand.class)
             .withCommand(ListJobflowCommand.class)
             .withCommand(ListOperatorCommand.class)
+            .withCommand(ListPlanCommand.class)
             .withCommand(ListDirectFileInputCommand.class)
             .withCommand(ListDirectFileOutputCommand.class)
             .withCommand(ListWindGateInputCommand.class)
@@ -68,7 +69,8 @@ public final class Info {
             .withDescription("Generates Graphviz DOT scripts")
             .withDefaultCommand(DrawUsageCommand.class)
             .withCommand(DrawJobflowCommand.class)
-            .withCommand(DrawOperatorCommand.class);
+            .withCommand(DrawOperatorCommand.class)
+            .withCommand(DrawPlanCommand.class);
 
         Cli<Runnable> cli = builder.build();
         Runnable command;

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/ListPlanCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/ListPlanCommand.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.cli;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.text.MessageFormat;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.asakusafw.lang.info.BatchInfo;
+import com.asakusafw.lang.info.JobflowInfo;
+import com.asakusafw.lang.info.operator.OperatorSpec.OperatorKind;
+import com.asakusafw.lang.info.operator.UserOperatorSpec;
+import com.asakusafw.lang.info.operator.view.OperatorGraphView;
+import com.asakusafw.lang.info.operator.view.OperatorView;
+import com.asakusafw.lang.info.operator.view.OutputView;
+import com.asakusafw.lang.info.plan.PlanAttribute;
+import com.asakusafw.lang.info.plan.PlanVertexSpec;
+
+import io.airlift.airline.Command;
+import io.airlift.airline.Option;
+
+/**
+ * A command for printing operators.
+ * @since 0.4.2
+ */
+@Command(
+        name = "plan",
+        description = "Displays execution plan",
+        hidden = false
+)
+public class ListPlanCommand extends SingleJobflowInfoCommand {
+
+    @Option(
+            name = { "--vertex", },
+            title = "vertex name",
+            description = "only displays elements in the plan vertex",
+            arity = 1,
+            required = false)
+    String vertex;
+
+    @Option(
+            name = { "--verbose", "-v", },
+            title = "verbose mode",
+            description = "verbose mode",
+            arity = 0,
+            required = false)
+    boolean showVerbose = false;
+
+    @Override
+    protected void process(PrintWriter writer, BatchInfo batch, JobflowInfo jobflow) throws IOException {
+        List<OperatorView> vertices = jobflow.findAttribute(PlanAttribute.class)
+                .map(OperatorGraphView::new)
+                .filter(it -> it.getOperators().isEmpty() == false)
+                .orElseThrow(() -> new IllegalStateException("there are no available execution plans"))
+                .getOperators(OperatorKind.PLAN_VERTEX)
+                .stream()
+                .sorted(Comparator.comparing((OperatorView it) -> ((PlanVertexSpec) it.getSpec()).getName()))
+                .collect(Collectors.toList());
+        if (vertex == null) {
+            vertices.forEach(it -> {
+                PlanVertexSpec spec = (PlanVertexSpec) it.getSpec();
+                if (showVerbose) {
+                    writer.printf("%s:%n", spec.getName());
+                    printVertex(writer, 4, it);
+                } else {
+                    writer.println(spec.getName());
+                }
+            });
+        } else {
+            OperatorView target = vertices.stream()
+                    .filter(it -> ((PlanVertexSpec) it.getSpec()).getName().equals(vertex))
+                    .findFirst()
+                    .orElseThrow(() -> new IOException(MessageFormat.format(
+                            "there are no vertex named \"{1}\" in jobflow {0}",
+                            Optional.ofNullable(jobflow.getDescriptionClass())
+                                .orElse(jobflow.getId()),
+                            vertex)));
+            printVertex(writer, 0, target);
+        }
+    }
+
+    private static void printVertex(PrintWriter writer, int indent, OperatorView vertex) {
+        PlanVertexSpec spec = (PlanVertexSpec) vertex.getSpec();
+        writer.printf("%slabel: %s%n", ListUtil.padding(indent), ListUtil.normalize(spec.getLabel()));
+        writer.printf("%sblockers: %s%n", ListUtil.padding(indent), Stream.concat(
+                    spec.getDependencies().stream(),
+                    vertex.getInputs().stream()
+                        .flatMap(p -> p.getOpposites().stream())
+                        .map(OutputView::getOwner)
+                        .filter(v -> v.getSpec().getOperatorKind() == OperatorKind.PLAN_VERTEX)
+                        .map(v -> ((PlanVertexSpec) v.getSpec()).getName()))
+                .sorted()
+                .distinct()
+                .collect(Collectors.joining(", ", "{", "}")));
+        ListUtil.printBlock(writer, indent, "operators", vertex.getElementGraph()
+                .getOperators(OperatorKind.USER)
+                .stream()
+                .map(op -> (UserOperatorSpec) op.getSpec())
+                .map(it -> String.format("%s#%s(@%s)",
+                        it.getDeclaringClass().getName(),
+                        it.getMethodName(),
+                        it.getAnnotation().getDeclaringClass().getSimpleName()))
+                .distinct()
+                .collect(Collectors.toList()));
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/ListUtil.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/ListUtil.java
@@ -17,6 +17,7 @@ package com.asakusafw.lang.info.cli;
 
 import java.io.File;
 import java.io.PrintWriter;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -62,7 +63,7 @@ final class ListUtil {
                 .orElse("N/A");
     }
 
-    private static String padding(int count) {
+    static String padding(int count) {
         if (count < 0) {
             return "";
         }
@@ -73,7 +74,7 @@ final class ListUtil {
         return buf.toString();
     }
 
-    static void printBlock(PrintWriter writer, int indent, Map<String, Object> members) {
+    static void printBlock(PrintWriter writer, int indent, Map<String, ?> members) {
         if (members.isEmpty()) {
             return;
         }
@@ -87,5 +88,14 @@ final class ListUtil {
                     k,
                     normalize(v));
         });
+    }
+
+    static void printBlock(PrintWriter writer, int indent, String title, List<?> members) {
+        if (members.isEmpty()) {
+            writer.printf("%s%s: -%n", ListUtil.padding(indent), normalize(title));
+        } else {
+            writer.printf("%s%s:%n", ListUtil.padding(indent), normalize(title));
+            members.forEach(it -> writer.printf("%s%s%n", ListUtil.padding(indent + 4), normalize(it)));
+        }
     }
 }

--- a/info/model/src/main/java/com/asakusafw/lang/info/graph/Port.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/graph/Port.java
@@ -84,6 +84,9 @@ public abstract class Port<
     public abstract List<TOpposite> getOpposites();
 
     TSelf connect(Output upstream, Input downstream, Consumer<? super Wire> configure) {
+        Util.require(upstream.getParent().getParent() != null, () -> String.format(
+                "port of the root node must not be connected: %s",
+                upstream));
         Util.require(upstream.getParent().getParent() == downstream.getParent().getParent(), () -> String.format(
                 "both %s and %s must be on the same node",
                 upstream.getParent(),

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/FlowOperatorSpec.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/FlowOperatorSpec.java
@@ -39,8 +39,7 @@ public final class FlowOperatorSpec implements OperatorSpec {
     }
 
     @JsonCreator
-    static FlowOperatorSpec restore(
-            @JsonProperty(Constants.ID_CLASS) String descriptionClass) {
+    static FlowOperatorSpec restore(@JsonProperty(Constants.ID_CLASS) String descriptionClass) {
         return of(Optional.ofNullable(descriptionClass)
                 .map(ClassInfo::of)
                 .orElse(null));
@@ -100,6 +99,7 @@ public final class FlowOperatorSpec implements OperatorSpec {
 
     @Override
     public String toString() {
-        return String.format("Flow(%s)", descriptionClass);
+        return String.format("Flow(%s)",
+                descriptionClass);
     }
 }

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/InputInfo.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/InputInfo.java
@@ -37,7 +37,7 @@ public interface InputInfo {
 
     /**
      * Returns the input granularity.
-     * @return the input granularity
+     * @return the input granularity, or {@code null} if is not defined
      */
     InputGranularity getGranulatity();
 

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/InputOperatorSpec.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/InputOperatorSpec.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * Represents an operator detail of flow inputs.
  * @since 0.4.2
  */
-public final class InputOperatorSpec implements OperatorSpec {
+public final class InputOperatorSpec implements NamedOperatorSpec {
 
     static final String KIND = "input";
 
@@ -75,10 +75,7 @@ public final class InputOperatorSpec implements OperatorSpec {
         return OperatorKind.INPUT;
     }
 
-    /**
-     * Returns the name of this port.
-     * @return the name
-     */
+    @Override
     public String getName() {
         return name;
     }

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/NamedOperatorSpec.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/NamedOperatorSpec.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.operator;
+
+/**
+ * Represents a detail of operator with name.
+ * @since 0.4.2
+ */
+public interface NamedOperatorSpec extends OperatorSpec {
+
+    /**
+     * Returns the name of this operator.
+     * @return the name
+     */
+    String getName();
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/OperatorSpec.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/OperatorSpec.java
@@ -15,6 +15,9 @@
  */
 package com.asakusafw.lang.info.operator;
 
+import com.asakusafw.lang.info.plan.PlanInputSpec;
+import com.asakusafw.lang.info.plan.PlanOutputSpec;
+import com.asakusafw.lang.info.plan.PlanVertexSpec;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
@@ -38,6 +41,9 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     @Type(value = OutputOperatorSpec.class, name = OutputOperatorSpec.KIND),
     @Type(value = MarkerOperatorSpec.class, name = MarkerOperatorSpec.KIND),
     @Type(value = CustomOperatorSpec.class, name = CustomOperatorSpec.KIND),
+    @Type(value = PlanVertexSpec.class, name = PlanVertexSpec.KIND),
+    @Type(value = PlanInputSpec.class, name = PlanInputSpec.KIND),
+    @Type(value = PlanOutputSpec.class, name = PlanOutputSpec.KIND),
 })
 public interface OperatorSpec {
 
@@ -90,5 +96,20 @@ public interface OperatorSpec {
          * This will be appeared in some optimization phases.
          */
         @JsonProperty(CustomOperatorSpec.KIND) CUSTOM,
+
+        /**
+         * Pseudo operators for plan vertices.
+         */
+        @JsonProperty(PlanVertexSpec.KIND) PLAN_VERTEX,
+
+        /**
+         * Pseudo operators for plan vertex inputs.
+         */
+        @JsonProperty(PlanInputSpec.KIND) PLAN_INPUT,
+
+        /**
+         * Pseudo operators for plan vertex outputs.
+         */
+        @JsonProperty(PlanOutputSpec.KIND) PLAN_OUTPUT,
     }
 }

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/OutputOperatorSpec.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/OutputOperatorSpec.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * Represents an operator detail of flow outputs.
  * @since 0.4.2
  */
-public final class OutputOperatorSpec implements OperatorSpec {
+public final class OutputOperatorSpec implements NamedOperatorSpec {
 
     static final String KIND = "output";
 
@@ -75,10 +75,7 @@ public final class OutputOperatorSpec implements OperatorSpec {
         return OperatorKind.OUTPUT;
     }
 
-    /**
-     * Returns the name of this port.
-     * @return the name
-     */
+    @Override
     public String getName() {
         return name;
     }

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/UserOperatorSpec.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/UserOperatorSpec.java
@@ -132,7 +132,7 @@ public final class UserOperatorSpec implements OperatorSpec {
     @Override
     public int hashCode() {
         final int prime = 31;
-        int result = 1;
+        int result = Objects.hashCode(getOperatorKind());
         result = prime * result + Objects.hashCode(annotation);
         result = prime * result + Objects.hashCode(implementationClass);
         result = prime * result + Objects.hashCode(declaringClass);

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/view/InputView.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/view/InputView.java
@@ -44,6 +44,14 @@ public class InputView implements InputInfo {
     }
 
     /**
+     * Returns the entity element.
+     * @return the entity element
+     */
+    public Input getEntity() {
+        return entity;
+    }
+
+    /**
      * Returns the owner of this port.
      * @return the owner
      */

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/view/OperatorGraphView.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/view/OperatorGraphView.java
@@ -25,10 +25,10 @@ import java.util.stream.Stream;
 import com.asakusafw.lang.info.graph.Input;
 import com.asakusafw.lang.info.graph.Node;
 import com.asakusafw.lang.info.graph.Output;
-import com.asakusafw.lang.info.operator.InputOperatorSpec;
+import com.asakusafw.lang.info.operator.NamedOperatorSpec;
 import com.asakusafw.lang.info.operator.OperatorGraphAttribute;
 import com.asakusafw.lang.info.operator.OperatorSpec.OperatorKind;
-import com.asakusafw.lang.info.operator.OutputOperatorSpec;
+import com.asakusafw.lang.info.plan.PlanAttribute;
 
 /**
  * A view of operator graph.
@@ -49,7 +49,15 @@ public class OperatorGraphView {
      * @param graph the source graph
      */
     public OperatorGraphView(OperatorGraphAttribute graph) {
-        this.root = graph.getRoot();
+        this(graph.getRoot());
+    }
+
+    /**
+     * Creates a new instance.
+     * @param plan the source execution plan
+     */
+    public OperatorGraphView(PlanAttribute plan) {
+        this(plan.getRoot());
     }
 
     OperatorGraphView(Node entity) {
@@ -73,26 +81,27 @@ public class OperatorGraphView {
     }
 
     /**
-     * Returns the input operators.
-     * @return the input operators
+     * Returns the element operators.
+     * @param kind the operator kind
+     * @return the operators
      */
-    public Map<String, OperatorView> getInputs() {
+    public Collection<OperatorView> getOperators(OperatorKind kind) {
         return all()
-                .filter(it -> it.getSpec().getOperatorKind() == OperatorKind.INPUT)
-                .collect(Collectors.toMap(
-                        it -> ((InputOperatorSpec) it.getSpec()).getName(),
-                        Function.identity()));
+                .filter(it -> it.getSpec().getOperatorKind() == kind)
+                .collect(Collectors.toList());
     }
 
     /**
-     * Returns the output operators.
-     * @return the output operators
+     * Returns the element operators.
+     * @param kind the operator kind
+     * @return the pairs of name and its operator
      */
-    public Map<String, OperatorView> getOutputs() {
+    public Map<String, OperatorView> getOperatorMap(OperatorKind kind) {
         return all()
-                .filter(it -> it.getSpec().getOperatorKind() == OperatorKind.OUTPUT)
+                .filter(it -> it.getSpec().getOperatorKind() == kind)
+                .filter(it -> it.getSpec() instanceof NamedOperatorSpec)
                 .collect(Collectors.toMap(
-                        it -> ((OutputOperatorSpec) it.getSpec()).getName(),
+                        it -> ((NamedOperatorSpec) it.getSpec()).getName(),
                         Function.identity()));
     }
 

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/view/OperatorView.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/view/OperatorView.java
@@ -44,7 +44,11 @@ public class OperatorView implements OperatorInfo {
         this.info = Util.extract(entity, OperatorAttribute.class);
     }
 
-    Node getEntity() {
+    /**
+     * Returns the entity element.
+     * @return the entity element
+     */
+    public Node getEntity() {
         return entity;
     }
 

--- a/info/model/src/main/java/com/asakusafw/lang/info/operator/view/OutputView.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/operator/view/OutputView.java
@@ -42,6 +42,14 @@ public class OutputView implements OutputInfo {
     }
 
     /**
+     * Returns the entity element.
+     * @return the entity element
+     */
+    public Output getEntity() {
+        return entity;
+    }
+
+    /**
      * Returns the owner of this port.
      * @return the owner
      */

--- a/info/model/src/main/java/com/asakusafw/lang/info/plan/Constants.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/plan/Constants.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.plan;
+
+final class Constants {
+
+    static final String ID_ID = "id";
+
+    static final String ID_ROOT = "root";
+
+    static final String ID_NAME = "name";
+
+    static final String ID_LABEL = "label";
+
+    static final String ID_DEPENDENCIES = "blockers";
+
+    static final String ID_INDEX = "index";
+
+    static final String ID_EXCHANGE = "exchange";
+
+    static final String ID_GROUP = "group";
+
+    private Constants() {
+        return;
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/plan/DataExchange.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/plan/DataExchange.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.plan;
+
+/**
+ * Represents a kind of data exchanging strategy.
+ * @since 0.4.2
+ */
+public enum DataExchange {
+
+    /**
+     * Does not exchange any data.
+     */
+    NOTHING,
+
+    /**
+     * Just copy/move data-set.
+     */
+    MOVE,
+
+    /**
+     * Scatter-gather.
+     */
+    SCATTER_GATHER,
+
+    /**
+     * Aggregation.
+     */
+    AGGREGATE,
+
+    /**
+     * Shuffle (and sort).
+     */
+    SHUFFLE,
+
+    /**
+     * Broadcast.
+     */
+    BROADCAST,
+
+    /**
+     * Unknown.
+     */
+    UNKNOWN,
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/plan/PlanAttribute.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/plan/PlanAttribute.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.plan;
+
+import java.util.Objects;
+
+import com.asakusafw.lang.info.Attribute;
+import com.asakusafw.lang.info.graph.Node;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * An {@link Attribute} which represents details of execution plans.
+ * @since 0.4.2
+ */
+public class PlanAttribute implements Attribute {
+
+    static final String ID = "execution-plan";
+
+    private final Node root;
+
+    /**
+     * Creates a new instance.
+     * @param root the root node
+     */
+    public PlanAttribute(Node root) {
+        this.root = root;
+    }
+
+    @JsonCreator
+    static PlanAttribute restore(
+            @JsonProperty(Constants.ID_ID) String id,
+            @JsonProperty(Constants.ID_ROOT) Node root) {
+        if (Objects.equals(id, ID) == false) {
+            throw new IllegalArgumentException();
+        }
+        return new PlanAttribute(root);
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    /**
+     * Returns the root node.
+     * @return the root node
+     */
+    public Node getRoot() {
+        return root;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Objects.hashCode(root);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        return Objects.equals(root, ((PlanAttribute) obj).root);
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/plan/PlanInputSpec.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/plan/PlanInputSpec.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.plan;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import com.asakusafw.lang.info.operator.InputGroup;
+import com.asakusafw.lang.info.operator.NamedOperatorSpec;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a pseudo-operator detail of inputs in execution plan.
+ * @since 0.4.2
+ */
+public final class PlanInputSpec implements NamedOperatorSpec {
+
+    /**
+     * The kind label.
+     */
+    public static final String KIND = "plan-input";
+
+    @JsonProperty(Constants.ID_NAME)
+    private final String name;
+
+    @JsonProperty(Constants.ID_EXCHANGE)
+    private final DataExchange exchange;
+
+    @JsonProperty(Constants.ID_GROUP)
+    private final InputGroup group;
+
+    private PlanInputSpec(String name, DataExchange exchange, InputGroup group) {
+        this.name = name;
+        this.exchange = exchange;
+        this.group = group;
+    }
+
+    /**
+     * Creates a new instance.
+     * @param name the port name
+     * @param exchange the data exchanging strategy
+     * @param group the data exchanging group (nullable)
+     * @return the instance
+     */
+    @JsonCreator
+    public static PlanInputSpec of(
+            @JsonProperty(Constants.ID_NAME) String name,
+            @JsonProperty(Constants.ID_EXCHANGE) DataExchange exchange,
+            @JsonProperty(Constants.ID_GROUP) InputGroup group) {
+        return new PlanInputSpec(name, exchange, group);
+    }
+
+    @Override
+    public OperatorKind getOperatorKind() {
+        return OperatorKind.PLAN_INPUT;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the data exchanging strategy.
+     * @return the data exchanging strategy
+     */
+    public DataExchange getExchange() {
+        return exchange;
+    }
+
+    /**
+     * Returns the data exchanging group.
+     * @return the data exchanging group, or {@code null} if it is not defined
+     */
+    public InputGroup getGroup() {
+        return group;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Objects.hashCode(name);
+        result = prime * result + Objects.hashCode(exchange);
+        result = prime * result + Objects.hashCode(group);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        PlanInputSpec other = (PlanInputSpec) obj;
+        return Objects.equals(name, other.name)
+                && Objects.equals(exchange, other.exchange)
+                && Objects.equals(group, other.group);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("PlanInput(name=%s, exchange=%s, group=%s)",
+                name,
+                exchange,
+                Optional.ofNullable(group).map(InputGroup::toString).orElse("N/A"));
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/plan/PlanOutputSpec.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/plan/PlanOutputSpec.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.plan;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import com.asakusafw.lang.info.operator.InputGroup;
+import com.asakusafw.lang.info.operator.NamedOperatorSpec;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a pseudo-operator detail of outputs in execution plan.
+ * @since 0.4.2
+ */
+public final class PlanOutputSpec implements NamedOperatorSpec {
+
+    /**
+     * The kind label.
+     */
+    public static final String KIND = "plan-output";
+
+    @JsonProperty(Constants.ID_NAME)
+    private final String name;
+
+    @JsonProperty(Constants.ID_EXCHANGE)
+    private final DataExchange exchange;
+
+    @JsonProperty(Constants.ID_GROUP)
+    private final InputGroup group;
+
+    private PlanOutputSpec(String name, DataExchange exchange, InputGroup group) {
+        this.name = name;
+        this.exchange = exchange;
+        this.group = group;
+    }
+
+    /**
+     * Creates a new instance.
+     * @param name the port name
+     * @param exchange the data exchanging strategy
+     * @param group the data exchanging group (nullable)
+     * @return the instance
+     */
+    @JsonCreator
+    public static PlanOutputSpec of(
+            @JsonProperty(Constants.ID_NAME) String name,
+            @JsonProperty(Constants.ID_EXCHANGE) DataExchange exchange,
+            @JsonProperty(Constants.ID_GROUP) InputGroup group) {
+        return new PlanOutputSpec(name, exchange, group);
+    }
+
+    @Override
+    public OperatorKind getOperatorKind() {
+        return OperatorKind.PLAN_OUTPUT;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the data exchanging strategy.
+     * @return the data exchanging strategy
+     */
+    public DataExchange getExchange() {
+        return exchange;
+    }
+
+    /**
+     * Returns the data exchanging group.
+     * @return the data exchanging group, or {@code null} if it is not defined
+     */
+    public InputGroup getGroup() {
+        return group;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Objects.hashCode(name);
+        result = prime * result + Objects.hashCode(exchange);
+        result = prime * result + Objects.hashCode(group);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        PlanOutputSpec other = (PlanOutputSpec) obj;
+        return Objects.equals(name, other.name)
+                && Objects.equals(exchange, other.exchange)
+                && Objects.equals(group, other.group);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("PlanOutput(name=%s, exchange=%s, group=%s)",
+                name,
+                exchange,
+                Optional.ofNullable(group).map(InputGroup::toString).orElse("N/A"));
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/plan/PlanVertexSpec.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/plan/PlanVertexSpec.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.plan;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import com.asakusafw.lang.info.operator.NamedOperatorSpec;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a pseudo-operator detail of vertices in execution plan.
+ * @since 0.4.2
+ */
+public final class PlanVertexSpec implements NamedOperatorSpec {
+
+    /**
+     * The kind label.
+     */
+    public static final String KIND = "plan-vertex";
+
+    @JsonProperty(Constants.ID_NAME)
+    private final String name;
+
+    @JsonProperty(Constants.ID_LABEL)
+    private final String label;
+
+    @JsonProperty(Constants.ID_DEPENDENCIES)
+    @JsonInclude(Include.NON_EMPTY)
+    private final List<String> dependencies;
+
+    private PlanVertexSpec(String name, String label, Collection<String> dependencies) {
+        this.name = name;
+        this.label = label;
+        this.dependencies = Util.freeze(dependencies);
+    }
+
+    /**
+     * Returns an instance.
+     * @param name the vertex name
+     * @param label the vertex label (nullable)
+     * @param dependencies the blocker vertices
+     * @return the instance
+     */
+    @JsonCreator
+    public static PlanVertexSpec of(
+            @JsonProperty(Constants.ID_NAME) String name,
+            @JsonProperty(Constants.ID_LABEL) String label,
+            @JsonProperty(Constants.ID_DEPENDENCIES) Collection<String> dependencies) {
+        return new PlanVertexSpec(name, label, dependencies);
+    }
+
+    @Override
+    public OperatorKind getOperatorKind() {
+        return OperatorKind.PLAN_VERTEX;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the label.
+     * @return the label, or {@code null} if it is not defined
+     */
+    public String getLabel() {
+        return label;
+    }
+
+    /**
+     * Returns the blocker vertex names.
+     * @return the blockers
+     */
+    public List<String> getDependencies() {
+        return dependencies;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = Objects.hashCode(getOperatorKind());
+        result = prime * result + Objects.hashCode(name);
+        result = prime * result + Objects.hashCode(label);
+        result = prime * result + Objects.hashCode(dependencies);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        PlanVertexSpec other = (PlanVertexSpec) obj;
+        return Objects.equals(name, other.name)
+                && Objects.equals(label, other.label)
+                && Objects.equals(dependencies, other.dependencies);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("PlanVertex(%s:%s)",
+                name,
+                Optional.ofNullable(label)
+                    .orElse("N/A"));
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/plan/Util.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/plan/Util.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.plan;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+final class Util {
+
+    private Util() {
+        return;
+    }
+
+    static <T> List<T> freeze(Collection<? extends T> elements) {
+        if (elements == null) {
+            return Collections.emptyList();
+        }
+        return Collections.unmodifiableList(new ArrayList<>(elements));
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/plan/package-info.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/plan/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Asakusa execution plan information models.
+ */
+package com.asakusafw.lang.info.plan;

--- a/info/model/src/main/java/com/asakusafw/lang/info/value/ClassInfo.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/value/ClassInfo.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * Represents a {@link Class} value.
  * @since 0.4.2
  */
-public final class ClassInfo implements ValueInfo {
+public final class ClassInfo implements ValueInfo, Comparable<ClassInfo> {
 
     static final String KIND = "class"; //$NON-NLS-1$
 
@@ -152,6 +152,11 @@ public final class ClassInfo implements ValueInfo {
         }
         ClassInfo other = (ClassInfo) obj;
         return Objects.equals(name, other.name);
+    }
+
+    @Override
+    public int compareTo(ClassInfo o) {
+        return name.compareTo(o.name);
     }
 
     @Override

--- a/info/model/src/test/java/com/asakusafw/lang/info/operator/OperatorSpecTest.java
+++ b/info/model/src/test/java/com/asakusafw/lang/info/operator/OperatorSpecTest.java
@@ -15,12 +15,17 @@
  */
 package com.asakusafw.lang.info.operator;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 import org.junit.Test;
 
 import com.asakusafw.lang.info.InfoSerDe;
 import com.asakusafw.lang.info.operator.CoreOperatorSpec.CoreOperatorKind;
+import com.asakusafw.lang.info.plan.DataExchange;
+import com.asakusafw.lang.info.plan.PlanInputSpec;
+import com.asakusafw.lang.info.plan.PlanOutputSpec;
+import com.asakusafw.lang.info.plan.PlanVertexSpec;
 import com.asakusafw.lang.info.value.AnnotationInfo;
 import com.asakusafw.lang.info.value.ClassInfo;
 
@@ -63,6 +68,9 @@ public class OperatorSpecTest {
         InfoSerDe.checkRestore(
                 OperatorSpec.class,
                 FlowOperatorSpec.of(ClassInfo.of("com.example.Flow")));
+        InfoSerDe.checkRestore(
+                OperatorSpec.class,
+                FlowOperatorSpec.of((ClassInfo) null));
     }
 
     /**
@@ -109,5 +117,35 @@ public class OperatorSpecTest {
         InfoSerDe.checkRestore(
                 OperatorSpec.class,
                 CustomOperatorSpec.of("testing"));
+    }
+
+    /**
+     * plan vertex.
+     */
+    @Test
+    public void plan_vertex() {
+        InfoSerDe.checkRestore(
+                OperatorSpec.class,
+                PlanVertexSpec.of("testing", "label", Arrays.asList("a", "b", "c")));
+    }
+
+    /**
+     * plan inputs.
+     */
+    @Test
+    public void plan_input() {
+        InfoSerDe.checkRestore(
+                OperatorSpec.class,
+                PlanInputSpec.of("testing", DataExchange.MOVE, InputGroup.parse(Arrays.asList("=key", "+order"))));
+    }
+
+    /**
+     * plan outputs.
+     */
+    @Test
+    public void plan_output() {
+        InfoSerDe.checkRestore(
+                OperatorSpec.class,
+                PlanOutputSpec.of("testing", DataExchange.MOVE, InputGroup.parse(Arrays.asList("=key", "+order"))));
     }
 }

--- a/info/model/src/test/java/com/asakusafw/lang/info/operator/view/OperatorGraphViewTest.java
+++ b/info/model/src/test/java/com/asakusafw/lang/info/operator/view/OperatorGraphViewTest.java
@@ -26,6 +26,7 @@ import com.asakusafw.lang.info.graph.Node;
 import com.asakusafw.lang.info.graph.NodeTestUtil;
 import com.asakusafw.lang.info.operator.CoreOperatorSpec;
 import com.asakusafw.lang.info.operator.CoreOperatorSpec.CoreOperatorKind;
+import com.asakusafw.lang.info.operator.OperatorSpec.OperatorKind;
 import com.asakusafw.lang.info.operator.CustomOperatorSpec;
 import com.asakusafw.lang.info.operator.InputAttribute;
 import com.asakusafw.lang.info.operator.InputGranularity;
@@ -71,8 +72,8 @@ public class OperatorGraphViewTest {
 
         OperatorGraphView view = new OperatorGraphView(new OperatorGraphAttribute(root));
         assertThat(view.getOperators(), hasSize(1));
-        assertThat(view.getInputs().keySet(), is(empty()));
-        assertThat(view.getOutputs().keySet(), is(empty()));
+        assertThat(view.getOperatorMap(OperatorKind.INPUT).keySet(), is(empty()));
+        assertThat(view.getOperatorMap(OperatorKind.OUTPUT).keySet(), is(empty()));
 
         OperatorView v = view.getOperators().stream().findAny().get();
         NodeTestUtil.contentEquals(v.getEntity(), op);
@@ -118,11 +119,11 @@ public class OperatorGraphViewTest {
 
         OperatorGraphView view = new OperatorGraphView(new OperatorGraphAttribute(root));
         assertThat(view.getOperators(), hasSize(2));
-        assertThat(view.getInputs().keySet(), containsInAnyOrder("in"));
-        assertThat(view.getOutputs().keySet(), containsInAnyOrder("out"));
+        assertThat(view.getOperatorMap(OperatorKind.INPUT).keySet(), containsInAnyOrder("in"));
+        assertThat(view.getOperatorMap(OperatorKind.OUTPUT).keySet(), containsInAnyOrder("out"));
 
-        OperatorView v0 = view.getInputs().get("in");
-        OperatorView v1 = view.getOutputs().get("out");
+        OperatorView v0 = view.getOperatorMap(OperatorKind.INPUT).get("in");
+        OperatorView v1 = view.getOperatorMap(OperatorKind.OUTPUT).get("out");
 
         assertThat(v0.getOutputs(), hasSize(1));
         assertThat(v1.getInputs(), hasSize(1));
@@ -142,16 +143,16 @@ public class OperatorGraphViewTest {
 
         OperatorGraphView view = new OperatorGraphView(new OperatorGraphAttribute(root));
         assertThat(view.getOperators(), hasSize(1));
-        assertThat(view.getInputs().keySet(), is(empty()));
-        assertThat(view.getOutputs().keySet(), is(empty()));
+        assertThat(view.getOperatorMap(OperatorKind.INPUT).keySet(), is(empty()));
+        assertThat(view.getOperatorMap(OperatorKind.OUTPUT).keySet(), is(empty()));
 
         OperatorView parent = view.getOperators().stream().findAny().get();
         assertThat(((CustomOperatorSpec) parent.getSpec()).getCategory(), is("parent"));
 
         OperatorGraphView inner = parent.getElementGraph();
         assertThat(inner.getOperators(), hasSize(1));
-        assertThat(inner.getInputs().keySet(), is(empty()));
-        assertThat(inner.getOutputs().keySet(), is(empty()));
+        assertThat(inner.getOperatorMap(OperatorKind.INPUT).keySet(), is(empty()));
+        assertThat(inner.getOperatorMap(OperatorKind.OUTPUT).keySet(), is(empty()));
 
         OperatorView child = inner.getOperators().stream().findAny().get();
         assertThat(((CustomOperatorSpec) child.getSpec()).getCategory(), is("child"));


### PR DESCRIPTION
## Summary

This PR enables execution plan informations in `batch-info.json` file for Asakusa {on M3BP, Vanilla}.

## Background, Problem or Goal of the patch

`batch-info.json` file has been introduced as incubating feature (`asakusafw.sdk.incubating = true`) since #113. This additionally enables execution plan information for Asakusa {on M3BP, Vanilla}.

## Design of the fix, or a new feature

This also introduces new sub-commands into information viewer (`info/cli`):
* `list plan` - displays execution plan information
* `draw plan` - generates execution plan graph as Graphviz DOT script

Please type `java -jar <info/cli/target/asakusa-info-cli-*-exec.jar> help` to see a usage of the sub-commands.

## Related Issue, Pull Request or Code

* #113
* #134 
