### PR TITLE
Add task graph information into `batch-info.json`.

### DIFF
--- a/compiler-project/extension-info/src/main/java/com/asakusafw/lang/compiler/extension/info/TaskListAttributeCollector.java
+++ b/compiler-project/extension-info/src/main/java/com/asakusafw/lang/compiler/extension/info/TaskListAttributeCollector.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.compiler.extension.info;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.asakusafw.lang.compiler.api.reference.CommandTaskReference;
+import com.asakusafw.lang.compiler.api.reference.JobflowReference;
+import com.asakusafw.lang.compiler.api.reference.TaskReference;
+import com.asakusafw.lang.info.api.AttributeCollector;
+import com.asakusafw.lang.info.task.TaskInfo;
+import com.asakusafw.lang.info.task.TaskListAttribute;
+
+/**
+ * Collects {@link TaskListAttribute}.
+ * @since 0.4.2
+ */
+public class TaskListAttributeCollector implements AttributeCollector {
+
+    static final String PROFILE_HADOOP = "hadoop";
+
+    @Override
+    public void process(Context context, JobflowReference jobflow) {
+        List<TaskInfo> tasks = new ArrayList<>();
+        for (TaskReference.Phase phase : TaskReference.Phase.values()) {
+            List<TaskReference> all = new ArrayList<>(jobflow.getTasks(phase));
+            all.forEach(it -> tasks.add(convert(all, phase, it)));
+        }
+        context.putAttribute(new TaskListAttribute(tasks));
+    }
+
+    private static TaskInfo convert(List<TaskReference> all, TaskReference.Phase phase, TaskReference task) {
+        return new TaskInfo(
+                toId(all.indexOf(task)),
+                convert(phase),
+                task.getModuleName(),
+                Optional.of(task)
+                    .filter(it -> it instanceof CommandTaskReference)
+                    .map(it -> (CommandTaskReference) it)
+                    .map(CommandTaskReference::getProfileName)
+                    .orElse(PROFILE_HADOOP),
+                task.getBlockers().stream()
+                    .map(all::indexOf)
+                    .filter(it -> it != null)
+                    .sorted()
+                    .map(String::valueOf)
+                    .collect(Collectors.toList()));
+    }
+
+    private static TaskInfo.Phase convert(TaskReference.Phase phase) {
+        switch (phase) {
+        case INITIALIZE:
+            return TaskInfo.Phase.INITIALIZE;
+        case IMPORT:
+            return TaskInfo.Phase.IMPORT;
+        case PROLOGUE:
+            return TaskInfo.Phase.PROLOGUE;
+        case MAIN:
+            return TaskInfo.Phase.MAIN;
+        case EPILOGUE:
+            return TaskInfo.Phase.EPILOGUE;
+        case EXPORT:
+            return TaskInfo.Phase.EXPORT;
+        case FINALIZE:
+            return TaskInfo.Phase.FINALIZE;
+        default:
+            throw new AssertionError(phase);
+        }
+    }
+
+    private static String toId(int id) {
+        return String.valueOf(id);
+    }
+}

--- a/compiler-project/extension-info/src/main/resources/META-INF/services/com.asakusafw.lang.info.api.AttributeCollector
+++ b/compiler-project/extension-info/src/main/resources/META-INF/services/com.asakusafw.lang.info.api.AttributeCollector
@@ -1,1 +1,2 @@
 com.asakusafw.lang.compiler.extension.info.ParameterListAttributeCollector
+com.asakusafw.lang.compiler.extension.info.TaskListAttributeCollector

