### PR TITLE
Enable vanilla testkit instead of mapreduce if `incubating true`.

### DIFF
--- a/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaSdkBasePlugin.groovy
+++ b/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaSdkBasePlugin.groovy
@@ -19,6 +19,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 import com.asakusafw.gradle.plugins.AsakusafwSdkExtension
+import com.asakusafw.gradle.plugins.AsakusafwSdkPluginParticipant
 import com.asakusafw.gradle.plugins.internal.AsakusaSdkPlugin
 import com.asakusafw.gradle.plugins.internal.PluginUtils
 import com.asakusafw.lang.gradle.plugins.internal.AsakusaLangSdkPlugin
@@ -45,7 +46,7 @@ class AsakusaVanillaSdkBasePlugin implements Plugin<Project> {
 
     private void configureTestkit() {
         AsakusafwSdkExtension sdk = AsakusaSdkPlugin.get(project).sdk
-        sdk.availableTestkits << new AsakusaVanillaTestkit()
+        sdk.availableTestkits << new AsakusaVanillaTestkit(sdk)
     }
 
     private void configureConfigurations() {
@@ -93,6 +94,23 @@ class AsakusaVanillaSdkBasePlugin implements Plugin<Project> {
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * A participant descriptor for {@link AsakusaVanillaSdkBasePlugin}.
+     * @since 0.9.2
+     */
+    static class Participant implements AsakusafwSdkPluginParticipant {
+
+        @Override
+        String getName() {
+            return descriptor.simpleName
+        }
+
+        @Override
+        Class<?> getDescriptor() {
+            return AsakusaVanillaSdkBasePlugin
         }
     }
 }

--- a/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaTestkit.groovy
+++ b/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaTestkit.groovy
@@ -18,14 +18,19 @@ package com.asakusafw.vanilla.gradle.plugins.internal
 import org.gradle.api.Project
 
 import com.asakusafw.gradle.plugins.AsakusaTestkit
-import com.asakusafw.gradle.plugins.AsakusafwPluginConvention
-import com.asakusafw.gradle.plugins.internal.AsakusaSdkPlugin
+import com.asakusafw.gradle.plugins.AsakusafwSdkExtension
 
 /**
  * An implementation of {@link AsakusaTestkit} which uses Asakusa Vanilla.
  * @since 0.4.0
  */
 class AsakusaVanillaTestkit implements AsakusaTestkit {
+
+    private final AsakusafwSdkExtension features
+
+    AsakusaVanillaTestkit(AsakusafwSdkExtension features) {
+        this.features = features
+    }
 
     @Override
     String getName() {
@@ -34,7 +39,11 @@ class AsakusaVanillaTestkit implements AsakusaTestkit {
 
     @Override
     int getPriority() {
-        return 10
+        if (features.incubating) {
+            return 1000
+        } else {
+            return 10
+        }
     }
 
     @Override

--- a/vanilla/gradle/src/main/resources/META-INF/services/com.asakusafw.gradle.plugins.AsakusafwSdkPluginParticipant
+++ b/vanilla/gradle/src/main/resources/META-INF/services/com.asakusafw.gradle.plugins.AsakusafwSdkPluginParticipant
@@ -1,0 +1,1 @@
+com.asakusafw.vanilla.gradle.plugins.internal.AsakusaVanillaSdkBasePlugin$Participant

--- a/vanilla/gradle/src/test/groovy/com/asakusafw/vanilla/gradle/plugins/AsakusaPluginParticipantTest.groovy
+++ b/vanilla/gradle/src/test/groovy/com/asakusafw/vanilla/gradle/plugins/AsakusaPluginParticipantTest.groovy
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.gradle.plugins
+
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+import com.asakusafw.vanilla.gradle.plugins.internal.AsakusaVanillaSdkBasePlugin
+
+/**
+ * Test for {@code AsakusafwPluginParticipant} with Vanilla.
+ */
+class AsakusaPluginParticipantTest {
+
+    /**
+     * The test initializer.
+     */
+    @Rule
+    public final TestRule initializer = new TestRule() {
+        Statement apply(Statement stmt, Description desc) {
+            project = ProjectBuilder.builder().withName(desc.methodName).build()
+            return stmt
+        }
+    }
+
+    Project project
+
+    /**
+     * {@code asakusafw-sdk} plugin includes {@code AsakusaVanillaSdkBasePlugin}.
+     */
+    @Test
+    void participant_asakusafw_sdk() {
+        project.apply plugin: 'asakusafw-sdk'
+        assert project.plugins.hasPlugin(AsakusaVanillaSdkBasePlugin)
+    }
+}


### PR DESCRIPTION
## Summary

This PR enables Asakusa Vanilla testkit in default if `asakusafw.sdk.incubating true`.

## Background, Problem or Goal of the patch

In the latest implementation, Asakusa on MapReduce is used as the default testkit. We make Vanilla default testkit if `incubating=true`. It is also available even if `apply plugin: 'asakusafw-vanilla'` does not exist in `build.gradle`. Note that, Asakusa on MapReduce testkit is still available in default if if `incubating=false`.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.