### PR TITLE
Fix integration test.

### DIFF
--- a/integration/src/integration-test/java/com/asakusafw/integration/lang/PortalTest.java
+++ b/integration/src/integration-test/java/com/asakusafw/integration/lang/PortalTest.java
@@ -158,7 +158,7 @@ public class PortalTest {
      */
     @Test
     public void list_hive() {
-        framework.withLaunch(AsakusaConstants.CMD_PORTAL, "hive");
+        framework.withLaunch(AsakusaConstants.CMD_PORTAL, "list", "hive");
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR fixes an integration test case which has been failed since #154.

## Background, Problem or Goal of the patch

#154 introduced an invalid test case that invokes a command `asakusa hive`. It should be `asakusa list hive`.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* #154 