--- a/compiler-project/extension-operator/src/main/java/com/asakusafw/lang/compiler/operator/info/PlanAttributeStore.java
+++ b/compiler-project/extension-operator/src/main/java/com/asakusafw/lang/compiler/operator/info/PlanAttributeStore.java
@@ -38,7 +38,7 @@ public final class PlanAttributeStore {
 
     static final Logger LOG = LoggerFactory.getLogger(PlanAttributeCollector.class);
 
-    static final Location SERIALIZE_LOCATION = Location.of("asakusafw-info/plan.json");
+    static final Location SERIALIZE_LOCATION = Location.of("META-INF/asakusafw-info/plan.json");
 
     private PlanAttributeStore() {
         return;

--- a/info/api/src/main/java/com/asakusafw/lang/info/api/AttributeCollector.java
+++ b/info/api/src/main/java/com/asakusafw/lang/info/api/AttributeCollector.java
@@ -19,6 +19,8 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import com.asakusafw.lang.compiler.api.CompilerOptions;
+import com.asakusafw.lang.compiler.api.reference.BatchReference;
+import com.asakusafw.lang.compiler.api.reference.JobflowReference;
 import com.asakusafw.lang.compiler.common.Location;
 import com.asakusafw.lang.compiler.model.graph.Batch;
 import com.asakusafw.lang.compiler.model.graph.Jobflow;
@@ -27,6 +29,7 @@ import com.asakusafw.lang.info.Attribute;
 /**
  * Collects {@link Attribute} from batch.
  * @since 0.4.1
+ * @version 0.4.2
  */
 public interface AttributeCollector {
 
@@ -45,6 +48,26 @@ public interface AttributeCollector {
      * @param jobflow the target jobflow
      */
     default void process(Context context, Jobflow jobflow) {
+        return;
+    }
+
+    /**
+     * Collects {@link Attribute} from the given batch.
+     * @param context the current context
+     * @param batch the target batch
+     * @since 0.4.2
+     */
+    default void process(Context context, BatchReference batch) {
+        return;
+    }
+
+    /**
+     * Collects {@link Attribute} from the given jobflow.
+     * @param context the current context
+     * @param jobflow the target jobflow
+     * @since 0.4.2
+     */
+    default void process(Context context, JobflowReference jobflow) {
         return;
     }
 

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/DrawCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/DrawCommand.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.cli;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import io.airlift.airline.Option;
+
+/**
+ * An abstract implementation of drawing commands.
+ * @since 0.4.2
+ */
+public abstract class DrawCommand extends SingleJobflowInfoCommand {
+
+    @Option(
+            name = { "--concentrate", },
+            title = "concentrate multi-edges",
+            description = "concentrate multi-edges",
+            arity = 0,
+            required = false)
+    Boolean concentrate;
+
+    /**
+     * Returns the graph options.
+     * @return the graph options
+     */
+    protected Map<String, ?> getGraphOptions() {
+        Map<String, String> graphs = new LinkedHashMap<>();
+        put(graphs, "compound", true);
+        put(graphs, "concentrate", concentrate);
+
+        Map<String, String> nodes = new LinkedHashMap<>();
+        Map<String, String> edges = new LinkedHashMap<>();
+
+        Map<String, Object> results = new LinkedHashMap<>();
+        results.put("graph", graphs);
+        results.put("node", nodes);
+        results.put("edge", edges);
+        return results;
+    }
+
+    private static void put(Map<String, String> map, String key, Object value) {
+        Optional.ofNullable(value).ifPresent(it -> map.put(key, String.valueOf(it)));
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/DrawEngine.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/DrawEngine.java
@@ -64,22 +64,13 @@ class DrawEngine {
 
     void draw(
             PrintWriter writer, OperatorGraphView root,
-            int limitDepth, Optional<String> label,
-            Consumer<? super Drawer> extension) {
-        drawer.add(root.getRoot(), Shape.GRAPH, label);
-        analyzeGraph(root, 1, limitDepth);
-        Optional.ofNullable(extension).ifPresent(it -> it.accept(drawer));
-        drawer.dump(writer, root.getRoot());
-    }
-
-    void draw(
-            PrintWriter writer, OperatorGraphView root,
             int limitDepth, List<String> label,
+            Map<String, ?> options,
             Consumer<? super Drawer> extension) {
         drawer.add(root.getRoot(), Shape.GRAPH, label);
         analyzeGraph(root, 1, limitDepth);
         Optional.ofNullable(extension).ifPresent(it -> it.accept(drawer));
-        drawer.dump(writer, root.getRoot());
+        drawer.dump(writer, root.getRoot(), options);
     }
 
     private void analyzeGraph(OperatorGraphView graph, int currentDepth, int limitDepth) {
@@ -305,6 +296,9 @@ class DrawEngine {
     private List<String> analyzePlanOutput(OperatorView operator, PlanOutputSpec spec) {
         List<String> body = new ArrayList<>();
         body.add(spec.getExchange().toString());
+        if (features.contains(Feature.EDGE_OPERATION)) {
+            body.addAll(spec.getExtraOperations());
+        }
         if (features.contains(Feature.EDGE_TYPE)) {
             operator.getInputs().stream()
                 .findAny()
@@ -377,6 +371,8 @@ class DrawEngine {
         PORT_TYPE(true),
 
         PORT_KEY(true),
+
+        EDGE_OPERATION(false),
 
         EDGE_TYPE(false),
 

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/DrawJobflowCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/DrawJobflowCommand.java
@@ -15,14 +15,23 @@
  */
 package com.asakusafw.lang.info.cli;
 
-import static com.asakusafw.lang.info.cli.DrawUtil.*;
-
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.asakusafw.lang.info.BatchInfo;
 import com.asakusafw.lang.info.JobflowInfo;
+import com.asakusafw.lang.info.cli.Drawer.Shape;
+import com.asakusafw.lang.info.graph.Node;
+import com.asakusafw.lang.info.task.TaskInfo;
+import com.asakusafw.lang.info.task.TaskListAttribute;
 import com.asakusafw.lang.info.value.ClassInfo;
 
 import io.airlift.airline.Command;
@@ -40,12 +49,20 @@ import io.airlift.airline.Option;
 public class DrawJobflowCommand extends InfoCommand {
 
     @Option(
-            name = { "--show-type", },
-            title = "display jobflow type",
-            description = "display jobflow type",
+            name = { "--show-task", },
+            title = "display task graph",
+            description = "display task graph",
             arity = 0,
             required = false)
-    boolean showJobflowType = false;
+    boolean showTask = false;
+
+    @Option(
+            name = { "--show-type", },
+            title = "display description type",
+            description = "display description type",
+            arity = 0,
+            required = false)
+    boolean showType = false;
 
     @Option(
             name = { "--show-all", "-a", },
@@ -57,33 +74,138 @@ public class DrawJobflowCommand extends InfoCommand {
 
     @Override
     protected void process(PrintWriter writer, BatchInfo info) throws IOException {
-        writer.println("digraph {");
-        writer.printf("label=%s;%n", literal(Optional.ofNullable(info.getDescriptionClass())
-                .map(ClassInfo::of)
-                .map(ClassInfo::getSimpleName)
-                .orElse(info.getId())));
-        info.getJobflows().forEach(it -> writer.printf(
-                "%s [label=%s];%n",
-                literal(it.getId()),
-                literal(analyzeJobflow(it))));
-        info.getJobflows().forEach(
-                downstream -> downstream.getBlockerIds().forEach(
-                        upstreamId -> writer.printf("%s -> %s",
-                                literal(upstreamId),
-                                literal(downstream.getId()))));
-        writer.println("}");
+        new Engine().draw(writer, info);
     }
 
-    private String analyzeJobflow(JobflowInfo it) {
-        if (showAll || showJobflowType) {
-            return String.join("\n",
-                    it.getId(),
-                    Optional.ofNullable(it.getDescriptionClass())
-                        .map(ClassInfo::of)
-                        .map(ClassInfo::getSimpleName)
-                        .orElse("N/A"));
-        } else {
-            return it.getId();
+    private class Engine {
+
+        private final Drawer drawer = new Drawer();
+
+        Engine() {
+            return;
+        }
+
+        void draw(PrintWriter writer, BatchInfo info) {
+            Node root = new Node();
+            addBatch(info, root);
+            Map<String, ?> options = getOptions();
+            drawer.dump(writer, root, options);
+        }
+
+        private Map<String, ?> getOptions() {
+            Map<String, String> graphs = new LinkedHashMap<>();
+            graphs.put("compound", String.valueOf(true));
+
+            Map<String, String> nodes = new LinkedHashMap<>();
+            Map<String, String> edges = new LinkedHashMap<>();
+
+            Map<String, Object> results = new LinkedHashMap<>();
+            results.put("graph", graphs);
+            results.put("node", nodes);
+            results.put("edge", edges);
+            return results;
+        }
+
+        private void addBatch(BatchInfo info, Node node) {
+            List<String> label = new ArrayList<>();
+            if (showAll || showType) {
+                Optional.ofNullable(info.getDescriptionClass())
+                    .map(ClassInfo::of)
+                    .map(ClassInfo::getSimpleName)
+                    .ifPresent(label::add);
+            }
+            label.add(info.getId());
+            Map<String, Node> jobflows = info.getJobflows().stream()
+                    .collect(Collectors.toMap(
+                            JobflowInfo::getId,
+                            it -> node.newElement()
+                                .withInput(null)
+                                .withOutput(null)
+                                .configure(e -> addJobflow(it, e))));
+            info.getJobflows().forEach(it -> it.getBlockerIds().stream()
+                    .map(jobflows::get)
+                    .filter(blocker -> blocker != null)
+                    .forEach(blocker -> blocker.getOutput(0).connect(jobflows.get(it.getId()).getInput(0))));
+
+            node.getWires().forEach(it -> drawer.connect(it.getSource(), it.getDestination()));
+            drawer.add(node, Shape.GRAPH, label);
+        }
+
+        private void addJobflow(JobflowInfo info, Node node) {
+            List<String> label = new ArrayList<>();
+            if (showAll || showType) {
+                Optional.ofNullable(info.getDescriptionClass())
+                    .map(ClassInfo::of)
+                    .map(ClassInfo::getSimpleName)
+                    .ifPresent(label::add);
+            }
+            label.add(info.getId());
+            if (showAll || showTask) {
+                Map<TaskInfo.Phase, List<TaskInfo>> phases = info.findAttribute(TaskListAttribute.class)
+                        .map(TaskListAttribute::getPhases)
+                        .orElse(Collections.emptyMap());
+                List<Node> elements = phases.entrySet().stream()
+                        .map(e -> node.newElement()
+                                .withInput(null)
+                                .withOutput(null)
+                                .configure(n -> addPhase(e.getKey(), e.getValue(), n)))
+                        .collect(Collectors.toList());
+                Node last = null;
+                for (Node e : elements) {
+                    if (last != null) {
+                        last.getOutput(0).connect(e.getInput(0));
+                    }
+                    last = e;
+                }
+            }
+            node.getWires().forEach(it -> drawer.connect(it.getSource(), it.getDestination()));
+            drawer.add(node, Shape.GRAPH, label);
+        }
+
+        private void addPhase(TaskInfo.Phase phase, List<TaskInfo> tasks, Node node) {
+            Map<String, Node> map = tasks.stream()
+                    .collect(Collectors.toMap(
+                            TaskInfo::getId,
+                            it -> node.newElement()
+                                .withInput(null)
+                                .withOutput(null)
+                                .configure(e -> addTask(it, e))));
+            tasks.forEach(succ -> succ.getBlockers().stream()
+                    .map(map::get)
+                    .filter(pred -> pred != null)
+                    .forEach(pred -> pred.getOutput(0).connect(map.get(succ.getId()).getInput(0))));
+            if (map.size() >= 1) {
+                Node begin = node.newElement().withOutput(null);
+                drawer.add(begin, Shape.POINT, Collections.emptyList());
+
+                Node end = node.newElement().withInput(null);
+                drawer.add(end, Shape.POINT, Collections.emptyList());
+
+                tasks.stream()
+                    .filter(it -> it.getBlockers().isEmpty())
+                    .map(TaskInfo::getId)
+                    .map(map::get)
+                    .forEach(it -> begin.getOutput(0).connect(it.getInput(0)));
+
+                Set<String> blockers = tasks.stream()
+                        .flatMap(it -> it.getBlockers().stream())
+                        .collect(Collectors.toSet());
+                tasks.stream()
+                    .map(TaskInfo::getId)
+                    .filter(it -> blockers.contains(it) == false)
+                    .map(map::get)
+                    .forEach(it -> it.getOutput(0).connect(end.getInput(0)));
+            }
+
+            node.getWires().forEach(it -> drawer.connect(it.getSource(), it.getDestination()));
+            drawer.add(node, Shape.GRAPH, Collections.singletonList(phase.getSymbol()));
+        }
+
+        private void addTask(TaskInfo info, Node node) {
+            List<String> label = new ArrayList<>();
+            Optional.ofNullable(info.getModuleName()).ifPresent(label::add);
+            Optional.ofNullable(info.getProfileName()).map(it -> String.format("@%s", it)).ifPresent(label::add);
+            drawer.add(node, Shape.BOX, label);
         }
     }
 }

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/DrawOperatorCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/DrawOperatorCommand.java
@@ -49,7 +49,7 @@ import io.airlift.airline.Option;
         description = "Generates operator graph as Graphviz DOT script",
         hidden = false
 )
-public class DrawOperatorCommand extends SingleJobflowInfoCommand {
+public class DrawOperatorCommand extends DrawCommand {
 
     @Option(
             name = { "--depth", },
@@ -140,7 +140,7 @@ public class DrawOperatorCommand extends SingleJobflowInfoCommand {
         }
         Set<Feature> features = extractFeatures();
         DrawEngine engine = new DrawEngine(features);
-        engine.draw(writer, graph, limitDepth, label, null);
+        engine.draw(writer, graph, limitDepth, label, getGraphOptions(), null);
     }
 
     private Set<Feature> extractFeatures() {

--- a/info/cli/src/main/java/com/asakusafw/lang/info/cli/DrawPlanCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/lang/info/cli/DrawPlanCommand.java
@@ -46,7 +46,7 @@ import io.airlift.airline.Option;
         description = "Generates execution plan as Graphviz DOT script",
         hidden = false
 )
-public class DrawPlanCommand extends SingleJobflowInfoCommand {
+public class DrawPlanCommand extends DrawCommand {
 
     @Option(
             name = { "--vertex", },
@@ -71,6 +71,14 @@ public class DrawPlanCommand extends SingleJobflowInfoCommand {
             arity = 0,
             required = false)
     boolean showArgument = false;
+
+    @Option(
+            name = { "--show-edge-operation", },
+            title = "display operations on edge",
+            description = "display operations on edge",
+            arity = 0,
+            required = false)
+    boolean showEdgeOperation = false;
 
     @Option(
             name = { "--show-io", },
@@ -154,7 +162,7 @@ public class DrawPlanCommand extends SingleJobflowInfoCommand {
         }
         Set<Feature> features = extractFeatures();
         DrawEngine engine = new DrawEngine(features);
-        engine.draw(writer, graph, depth, label, null);
+        engine.draw(writer, graph, depth, label, getGraphOptions(), null);
     }
 
     private Set<Feature> extractFeatures() {
@@ -167,6 +175,9 @@ public class DrawPlanCommand extends SingleJobflowInfoCommand {
         }
         if (showExternalIo) {
             results.add(Feature.EXTERNAL_IO_CLASS);
+        }
+        if (showEdgeOperation) {
+            results.add(Feature.EDGE_OPERATION);
         }
         if (showPortName) {
             results.add(Feature.PORT_NAME);

--- a/info/model/src/main/java/com/asakusafw/lang/info/task/TaskInfo.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/task/TaskInfo.java
@@ -1,0 +1,215 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.task;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a task.
+ * @since 0.4.2
+ */
+public class TaskInfo {
+
+    private static final String ID_ID = "id";
+
+    private static final String ID_PHASE = "phase";
+
+    private static final String ID_MODULE = "module";
+
+    private static final String ID_PROFILE = "profile";
+
+    private static final String ID_BLOCKERS = "blockers";
+
+    @JsonProperty(ID_ID)
+    private final String id;
+
+    @JsonProperty(ID_PHASE)
+    private final Phase phase;
+
+    @JsonProperty(ID_MODULE)
+    private final String moduleName;
+
+    @JsonProperty(ID_PROFILE)
+    private final String profileName;
+
+    @JsonProperty(ID_BLOCKERS)
+    @JsonInclude(Include.NON_EMPTY)
+    private final Set<String> blockers;
+
+    /**
+     * Creates a new instance.
+     * @param id the task ID
+     * @param phase the task phase
+     * @param moduleName the module name
+     * @param profileName the profile name
+     * @param blockers the blocker task ID
+     */
+    @JsonCreator
+    public TaskInfo(
+            @JsonProperty(ID_ID) String id,
+            @JsonProperty(ID_PHASE) Phase phase,
+            @JsonProperty(ID_MODULE) String moduleName,
+            @JsonProperty(ID_PROFILE) String profileName,
+            @JsonProperty(ID_BLOCKERS) Collection<String> blockers) {
+        this.id = id;
+        this.phase = phase;
+        this.moduleName = moduleName;
+        this.profileName = profileName;
+        this.blockers = Optional.ofNullable(blockers)
+                .map(it -> Collections.unmodifiableSet(new LinkedHashSet<>(blockers)))
+                .orElse(Collections.emptySet());
+    }
+
+    /**
+     * Returns the task ID.
+     * @return the task ID
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Returns the phase.
+     * @return the phase
+     */
+    public Phase getPhase() {
+        return phase;
+    }
+
+    /**
+     * Returns the module name.
+     * @return the module name
+     */
+    public String getModuleName() {
+        return moduleName;
+    }
+
+    /**
+     * Returns the profile name.
+     * @return the profile name, or {@code null} if it is not defined
+     */
+    public String getProfileName() {
+        return profileName;
+    }
+
+    /**
+     * Returns the blocker task IDs.
+     * @return the blocker task IDs
+     */
+    public Set<String> getBlockers() {
+        return blockers;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Objects.hashCode(id);
+        result = prime * result + Objects.hashCode(phase);
+        result = prime * result + Objects.hashCode(moduleName);
+        result = prime * result + Objects.hashCode(profileName);
+        result = prime * result + Objects.hashCode(blockers);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        TaskInfo other = (TaskInfo) obj;
+        return Objects.equals(id, other.id)
+                && Objects.equals(phase, other.phase)
+                && Objects.equals(moduleName, other.moduleName)
+                && Objects.equals(profileName, other.profileName)
+                && Objects.equals(blockers, other.blockers);
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "Task(id=%s, phase=%s, module=%s, profile=%s, blockers=%s)",
+                id, phase, moduleName, profileName, blockers);
+    }
+
+    /**
+     * Represents kind of task phase.
+     * @since 0.4.2
+     */
+    public enum Phase {
+
+        /**
+         * Initialization.
+         */
+        INITIALIZE,
+
+        /**
+         * Importing input data.
+         */
+        IMPORT,
+
+        /**
+         * Pre-processing input data.
+         */
+        PROLOGUE,
+
+        /**
+         * Processing data.
+         */
+        MAIN,
+
+        /**
+         * Post-processing output data.
+         */
+        EPILOGUE,
+
+        /**
+         * Exporting output data.
+         */
+        EXPORT,
+
+        /**
+         * Finalization.
+         */
+        FINALIZE,
+        ;
+
+        /**
+         * Returns the symbol of this phase.
+         * @return the symbol of this phase
+         */
+        public String getSymbol() {
+            return name().toLowerCase(Locale.ENGLISH);
+        }
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/task/TaskListAttribute.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/task/TaskListAttribute.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.task;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import com.asakusafw.lang.info.Attribute;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a list of tasks in jobflow.
+ * @since 0.4.2
+ */
+public class TaskListAttribute implements Attribute {
+
+    static final String ID = "task-list";
+
+    private static final String ID_TASKS = "tasks";
+
+    @JsonProperty(ID_TASKS)
+    @JsonInclude(Include.NON_ABSENT)
+    private final List<TaskInfo> tasks;
+
+    /**
+     * Creates a new instance.
+     * @param tasks list of tasks
+     */
+    public TaskListAttribute(Collection<? extends TaskInfo> tasks) {
+        this.tasks = Collections.unmodifiableList(new ArrayList<>(tasks));
+    }
+
+    @JsonCreator
+    static TaskListAttribute restore(
+            @JsonProperty("id") String id,
+            @JsonProperty(ID_TASKS) Collection<? extends TaskInfo> tasks) {
+        if (Objects.equals(id, ID) == false) {
+            throw new IllegalArgumentException();
+        }
+        return new TaskListAttribute(Optional.ofNullable(tasks).orElse(Collections.emptyList()));
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    /**
+     * Returns the tasks.
+     * @return the tasks
+     */
+    public List<TaskInfo> getTasks() {
+        return tasks;
+    }
+
+    /**
+     * Returns the available phases.
+     * @return the available phases:
+     *      each key is naturally ordered, and present only if there are any tasks in the phase
+     */
+    @JsonIgnore
+    public Map<TaskInfo.Phase, List<TaskInfo>> getPhases() {
+        Map<TaskInfo.Phase, List<TaskInfo>> results = new EnumMap<>(TaskInfo.Phase.class);
+        tasks.forEach(it -> results.computeIfAbsent(it.getPhase(), k -> new ArrayList<>()).add(it));
+        return results;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Objects.hashCode(tasks);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        return Objects.equals(tasks, ((TaskListAttribute) obj).tasks);
+    }
+
+    @Override
+    public String toString() {
+        return tasks.toString();
+    }
+}

--- a/info/model/src/main/java/com/asakusafw/lang/info/task/package-info.java
+++ b/info/model/src/main/java/com/asakusafw/lang/info/task/package-info.java
@@ -13,29 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.lang.info.plan;
-
-final class Constants {
-
-    static final String ID_ID = "id";
-
-    static final String ID_ROOT = "root";
-
-    static final String ID_NAME = "name";
-
-    static final String ID_LABEL = "label";
-
-    static final String ID_DEPENDENCIES = "blockers";
-
-    static final String ID_INDEX = "index";
-
-    static final String ID_EXCHANGE = "exchange";
-
-    static final String ID_GROUP = "group";
-
-    static final String ID_EXTRA = "extra";
-
-    private Constants() {
-        return;
-    }
-}
+/**
+ * Asakusa task information models.
+ */
+package com.asakusafw.lang.info.task;

--- a/info/model/src/test/java/com/asakusafw/lang/info/task/TaskListAttributeTest.java
+++ b/info/model/src/test/java/com/asakusafw/lang/info/task/TaskListAttributeTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.info.task;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
+import com.asakusafw.lang.info.Attribute;
+import com.asakusafw.lang.info.InfoSerDe;
+import com.asakusafw.lang.info.task.TaskInfo.Phase;
+
+/**
+ * Test for {@link TaskListAttribute}.
+ */
+public class TaskListAttributeTest {
+
+    /**
+     * simple case.
+     */
+    @Test
+    public void simple() {
+        InfoSerDe.checkRestore(
+                Attribute.class,
+                new TaskListAttribute(Arrays.asList(
+                        new TaskInfo(
+                                "a",
+                                Phase.IMPORT,
+                                "windgate",
+                                "testing",
+                                Collections.emptyList()),
+                        new TaskInfo(
+                                "b",
+                                Phase.MAIN,
+                                "vanilla",
+                                "vanilla",
+                                Collections.emptyList()),
+                        new TaskInfo(
+                                "c",
+                                Phase.FINALIZE,
+                                "windgate",
+                                "testing",
+                                Collections.emptyList()),
+                        new TaskInfo(
+                                "d",
+                                Phase.FINALIZE,
+                                "finalizer",
+                                "vanilla",
+                                Arrays.asList("c")))));
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds task graph information into `batch-info.json`.

## Background, Problem or Goal of the patch

`batch-info.json` file has been introduced as incubating feature (`asakusafw.sdk.incubating = true`) since #113. This additionally enables task graph information for Asakusa {on Spark, M3BP, Vanilla}.

## Design of the fix, or a new feature

This also enables to display task information by using information viewer (`info/cli`):
* `list jobflow -v`
* `draw jobflow --show-task`

## Related Issue, Pull Request or Code

* #113 