### PR TITLE
Keep parameter names of WindGate vocabularies.

### DIFF
--- a/compiler-project/extension-windgate/src/main/java/com/asakusafw/lang/compiler/extension/windgate/DescriptionModel.java
+++ b/compiler-project/extension-windgate/src/main/java/com/asakusafw/lang/compiler/extension/windgate/DescriptionModel.java
@@ -18,6 +18,8 @@ package com.asakusafw.lang.compiler.extension.windgate;
 import java.io.Serializable;
 import java.text.MessageFormat;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
 
 import com.asakusafw.vocabulary.windgate.WindGateProcessDescription;
 import com.asakusafw.windgate.core.DriverScript;
@@ -34,6 +36,8 @@ public class DescriptionModel implements Serializable {
     private String resourceName;
 
     private HashMap<String, String> configuration;
+
+    private Set<String> parameterNames;
 
     /**
      * for serializers.
@@ -68,6 +72,7 @@ public class DescriptionModel implements Serializable {
         }
         this.resourceName = script.getResourceName();
         this.configuration = new HashMap<>(script.getConfiguration());
+        this.parameterNames = new HashSet<>(script.getParameterNames());
     }
 
     /**
@@ -83,6 +88,6 @@ public class DescriptionModel implements Serializable {
      * @return the driver script
      */
     public DriverScript getDriverScript() {
-        return new DriverScript(resourceName, configuration);
+        return new DriverScript(resourceName, configuration, parameterNames);
     }
 }

--- a/compiler-project/extension-windgate/src/test/java/com/asakusafw/lang/compiler/extension/windgate/WindGatePortProcessorTest.java
+++ b/compiler-project/extension-windgate/src/test/java/com/asakusafw/lang/compiler/extension/windgate/WindGatePortProcessorTest.java
@@ -126,6 +126,40 @@ public class WindGatePortProcessorTest {
     }
 
     /**
+     * input parameters.
+     */
+    @Test
+    public void input_parameters() {
+        DriverScript script = script("r", "k0", "v0");
+        InputDesc desc = new InputDesc(String.class, "p", new DriverScript(
+                script.getResourceName(),
+                script.getConfiguration(),
+                Collections.singleton("testing")));
+        MockExternalPortProcessorContext context = context();
+        WindGatePortProcessor proc = new WindGatePortProcessor();
+
+        ExternalInputInfo info = proc.analyzeInput(context, "t", desc);
+        assertThat(info.getParameterNames(), contains("testing"));
+    }
+
+    /**
+     * output parameters.
+     */
+    @Test
+    public void output_parameters() {
+        DriverScript script = script("r", "k0", "v0");
+        OutputDesc desc = new OutputDesc(String.class, "p", new DriverScript(
+                script.getResourceName(),
+                script.getConfiguration(),
+                Collections.singleton("testing")));
+        MockExternalPortProcessorContext context = context();
+        WindGatePortProcessor proc = new WindGatePortProcessor();
+
+        ExternalOutputInfo info = proc.analyzeOutput(context, "t", desc);
+        assertThat(info.getParameterNames(), contains("testing"));
+    }
+
+    /**
      * invalid input.
      */
     @Test(expected = DiagnosticException.class)


### PR DESCRIPTION
## Summary

This PR fixes bug of missing parameter information of WindGate I/O.

## Background, Problem or Goal of the patch

`asakusa list parameter` does not show implicitly referred parameters in WindGate.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.