### PR TITLE
`asakusa run` on Windows.

### DIFF
--- a/compiler-project/extension-windgate/src/main/java/com/asakusafw/lang/compiler/extension/windgate/WindGatePortProcessor.java
+++ b/compiler-project/extension-windgate/src/main/java/com/asakusafw/lang/compiler/extension/windgate/WindGatePortProcessor.java
@@ -69,9 +69,9 @@ public class WindGatePortProcessor
 
     static final Logger LOG = LoggerFactory.getLogger(WindGatePortProcessor.class);
 
-    static final Location CMD_PROCESS = Location.of("windgate/bin/process.sh"); //$NON-NLS-1$
+    static final Location CMD_PROCESS = Location.of("windgate/bin/process"); //$NON-NLS-1$
 
-    static final Location CMD_FINALIZE = Location.of("windgate/bin/finalize.sh"); //$NON-NLS-1$
+    static final Location CMD_FINALIZE = Location.of("windgate/bin/finalize"); //$NON-NLS-1$
 
     static final String OPT_IMPORT = "import"; //$NON-NLS-1$
 

--- a/compiler-project/tester/src/main/java/com/asakusafw/lang/compiler/tester/executor/HadoopTaskExecutor.java
+++ b/compiler-project/tester/src/main/java/com/asakusafw/lang/compiler/tester/executor/HadoopTaskExecutor.java
@@ -31,6 +31,7 @@ import com.asakusafw.lang.compiler.hadoop.HadoopTaskReference;
  */
 public class HadoopTaskExecutor implements TaskExecutor {
 
+    // FIXME replace with workflow
     private static final Location PATH_YAESS_HADOOP =
             Location.of("yaess-hadoop/libexec/hadoop-execute.sh"); //$NON-NLS-1$
 

--- a/dag/runtime/extension/windows/.gitignore
+++ b/dag/runtime/extension/windows/.gitignore
@@ -1,0 +1,5 @@
+/target
+/.project
+/.classpath
+/.settings
+/bin

--- a/dag/runtime/extension/windows/pom.xml
+++ b/dag/runtime/extension/windows/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <name>Asakusa DAG Windows Workaround</name>
+  <artifactId>asakusa-dag-extension-windows</artifactId>
+  <parent>
+    <artifactId>project</artifactId>
+    <groupId>com.asakusafw.dag.runtime</groupId>
+    <version>0.5.0-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>asakusa-dag-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.asakusafw</groupId>
+      <artifactId>asakusa-runtime</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>asakusa-dag-api</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <classifier>tests</classifier>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/dag/runtime/extension/windows/src/main/java/com/asakusafw/dag/extension/windows/WindowsSupportExtension.java
+++ b/dag/runtime/extension/windows/src/main/java/com/asakusafw/dag/extension/windows/WindowsSupportExtension.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dag.extension.windows;
+
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.dag.api.processor.ProcessorContext;
+import com.asakusafw.dag.api.processor.ProcessorContext.Editor;
+import com.asakusafw.dag.api.processor.extension.ProcessorContextExtension;
+import com.asakusafw.lang.utils.common.InterruptibleIo;
+import com.asakusafw.runtime.windows.WindowsConfigurator;
+
+/**
+ * Activating Windows workarounds.
+ * @since 0.5.0
+ */
+public class WindowsSupportExtension implements ProcessorContextExtension {
+
+    static final Logger LOG = LoggerFactory.getLogger(WindowsSupportExtension.class);
+
+    @Override
+    public InterruptibleIo install(ProcessorContext context, Editor editor) throws IOException, InterruptedException {
+        LOG.debug("enabling Windows workarond");
+        WindowsConfigurator.install();
+        return null;
+    }
+}

--- a/dag/runtime/extension/windows/src/main/java/com/asakusafw/dag/extension/windows/package-info.java
+++ b/dag/runtime/extension/windows/src/main/java/com/asakusafw/dag/extension/windows/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Asakusa DAG workaround for executing on Windows platform.
+ */
+package com.asakusafw.dag.extension.windows;

--- a/dag/runtime/extension/windows/src/main/resources/META-INF/services/com.asakusafw.dag.api.processor.extension.ProcessorContextExtension
+++ b/dag/runtime/extension/windows/src/main/resources/META-INF/services/com.asakusafw.dag.api.processor.extension.ProcessorContextExtension
@@ -1,0 +1,1 @@
+com.asakusafw.dag.extension.windows.WindowsSupportExtension

--- a/dag/runtime/pom.xml
+++ b/dag/runtime/pom.xml
@@ -27,5 +27,6 @@
     <module>extension/counter</module>
     <module>extension/trace</module>
     <module>extension/wait</module>
+    <module>extension/windows</module>
   </modules>
 </project>

--- a/vanilla/compiler/common/src/main/java/com/asakusafw/vanilla/compiler/common/VanillaTask.java
+++ b/vanilla/compiler/common/src/main/java/com/asakusafw/vanilla/compiler/common/VanillaTask.java
@@ -19,7 +19,7 @@ import com.asakusafw.lang.compiler.common.Location;
 
 /**
  * Constants about Asakusa Vanilla tasks.
- * @since 0.4.0
+ * @since 0.5.0
  */
 public final class VanillaTask {
 
@@ -31,7 +31,13 @@ public final class VanillaTask {
     /**
      * The Vanilla bootstrap command path (relative from the Asakusa framework installation).
      */
-    public static final Location PATH_COMMAND = PATH_ASSEMBLY.append(Location.of("bin/execute.sh")); //$NON-NLS-1$
+    public static final Location PATH_COMMAND = PATH_ASSEMBLY.append(Location.of("bin/execute")); //$NON-NLS-1$
+
+    /**
+     * The Vanilla bootstrap command path for Windows platform (relative from the Asakusa framework installation).
+     * @since 0.5.0
+     */
+    public static final Location PATH_COMMAND_WINDOWS = PATH_ASSEMBLY.append(Location.of("bin/execute.cmd")); //$NON-NLS-1$
 
     /**
      * The Vanilla configuration directory path (relative from the Asakusa framework installation).

--- a/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaOrganizer.groovy
+++ b/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaOrganizer.groovy
@@ -19,6 +19,7 @@ import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.FileCopyDetails
 
 import com.asakusafw.gradle.plugins.AsakusafwBaseExtension
 import com.asakusafw.gradle.plugins.AsakusafwBasePlugin
@@ -80,10 +81,12 @@ class AsakusaVanillaOrganizer extends AbstractOrganizer {
             AsakusaVanillaBaseExtension vanilla = AsakusaVanillaBasePlugin.get(project)
             createDependencies('asakusafw', [
                 VanillaDist : [
-                    "com.asakusafw.vanilla.runtime:asakusa-vanilla-assembly:${vanilla.featureVersion}:dist@jar"
+                    "com.asakusafw.vanilla.runtime:asakusa-vanilla-assembly:${vanilla.featureVersion}:dist@jar",
+                    "com.asakusafw.vanilla.runtime:asakusa-vanilla-bootstrap:${vanilla.featureVersion}:dist@jar",
                 ],
                 VanillaLib : [
                     "com.asakusafw.vanilla.runtime:asakusa-vanilla-assembly:${vanilla.featureVersion}:lib@jar",
+                    "com.asakusafw.vanilla.runtime:asakusa-vanilla-bootstrap:${vanilla.featureVersion}:exec@jar",
                     "ch.qos.logback:logback-classic:${base.logbackVersion}",
                 ],
                 VanillaHadoopLib : [
@@ -107,9 +110,17 @@ class AsakusaVanillaOrganizer extends AbstractOrganizer {
             Vanilla : {
                 into('.') {
                     extract configuration('asakusafwVanillaDist')
+                    process {
+                        filesMatching('**/vanilla/bin/execute') { FileCopyDetails f ->
+                            f.setMode(0755)
+                        }
+                    }
                 }
                 into('vanilla/lib') {
                     put configuration('asakusafwVanillaLib')
+                    process {
+                        rename(/(asakusa-vanilla-bootstrap)-.*-exec\.jar/, '$1.jar')
+                    }
                 }
             },
             VanillaHadoop : {

--- a/vanilla/runtime/assembly/.gitattributes
+++ b/vanilla/runtime/assembly/.gitattributes
@@ -1,0 +1,1 @@
+src/main/dist/vanilla/bin/* eol=lf

--- a/vanilla/runtime/assembly/src/main/dist/vanilla/bin/execute
+++ b/vanilla/runtime/assembly/src/main/dist/vanilla/bin/execute
@@ -170,7 +170,6 @@ then
     echo "        System Options: ${_APP_OPTIONS[@]}" 1>&2
     echo "  ASAKUSA_VANILLA_OPTS: $ASAKUSA_VANILLA_OPTS" 1>&2
     echo "          User Options: $@" 1>&2
-    echo "           Librarypath: ${_LIBRARYPATH[@]}" 1>&2
     echo "             Classpath: ${_CLASSPATH[@]}" 1>&2
     exit $_RET
 fi

--- a/vanilla/runtime/bootstrap/.gitignore
+++ b/vanilla/runtime/bootstrap/.gitignore
@@ -1,0 +1,5 @@
+/target
+/.project
+/.classpath
+/.settings
+/bin

--- a/vanilla/runtime/bootstrap/pom.xml
+++ b/vanilla/runtime/bootstrap/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <name>Asakusa Vanilla Java Bootstrap</name>
+  <artifactId>asakusa-vanilla-bootstrap</artifactId>
+  <parent>
+    <artifactId>project</artifactId>
+    <groupId>com.asakusafw.vanilla.runtime</groupId>
+    <version>0.5.0-SNAPSHOT</version>
+  </parent>
+
+  <packaging>jar</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <descriptors>
+                <descriptor>src/main/assembly/dist.xml</descriptor>
+              </descriptors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>com.asakusafw.vanilla.bootstrap.VanillaBootstrap</mainClass>
+                </transformer>
+              </transformers>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>exec</shadedClassifierName>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  
+</project>

--- a/vanilla/runtime/bootstrap/src/main/assembly/dist.xml
+++ b/vanilla/runtime/bootstrap/src/main/assembly/dist.xml
@@ -1,0 +1,18 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+  <id>dist</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+
+  <fileSets>
+    <fileSet>
+      <directory>src/main/dist</directory>
+      <outputDirectory>.</outputDirectory>
+      <fileMode>0644</fileMode>
+      <directoryMode>0755</directoryMode>
+      <lineEnding>dos</lineEnding>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/vanilla/runtime/bootstrap/src/main/dist/vanilla/bin/execute.cmd
+++ b/vanilla/runtime/bootstrap/src/main/dist/vanilla/bin/execute.cmd
@@ -1,0 +1,29 @@
+@REM
+@REM Copyright 2011-2017 Asakusa Framework Team.
+@REM
+@REM Licensed under the Apache License, Version 2.0 (the "License");
+@REM you may not use this file except in compliance with the License.
+@REM You may obtain a copy of the License at
+@REM
+@REM     http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing, software
+@REM distributed under the License is distributed on an "AS IS" BASIS,
+@REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@REM See the License for the specific language governing permissions and
+@REM limitations under the License.
+@REM
+
+@echo off
+setlocal
+
+if not defined ASAKUSA_HOME (
+    echo environment variable %%ASAKUSA_HOME%% must be defined
+    exit /b 1
+)
+
+set java_jar=%ASAKUSA_HOME%\vanilla\lib\asakusa-vanilla-bootstrap.jar
+set java_props=%ASAKUSA_VANILLA_OPTS%
+set java_props=%java_props% -Dhadoop.home.dir=%ASAKUSA_HOME%\hadoop
+
+java %java_props% -jar %java_jar% %*

--- a/vanilla/runtime/bootstrap/src/main/java/com/asakusafw/vanilla/bootstrap/Arguments.java
+++ b/vanilla/runtime/bootstrap/src/main/java/com/asakusafw/vanilla/bootstrap/Arguments.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.bootstrap;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Represents program arguments.
+ * @since 0.5.0
+ */
+public class Arguments {
+
+    private final List<String> entries = new ArrayList<>();
+
+    /**
+     * Adds an entry.
+     * @param entry the entry
+     * @return this
+     */
+    public Arguments add(String entry) {
+        entries.add(entry);
+        return this;
+    }
+
+    /**
+     * Adds a pair of entries.
+     * @param e1 the first entry
+     * @param e2 the second entry
+     * @return this
+     */
+    public Arguments add(String e1, Object e2) {
+        entries.add(e1);
+        entries.add(String.valueOf(e2));
+        return this;
+    }
+
+    /**
+     * Adds a series of entries.
+     * @param values the entries
+     * @return this
+     */
+    public Arguments add(Iterable<String> values) {
+        values.forEach(entries::add);
+        return this;
+    }
+
+    /**
+     * Returns the entries as a string array.
+     * @return the entries
+     */
+    public String[] toArray() {
+        return entries.toArray(new String[entries.size()]);
+    }
+
+    @Override
+    public String toString() {
+        return entries.stream()
+                .collect(Collectors.joining(", ", "Arguments(", ")"));
+    }
+}

--- a/vanilla/runtime/bootstrap/src/main/java/com/asakusafw/vanilla/bootstrap/Classpath.java
+++ b/vanilla/runtime/bootstrap/src/main/java/com/asakusafw/vanilla/bootstrap/Classpath.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.bootstrap;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Represents a classpath of {@link VanillaBootstrap}.
+ * @since 0.5.0
+ */
+public class Classpath {
+
+    private final List<Path> entries = new ArrayList<>();
+
+    /**
+     * Adds an entry into this classpath.
+     * @param entry the target file or directory
+     * @param mandatory {@code true} if it is mandatory, otherwise {@code false}
+     * @return this
+     * @throws IllegalStateException if the mandatory entry is not found
+     */
+    public Classpath add(Path entry, boolean mandatory) {
+        if (Files.exists(entry)) {
+            entries.add(entry);
+        } else if (mandatory) {
+            throw new IllegalStateException(MessageFormat.format(
+                    "classpath entry must exist: {0}",
+                    entry));
+        }
+        return this;
+    }
+
+    /**
+     * Adds entries in the given directory into this classpath.
+     * @param directory the target directory
+     * @param mandatory {@code true} if it is mandatory, otherwise {@code false}
+     * @return this
+     * @throws IllegalStateException if the mandatory directory is not found
+     */
+    public Classpath addEntries(Path directory, boolean mandatory) {
+        if (Files.isDirectory(directory)) {
+            try {
+                Files.list(directory).forEach(entries::add);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        } else if (mandatory) {
+            throw new IllegalStateException(MessageFormat.format(
+                    "classpath entry must exist: {0}",
+                    directory));
+        }
+        return this;
+    }
+
+    /**
+     * Executes the given main class.
+     * @param base the base class loader
+     * @param className the main class name
+     * @param args the program arguments
+     * @throws IllegalStateException if error occurred while running main class
+     */
+    public void exec(ClassLoader base, String className, String... args) {
+        try (Session session = session(base)) {
+            session.exec(className, args);
+        }
+    }
+
+    /**
+     * Returns a new classpath session.
+     * @param base the base class loader
+     * @return the created session
+     */
+    public Session session(ClassLoader base) {
+        return new Session(URLClassLoader.newInstance(
+                entries.stream()
+                        .filter(Files::exists)
+                        .flatMap(it -> {
+                            try {
+                                return Stream.of(it.toUri().toURL());
+                            } catch (MalformedURLException e) {
+                                e.printStackTrace();
+                                return Stream.empty();
+                            }
+                        })
+                        .toArray(URL[]::new),
+                base));
+    }
+
+    @Override
+    public String toString() {
+        return entries.stream()
+                .map(Path::toString)
+                .collect(Collectors.joining(", ", "Classpath(", ")"));
+    }
+
+    static ClassLoader setContextClassLoader(ClassLoader classLoader) {
+        return AccessController.doPrivileged((PrivilegedAction<ClassLoader>) () -> {
+            ClassLoader old = Thread.currentThread().getContextClassLoader();
+            Thread.currentThread().setContextClassLoader(classLoader);
+            return old;
+        });
+    }
+
+    /**
+     * Represents a session of {@link Classpath}.
+     * @since 0.5.0
+     */
+    public static class Session implements Closeable {
+
+        private final ClassLoader previous;
+
+        private URLClassLoader active;
+
+        Session(URLClassLoader active) {
+            this.previous = setContextClassLoader(active);
+            this.active = active;
+        }
+
+        /**
+         * Returns the class loader of this session.
+         * @return the class loader
+         */
+        public ClassLoader getClassLoader() {
+            ClassLoader cl = active;
+            if (cl == null) {
+                throw new IllegalStateException();
+            }
+            return cl;
+        }
+
+        /**
+         * Executes the given main class.
+         * @param className the main class name
+         * @param args the program arguments
+         * @throws IllegalStateException if error occurred while starting main class
+         * @throws ExecutionException if error occurred while running main class
+         */
+        public void exec(String className, String... args) {
+            try {
+                Class<?> mainClass = Class.forName(className, false, getClassLoader());
+                Method mainMethod = mainClass.getMethod("main", String[].class);
+                mainMethod.invoke(null, new Object[] { args });
+            } catch (InvocationTargetException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof Error) {
+                    throw (Error) cause;
+                }
+                if (cause instanceof RuntimeException) {
+                    throw (RuntimeException) cause;
+                }
+                throw new ExecutionException(MessageFormat.format(
+                        "error occurred while running {0}.main({1})",
+                        className,
+                        String.join(", ", args)), cause);
+            } catch (ReflectiveOperationException e) {
+                throw new IllegalStateException(MessageFormat.format(
+                        "error occurred while launching main class: {0}",
+                        className), e);
+            }
+        }
+
+        @Override
+        public void close() {
+            if (active != null) {
+                // NOTE: we never close the class loader, because Hadoop may register some shutdown hooks
+                setContextClassLoader(previous);
+                active = null;
+            }
+        }
+    }
+
+}

--- a/vanilla/runtime/bootstrap/src/main/java/com/asakusafw/vanilla/bootstrap/ConfigurationException.java
+++ b/vanilla/runtime/bootstrap/src/main/java/com/asakusafw/vanilla/bootstrap/ConfigurationException.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.bootstrap;
+
+/**
+ * Represents that execution preconditions are not satisfied.
+ * @since 0.5.0
+ */
+public class ConfigurationException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Creates a new instance.
+     * @param message the exception message
+     */
+    public ConfigurationException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance.
+     * @param message the exception message
+     * @param cause the original cause (nullable)
+     */
+    public ConfigurationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/vanilla/runtime/bootstrap/src/main/java/com/asakusafw/vanilla/bootstrap/Context.java
+++ b/vanilla/runtime/bootstrap/src/main/java/com/asakusafw/vanilla/bootstrap/Context.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.bootstrap;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents a bootstrap context.
+ * @since 0.5.0
+ */
+public class Context {
+
+    private static final int IDX_BATCH_ID = 0;
+
+    private static final int IDX_FLOW_ID = 1;
+
+    private static final int IDX_EXECUTION_ID = 2;
+
+    private static final int IDX_BATCH_ARGUMENTS = 3;
+
+    private static final int IDX_APPLICATON_CLASS_NAME = 4;
+
+    private static final int IDX_EXTRA_ARGUMENTS_BEGIN = 5;
+
+    private final String applicationClassName;
+
+    private final String batchId;
+
+    private final String flowId;
+
+    private final String executionId;
+
+    private final String batchArguments;
+
+    private final List<String> extraArguments;
+
+    /**
+     * Creates a new instance.
+     * @param applicationClassName the application class name
+     * @param batchId the batch ID
+     * @param flowId the flow ID
+     * @param executionId the execution ID
+     * @param batchArguments the batch arguments
+     * @param extraArguments the extra arguments
+     */
+    public Context(
+            String applicationClassName,
+            String batchId, String flowId, String executionId,
+            String batchArguments, List<String> extraArguments) {
+        this.applicationClassName = applicationClassName;
+        this.batchId = batchId;
+        this.flowId = flowId;
+        this.executionId = executionId;
+        this.batchArguments = batchArguments;
+        this.extraArguments = Collections.unmodifiableList(new ArrayList<>(extraArguments));
+    }
+
+    /**
+     * Parses the program arguments.
+     * @param args the program arguments
+     * @return this
+     */
+    public static Context parse(String... args) {
+        if (args.length < 5) {
+            throw new ConfigurationException(MessageFormat.format(
+                    "invalid arguments: {0}",
+                    String.join(", ", args)));
+        }
+        return new Context(
+                args[IDX_APPLICATON_CLASS_NAME],
+                args[IDX_BATCH_ID],
+                args[IDX_FLOW_ID],
+                args[IDX_EXECUTION_ID],
+                args[IDX_BATCH_ARGUMENTS],
+                Arrays.asList(args).subList(IDX_EXTRA_ARGUMENTS_BEGIN, args.length));
+    }
+
+    /**
+     * Returns the application class name.
+     * @return the application class name
+     */
+    public String getApplicationClassName() {
+        return applicationClassName;
+    }
+
+    /**
+     * Returns the batch ID.
+     * @return the batch ID
+     */
+    public String getBatchId() {
+        return batchId;
+    }
+
+    /**
+     * Returns the flow ID.
+     * @return the flow ID
+     */
+    public String getFlowId() {
+        return flowId;
+    }
+
+    /**
+     * Returns the execution ID.
+     * @return the execution ID
+     */
+    public String getExecutionId() {
+        return executionId;
+    }
+
+    /**
+     * Returns the serialized batch arguments.
+     * @return the serialized batch arguments
+     */
+    public String getBatchArguments() {
+        return batchArguments;
+    }
+
+    /**
+     * Returns the extra arguments.
+     * @return the extra arguments
+     */
+    public List<String> getExtraArguments() {
+        return extraArguments;
+    }
+}

--- a/vanilla/runtime/bootstrap/src/main/java/com/asakusafw/vanilla/bootstrap/CoreConstants.java
+++ b/vanilla/runtime/bootstrap/src/main/java/com/asakusafw/vanilla/bootstrap/CoreConstants.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.bootstrap;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.MessageFormat;
+
+/**
+ * Constants of Asakusa Framework Core.
+ * @since 0.5.0
+ */
+public final class CoreConstants {
+
+    /**
+     * The environment variable name of framework installation path.
+     */
+    public static final String ENV_ASAKUSA_HOME = "ASAKUSA_HOME";
+
+    /**
+     * The environment variable name of batch application installation path.
+     */
+    public static final String ENV_ASAKUSA_BATCHAPPS_HOME = "ASAKUSA_BATCHAPPS_HOME";
+
+    /**
+     * The default path of batch application installation path (relative from framework root).
+     */
+    public static final String PATH_DEFAULT_BATCHAPPS_DIR = "batchapps";
+
+    /**
+     * The framework core libraries directory path (relative from framework root).
+     */
+    public static final String PATH_CORE_LIB_DIR = "core/lib";
+
+    /**
+     * The framework core configuration directory path (relative from framework root).
+     */
+    public static final String PATH_CORE_CONF_DIR = "core/conf";
+
+    /**
+     * The framework core configuration file path (relative from framework root).
+     */
+    public static final String PATH_CORE_CONF_FILE = PATH_CORE_CONF_DIR + "/asakusa-resources.xml";
+
+    /**
+     * The framework embedded Hadoop libraries directory path (relative from framework root).
+     */
+    public static final String PATH_HADOOP_EMBEDDED_LIB_DIR = "hadoop/lib";
+
+    /**
+     * The framework extension libraries directory path (relative from framework root).
+     */
+    public static final String PATH_EXTENSION_LIB_DIR = "ext/lib";
+
+    /**
+     * The jobflow package file path prefix (relative from batchapps root).
+     */
+    public static final String PATH_APP_JOBFLOW_LIB_FILE_PREFIX = "lib/jobflow-";
+
+    /**
+     * The jobflow package file path suffix.
+     */
+    public static final String PATH_APP_JOBFLOW_LIB_FILE_SUFFIX = ".jar";
+
+    /**
+     * The batch shared libraries directory path (relative from batchapps root).
+     */
+    public static final String PATH_APP_USER_LIB_DIR = "usr/lib";
+
+    private CoreConstants() {
+        return;
+    }
+
+    /**
+     * Returns the framework installation directory.
+     * @param env the current environment variables
+     * @return the target path
+     * @throws ConfigurationException if the mandatory settings are not configured
+     */
+    public static Path getHome(Environment env) {
+        return env.find(ENV_ASAKUSA_HOME)
+                .filter(it -> it.isEmpty() == false)
+                .map(Paths::get)
+                .orElseThrow(() -> new ConfigurationException(MessageFormat.format(
+                        "environment variable \"{0}\" must be defined",
+                        ENV_ASAKUSA_HOME)));
+    }
+
+    /**
+     * Returns the batch application installation directory.
+     * @param env the current environment variables
+     * @return the target path
+     * @throws ConfigurationException if the mandatory settings are not configured
+     */
+    public static Path getBatchappsHome(Environment env) {
+        return env.find(ENV_ASAKUSA_BATCHAPPS_HOME)
+                .filter(it -> it.isEmpty() == false)
+                .map(Paths::get)
+                .orElseGet(() -> getHome(env).resolve(PATH_DEFAULT_BATCHAPPS_DIR));
+    }
+
+    /**
+     * Returns the application base directory.
+     * @param env the current environment variables
+     * @param batchId the batch ID
+     * @return the target path
+     * @throws ConfigurationException if the mandatory settings are not configured
+     */
+    public static Path getApplication(Environment env, String batchId) {
+        return getBatchappsHome(env).resolve(batchId);
+    }
+
+    /**
+     * Returns the jobflow package file.
+     * @param application {@link #getApplication(Environment, String) the application directory}
+     * @param flowId the target flow ID
+     * @return the target path
+     * @throws ConfigurationException if the mandatory settings are not configured
+     */
+    public static Path getAppJobflowLibFile(Path application, String flowId) {
+        String entry = PATH_APP_JOBFLOW_LIB_FILE_PREFIX + flowId + PATH_APP_JOBFLOW_LIB_FILE_SUFFIX;
+        return application.resolve(entry);
+    }
+}

--- a/vanilla/runtime/bootstrap/src/main/java/com/asakusafw/vanilla/bootstrap/Environment.java
+++ b/vanilla/runtime/bootstrap/src/main/java/com/asakusafw/vanilla/bootstrap/Environment.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.bootstrap;
+
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * Represents a set of environment variables.
+ * @since 0.5.0
+ */
+public class Environment {
+
+    static final boolean CASE_SENSITIVE = isCaseSensitiveEnvironmentVariables();
+
+    private final Map<String, String> entries = CASE_SENSITIVE
+            ? new LinkedHashMap<>()
+            : new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
+    private static boolean isCaseSensitiveEnvironmentVariables() {
+        Map<String, String> env = System.getenv();
+        if (env instanceof SortedMap<?, ?>) {
+            Comparator<? super String> comparator = ((SortedMap<String, String>) env).comparator();
+            return comparator == null || comparator.compare("a", "A") != 0;
+        }
+        if (env.isEmpty() == false) {
+            for (String name : env.keySet()) {
+                String upper = name.toUpperCase(Locale.ENGLISH);
+                String lower = name.toLowerCase(Locale.ENGLISH);
+                if (upper.equals(lower) == false) {
+                    String value = System.getenv(name);
+                    String upperValue = System.getenv(upper);
+                    String lowerValue = System.getenv(lower);
+                    return Objects.equals(value, upperValue) == false || Objects.equals(value, lowerValue) == false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns a new system environment variables.
+     * @return a copy of system environment variables
+     */
+    public static Environment system() {
+        Environment result = new Environment();
+        result.entries.putAll(System.getenv());
+        return result;
+    }
+
+    /**
+     * Returns a value of environment variable.
+     * @param key key of the target environment variable
+     * @return the corresponded environmet variable value, or {@code empty} if it is not defined
+     */
+    public Optional<String> find(String key) {
+        return Optional.ofNullable(entries.get(key));
+    }
+
+    /**
+     * Returns the view of environment variables.
+     * @return the environment variables
+     */
+    public Map<String, String> entries() {
+        return entries;
+    }
+}

--- a/vanilla/runtime/bootstrap/src/main/java/com/asakusafw/vanilla/bootstrap/ExecutionException.java
+++ b/vanilla/runtime/bootstrap/src/main/java/com/asakusafw/vanilla/bootstrap/ExecutionException.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.bootstrap;
+
+/**
+ * Represents that execution preconditions are not satisfied.
+ * @since 0.5.0
+ */
+public class ExecutionException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Creates a new instance.
+     * @param message the exception message
+     */
+    public ExecutionException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance.
+     * @param message the exception message
+     * @param cause the original cause (nullable)
+     */
+    public ExecutionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/vanilla/runtime/bootstrap/src/main/java/com/asakusafw/vanilla/bootstrap/VanillaBootstrap.java
+++ b/vanilla/runtime/bootstrap/src/main/java/com/asakusafw/vanilla/bootstrap/VanillaBootstrap.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.bootstrap;
+
+import static com.asakusafw.vanilla.bootstrap.CoreConstants.*;
+import static com.asakusafw.vanilla.bootstrap.VanillaConstants.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * A bootstrap entry of Asakusa Vanilla.
+ * @since 0.5.0
+ */
+public class VanillaBootstrap {
+
+    private final Environment environment;
+
+    private final ClassLoader classLoader;
+
+    /**
+     * Creates a new instance.
+     * @param environment the environment variables
+     * @param classLoader the class loader
+     */
+    public VanillaBootstrap(Environment environment, ClassLoader classLoader) {
+        this.environment = environment;
+        this.classLoader = classLoader;
+    }
+
+    /**
+     * Program entry.
+     * @param args the program arguments
+     */
+    public static void main(String... args) {
+        VanillaBootstrap bootstrap = new VanillaBootstrap(Environment.system(), ClassLoader.getSystemClassLoader());
+        bootstrap.exec(Context.parse(args));
+    }
+
+    /**
+     * Executes Vanilla application.
+     * @param context the application context
+     */
+    public void exec(Context context) {
+        Classpath classpath = buildClasspath(context);
+        Arguments arguments = buildArguments(context);
+        classpath.exec(classLoader, CLASS_VANILLA_LAUNCHER, arguments.toArray());
+    }
+
+    private Classpath buildClasspath(Context context) {
+        Classpath cp = new Classpath();
+
+        Path application = getApplication(environment, context.getBatchId());
+        cp.add(getAppJobflowLibFile(application, context.getFlowId()), true);
+        cp.add(application.resolve(PATH_APP_USER_LIB_DIR), false);
+
+        Path home = getHome(environment);
+        cp.add(home.resolve(PATH_VANILLA_CONF_DIR), false);
+        cp.addEntries(home.resolve(PATH_VANILLA_LIB_DIR), true);
+        cp.addEntries(home.resolve(PATH_EXTENSION_LIB_DIR), false);
+        cp.addEntries(home.resolve(PATH_CORE_LIB_DIR), true);
+
+        Path hadoop = home.resolve(PATH_VANILLA_EMBEDDED_HADOOP_LIB_DIR);
+        if (Files.isDirectory(hadoop)) {
+            cp.addEntries(hadoop, false);
+        } else {
+            cp.addEntries(home.resolve(PATH_HADOOP_EMBEDDED_LIB_DIR), true);
+        }
+
+        return cp;
+    }
+
+    private Arguments buildArguments(Context context) {
+        Arguments args = new Arguments();
+
+        args.add(OPT_APPLICATION, context.getApplicationClassName());
+        args.add(OPT_BATCH_ID, context.getBatchId());
+        args.add(OPT_FLOW_ID, context.getFlowId());
+        args.add(OPT_EXECUTION_ID, context.getExecutionId());
+        args.add(OPT_BATCH_ARGUMENTS, context.getBatchArguments());
+
+        Path home = getHome(environment);
+        Optional.of(home.resolve(PATH_CORE_CONF_FILE))
+                .filter(Files::isRegularFile)
+                .ifPresent(it -> args.add(OPT_HADOOP_CONF, OPT_LOCATION_PREFIX + it));
+        Optional.of(home.resolve(PATH_VANILLA_CONF_FILE))
+                .filter(Files::isRegularFile)
+                .ifPresent(it -> args.add(OPT_ENGINE_CONF, OPT_LOCATION_PREFIX + it));
+
+        environment.find(ENV_VANILLA_LAUNCHER_ARGUMENTS)
+                .map(it -> Arrays.stream(it.split("\\s+"))
+                        .map(String::trim)
+                        .filter(s -> s.isEmpty() == false)
+                        .collect(Collectors.toList()))
+                .ifPresent(args::add);
+        args.add(context.getExtraArguments());
+
+        return args;
+    }
+}

--- a/vanilla/runtime/bootstrap/src/main/java/com/asakusafw/vanilla/bootstrap/VanillaConstants.java
+++ b/vanilla/runtime/bootstrap/src/main/java/com/asakusafw/vanilla/bootstrap/VanillaConstants.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.bootstrap;
+
+/**
+ * Constants of Asakusa Vanilla.
+ * @since 0.5.0
+ */
+public final class VanillaConstants {
+
+    /**
+     * The common launcher option name of Hadoop configuration entry.
+     */
+    public static final String OPT_HADOOP_CONF = "--hadoop-conf";
+
+    /**
+     * The common launcher option name of execution engine configuration entry.
+     */
+    public static final String OPT_ENGINE_CONF = "--engine-conf";
+
+    /**
+     * The common launcher option name of application class.
+     */
+    public static final String OPT_APPLICATION = "--client";
+
+    /**
+     * The common launcher option name of batch ID.
+     */
+    public static final String OPT_BATCH_ID = "--batch-id";
+
+    /**
+     * The common launcher option name of flow ID.
+     */
+    public static final String OPT_FLOW_ID = "--flow-id";
+
+    /**
+     * The common launcher option name of execution ID.
+     */
+    public static final String OPT_EXECUTION_ID = "--execution-id";
+
+    /**
+     * The common launcher option name of serialized batch arguments.
+     */
+    public static final String OPT_BATCH_ARGUMENTS = "--batch-arguments";
+
+    /**
+     * The option value prefix of that represents a file location.
+     */
+    public static final String OPT_LOCATION_PREFIX = "@";
+
+
+    static final String PATH_VANILLA_BASE = "vanilla";
+
+    /**
+     * The path of the Vanilla configuration directory.
+     */
+    public static final String PATH_VANILLA_CONF_DIR = PATH_VANILLA_BASE + "/conf";
+
+    /**
+     * The path of the Vanilla engine configuration file.
+     */
+    public static final String PATH_VANILLA_CONF_FILE = PATH_VANILLA_CONF_DIR + "/vanilla.properties";
+
+    /**
+     * The path of the Vanilla engine libraries directory.
+     */
+    public static final String PATH_VANILLA_LIB_DIR = PATH_VANILLA_BASE + "/lib";
+
+    /**
+     * The path of the Vanilla embedded Hadoop libraries directory.
+     */
+    public static final String PATH_VANILLA_EMBEDDED_HADOOP_LIB_DIR = PATH_VANILLA_BASE + "/lib/hadoop";
+
+    /**
+     * The class name of Vanilla launcher class.
+     */
+    public static final String CLASS_VANILLA_LAUNCHER = "com.asakusafw.vanilla.client.VanillaLauncher";
+
+    /**
+     * The environment variable name of extra Vanilla launcher arguments.
+     */
+    public static final String ENV_VANILLA_LAUNCHER_ARGUMENTS = "ASAKUSA_VANILLA_ARGS";
+
+    private VanillaConstants() {
+        return;
+    }
+}

--- a/vanilla/runtime/bootstrap/src/main/java/com/asakusafw/vanilla/bootstrap/package-info.java
+++ b/vanilla/runtime/bootstrap/src/main/java/com/asakusafw/vanilla/bootstrap/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Launches Asakusa Vanilla.
+ */
+package com.asakusafw.vanilla.bootstrap;

--- a/vanilla/runtime/pom.xml
+++ b/vanilla/runtime/pom.xml
@@ -16,5 +16,6 @@
     <module>core</module>
     <module>client</module>
     <module>assembly</module>
+    <module>bootstrap</module>
   </modules>
 </project>


### PR DESCRIPTION
## Summary

This PR enables `asakusa run` command to execute batch applications on Windows platform.

## Background, Problem or Goal of the patch

see asakusafw/asakusafw#752.

## Design of the fix, or a new feature

This includes the following changes:

* remove `.sh` extension from Vanilla command (`vanilla/bin/execute.sh`)
* add `vanilla/bin/execute.cmd`
* fix for upstream change which renames WindGate commands

## Related Issue, Pull Request or Code

* asakusafw/asakusafw#752
