### PR TITLE
Fix treating `stop` operators as ineffective `checkpoint`.

### DIFF
--- a/compiler-project/analyzer/src/main/java/com/asakusafw/lang/compiler/analyzer/FlowGraphAnalyzer.java
+++ b/compiler-project/analyzer/src/main/java/com/asakusafw/lang/compiler/analyzer/FlowGraphAnalyzer.java
@@ -418,7 +418,10 @@ public final class FlowGraphAnalyzer {
     }
 
     static boolean isCheckpoint(FlowElementDescription description) {
-        return description.getAttribute(FlowBoundary.class) == FlowBoundary.STAGE;
+        return description.getKind() == FlowElementKind.PSEUD
+                && description.getInputPorts().size() >= 1
+                && description.getOutputPorts().size() >= 1
+                && description.getAttribute(FlowBoundary.class) == FlowBoundary.STAGE;
     }
 
     private static ReifiableTypeDescription typeOf(java.lang.reflect.Type type) {


### PR DESCRIPTION
## Summary

This PR fixes treating `stop` operators as ineffective `checkpoint` operators.

## Background, Problem or Goal of the patch

In the latest implementation, the DSL compiler sometimes converts `stop` operators into `checkpoint` operators. Either way, the compiler will remove them.

Note that, DSL information viewer, which has been introduced in #134, can display such ineffective `checkpoint` operators.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.
