### PR TITLE
Promote Asakusa Vanilla as the default testkit.

### DIFF
--- a/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaTestkit.groovy
+++ b/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaTestkit.groovy
@@ -39,11 +39,7 @@ class AsakusaVanillaTestkit implements AsakusaTestkit {
 
     @Override
     int getPriority() {
-        if (features.incubating) {
-            return 1000
-        } else {
-            return 10
-        }
+        return 200
     }
 
     @Override


### PR DESCRIPTION
## Summary

This PR makes Asakusa Vanilla as default testkit instead of MapReduce.

## Background, Problem or Goal of the patch

Asakusa Vanilla testkit has been enabled in #144 only if `asakusafw.sdk.incubating true`, otherwise enabled MapReduce testkit. This PR enables the Vanilla testkit even if `asakusafw.sdk.incubating true` is not specified.

## Design of the fix, or a new feature

The latest `AsakusaVanillaTestkit.priority` was `10` on `incubating=false`, or `1,000` on `incubating=true` by contrast the MapReduce testkit has `100`. We fixed the prority of Vanilla testkit to `200`, and MapReduce testkit to `1` (in asakusafw/asakusafw-mapreduce#11), then the Vanilla testkit will be always enabled from here.

## Related Issue, Pull Request or Code

* #144
* asakusafw/asakusafw-mapreduce#11
