### PR TITLE
Fix I/O port name for exec plan information.

### DIFF
--- a/dag/compiler/flow/src/main/java/com/asakusafw/dag/compiler/flow/DataFlowGenerator.java
+++ b/dag/compiler/flow/src/main/java/com/asakusafw/dag/compiler/flow/DataFlowGenerator.java
@@ -686,14 +686,14 @@ public final class DataFlowGenerator {
                     .findFirst()
                     .orElseGet(() -> PlanOutputSpec.of(r.getId(), DataExchange.UNKNOWN, null))));
         sub.getInputs().stream()
-            .filter(it -> mapper.containsKey(it) == false)
+            .filter(it -> vertex.getInputs().containsKey(it) == false)
             .map(InputSpec::get)
             .forEach(spec -> mapper.put(spec.getOrigin().getOperator(), PlanInputSpec.of(
                     spec.getId(),
                     spec.getInputType() == InputType.NO_DATA ? DataExchange.NOTHING : DataExchange.UNKNOWN,
                     null)));
         sub.getOutputs().stream()
-            .filter(it -> mapper.containsKey(it) == false)
+            .filter(it -> vertex.getOutputs().containsKey(it) == false)
             .map(OutputSpec::get)
             .forEach(spec -> mapper.put(spec.getOrigin().getOperator(), PlanOutputSpec.of(
                     spec.getId(),


### PR DESCRIPTION
## Summary

This PR fixes generating execution plan information in {on M3BP, Vanilla}.

## Background, Problem or Goal of the patch

The latest implementation sometimes generates wrong I/O port name for vertices, and it may raise NPE at the viewer tool introduced in #134.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* #134 