### PR TITLE
Display correct command name of `tools/bin/info.sh`.

### DIFF
--- a/info/cli/src/main/dist/tools/bin/info.sh
+++ b/info/cli/src/main/dist/tools/bin/info.sh
@@ -33,4 +33,4 @@ then
     exit 1
 fi
 
-exec java -jar "$_ROOT/lib/asakusa-info.jar" "$@"
+exec java $JAVA_OPTS -Dinfo.cli.name=info.sh -jar "$_ROOT/lib/asakusa-info.jar" "$@"


### PR DESCRIPTION
## Summary

This PR enables `$ASAKUSA_HOME/tools/bin/info.sh` to display correct command name of itself in the help message.

## Background, Problem or Goal of the patch

In the latest implementation the command `$ASAKUSA_HOME/tools/bin/info.sh` shows a help message like:

```
usage: java -jar asakusa-info.jar <command> [<args>]

The most commonly used java -jar asakusa-info.jar commands are:
    draw   Generates Graphviz DOT scripts
    help   Display help information
    list   Displays information list

See 'java -jar asakusa-info.jar help <command>' for more information on a
specific command.
```

We improved the above message into:

```
usage: info.sh <command> [<args>]

The most commonly used info.sh commands are:
    draw   Generates Graphviz DOT scripts
    help   Display help information
    list   Displays information list

See 'info.sh help <command>' for more information on a specific command.
```

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* #142 