### PR TITLE
Introduce `TemporaryFile{Input,Output}Format`.

### DIFF
--- a/bridge-project/runtime-hadoop/src/main/java/com/asakusafw/bridge/hadoop/temporary/TemporaryFileInputFormat.java
+++ b/bridge-project/runtime-hadoop/src/main/java/com/asakusafw/bridge/hadoop/temporary/TemporaryFileInputFormat.java
@@ -1,0 +1,273 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.bridge.hadoop.temporary;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.hadoop.util.StringUtils;
+
+import com.asakusafw.runtime.directio.DirectInputFragment;
+import com.asakusafw.runtime.directio.hadoop.BlockInfo;
+import com.asakusafw.runtime.directio.hadoop.BlockMap;
+import com.asakusafw.runtime.stage.temporary.TemporaryFile;
+import com.asakusafw.runtime.stage.temporary.TemporaryFileInput;
+
+/**
+ * A temporary input format.
+ * @param <T> data type
+ * @since 0.5.0
+ */
+public final class TemporaryFileInputFormat<T> extends FileInputFormat<NullWritable, T> {
+
+    static final Log LOG = LogFactory.getLog(TemporaryFileInputFormat.class);
+
+    static final String KEY_DEFAULT_SPLIT_SIZE = "com.asakusafw.stage.input.temporary.blockSize"; //$NON-NLS-1$
+
+    static final long DEFAULT_SPLIT_SIZE = 128L * 1024 * 1024;
+
+    /**
+     * Sets the input paths.
+     * @param conf the configuration
+     * @param expressions the path expressions
+     * @throws IOException if I/O error was occurred
+     */
+    public static void setInputPaths(Configuration conf, Path... expressions) throws IOException {
+        StringBuilder buf = new StringBuilder();
+        for (Path path : expressions) {
+            Path q = path.getFileSystem(conf).makeQualified(path);
+            if (buf.length() != 0) {
+                buf.append(',');
+            }
+            buf.append(StringUtils.escapeString(q.toString()));
+        }
+        conf.set(INPUT_DIR, buf.toString());
+    }
+
+    @Override
+    public List<InputSplit> getSplits(JobContext context) throws IOException {
+        return getSplits(
+                context.getConfiguration(),
+                Optional.ofNullable(FileInputFormat.getInputPaths(context))
+                        .map(Arrays::asList)
+                        .orElse(Collections.emptyList()));
+    }
+
+    private static List<InputSplit> getSplits(Configuration configuration, List<Path> paths) throws IOException {
+        long splitSize = configuration.getLong(KEY_DEFAULT_SPLIT_SIZE, DEFAULT_SPLIT_SIZE);
+        List<InputSplit> results = new ArrayList<>();
+        for (Path path : paths) {
+            FileSystem fs = path.getFileSystem(configuration);
+            FileStatus[] statuses = fs.globStatus(path);
+            if (statuses == null) {
+                continue;
+            }
+            for (FileStatus status : statuses) {
+                BlockMap blockMap = BlockMap.create(
+                        status.getPath().toString(),
+                        status.getLen(),
+                        BlockMap.computeBlocks(fs, status),
+                        false);
+                results.addAll(computeSplits(status.getPath(), blockMap, splitSize));
+            }
+        }
+        return results;
+    }
+
+    /**
+     * Compute input splits for the target file.
+     * @param path the target file path
+     * @param blockMap the file block map
+     * @param splitSize the expected split size, or {@code <= 0} to prevent splits
+     * @return the computed input splits for the file
+     */
+    static List<FileSplit> computeSplits(Path path, BlockMap blockMap, long splitSize) {
+        long align = splitSize;
+        if (splitSize > 0) {
+            long remain = splitSize % TemporaryFile.BLOCK_SIZE;
+            if (remain != 0) {
+                align += TemporaryFile.BLOCK_SIZE - remain;
+            }
+        }
+        long size = blockMap.getFileSize();
+        long start = 0;
+        List<FileSplit> results = new ArrayList<>();
+        for (BlockInfo block : blockMap.getBlocks()) {
+            assert start % TemporaryFile.BLOCK_SIZE == 0;
+            long end = block.getEnd();
+            if (end < start) {
+                continue;
+            }
+            long remain = end % TemporaryFile.BLOCK_SIZE;
+            if (remain != 0) {
+                end = Math.min(size, end + (TemporaryFile.BLOCK_SIZE - remain));
+            }
+            results.addAll(createSplits(path, blockMap, start, end, align));
+            start = end;
+        }
+        return results;
+    }
+
+    private static List<FileSplit> createSplits(
+            Path path, BlockMap blockMap, long start, long end, long splitSize) {
+        if (start >= end) {
+            return Collections.emptyList();
+        }
+        if (splitSize <= 0) {
+            FileSplit split = getSplit(blockMap, path, start, end);
+            return Collections.singletonList(split);
+        }
+        long threashold = (long) (splitSize * 1.2);
+        List<FileSplit> results = new ArrayList<>();
+        long current = start;
+        while (current < end) {
+            long next;
+            if (end - current < threashold) {
+                next = end;
+            } else {
+                next = current + splitSize;
+            }
+            FileSplit split = getSplit(blockMap, path, current, next);
+            results.add(split);
+            current = next;
+        }
+        return results;
+    }
+
+    private static FileSplit getSplit(BlockMap blockMap, Path path, long start, long end) {
+        DirectInputFragment f = blockMap.get(start, end);
+        List<String> owners = f.getOwnerNodeNames();
+        FileSplit split = new FileSplit(
+                path, start, end - start,
+                owners.toArray(new String[owners.size()]));
+        return split;
+    }
+
+    @Override
+    public RecordReader<NullWritable, T> createRecordReader(
+            InputSplit split,
+            TaskAttemptContext context) throws IOException, InterruptedException {
+        FileSplit s = (FileSplit) split;
+        assert s.getStart() % TemporaryFile.BLOCK_SIZE == 0;
+        assert s.getStart() > 0 || s.getLength() > 0;
+        return createRecordReader();
+    }
+
+    /**
+     * Create a record reader for this input format.
+     * @param <T> the value type
+     * @return the record reader
+     */
+    @SuppressWarnings("unchecked")
+    static <T> RecordReader<NullWritable, T> createRecordReader() {
+        return (RecordReader<NullWritable, T>) new Reader<>();
+    }
+
+    private static final class Reader<T extends Writable> extends RecordReader<NullWritable, T> {
+
+        private long size;
+
+        private TemporaryFileInput<T> input;
+
+        private T value;
+
+        Reader() {
+            return;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
+            FileSplit s = (FileSplit) split;
+            this.size = s.getLength();
+            Path path = s.getPath();
+            FileSystem fs = path.getFileSystem(context.getConfiguration());
+            int blocks = computeBlocks(s);
+            FSDataInputStream stream = fs.open(path);
+            boolean succeed = false;
+            try {
+                if (s.getStart() != 0) {
+                    assert s.getStart() % TemporaryFile.BLOCK_SIZE == 0;
+                    stream.seek(s.getStart());
+                }
+                this.input = (TemporaryFileInput<T>) new TemporaryFileInput<>(stream, blocks);
+                Class<?> aClass = context.getConfiguration().getClassByName(input.getDataTypeName());
+                this.value = (T) ReflectionUtils.newInstance(aClass, context.getConfiguration());
+                succeed = true;
+            } catch (ClassNotFoundException e) {
+                throw new IOException(e);
+            } finally {
+                if (succeed == false) {
+                    stream.close();
+                }
+            }
+        }
+
+        private int computeBlocks(FileSplit s) {
+            long length = s.getLength() + TemporaryFile.BLOCK_SIZE - 1;
+            return (int) (length / TemporaryFile.BLOCK_SIZE);
+        }
+
+        @Override
+        public boolean nextKeyValue() throws IOException, InterruptedException {
+            return input.readTo(value);
+        }
+
+        @Override
+        public NullWritable getCurrentKey() throws IOException, InterruptedException {
+            return NullWritable.get();
+        }
+
+        @Override
+        public T getCurrentValue() throws IOException, InterruptedException {
+            return value;
+        }
+
+        @Override
+        public float getProgress() throws IOException, InterruptedException {
+            long current = input.getCurrentBlock() * (long) TemporaryFile.BLOCK_SIZE;
+            current += input.getPositionInBlock();
+            return (float) current / size;
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (input != null) {
+                input.close();
+            }
+        }
+    }
+}

--- a/bridge-project/runtime-hadoop/src/main/java/com/asakusafw/bridge/hadoop/temporary/TemporaryFileOutputFormat.java
+++ b/bridge-project/runtime-hadoop/src/main/java/com/asakusafw/bridge/hadoop/temporary/TemporaryFileOutputFormat.java
@@ -53,7 +53,7 @@ public final class TemporaryFileOutputFormat<T> extends FileOutputFormat<NullWri
     public static final String DEFAULT_FILE_NAME = PART;
 
     /**
-     * Sets the output directory
+     * Sets the output directory.
      * @param conf the current configuration
      * @param directory the target directory
      * @throws IOException if I/O error was occurred

--- a/bridge-project/runtime-hadoop/src/main/java/com/asakusafw/bridge/hadoop/temporary/TemporaryFileOutputFormat.java
+++ b/bridge-project/runtime-hadoop/src/main/java/com/asakusafw/bridge/hadoop/temporary/TemporaryFileOutputFormat.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.bridge.hadoop.temporary;
+
+import java.io.IOException;
+import java.text.MessageFormat;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+import org.apache.hadoop.mapreduce.security.TokenCache;
+
+import com.asakusafw.runtime.io.ModelOutput;
+import com.asakusafw.runtime.stage.temporary.TemporaryStorage;
+
+/**
+ * A temporary output format.
+ * @param <T> target type
+ * @since 0.5.0
+ */
+public final class TemporaryFileOutputFormat<T> extends FileOutputFormat<NullWritable, T> {
+
+    static final Log LOG = LogFactory.getLog(TemporaryFileOutputFormat.class);
+
+    /**
+     * The Hadoop property key of output name prefix.
+     */
+    public static final String KEY_FILE_NAME = BASE_OUTPUT_NAME;
+
+    /**
+     * The default output name prefix.
+     */
+    public static final String DEFAULT_FILE_NAME = PART;
+
+    /**
+     * Sets the output directory
+     * @param conf the current configuration
+     * @param directory the target directory
+     * @throws IOException if I/O error was occurred
+     */
+    public static void setOutputPath(Configuration conf, Path directory) throws IOException {
+        Path q = directory.getFileSystem(conf).makeQualified(directory);
+        conf.set(OUTDIR, q.toString());
+      }
+
+    @Override
+    public void checkOutputSpecs(JobContext context) throws IOException {
+        Path path = getOutputPath(context);
+        if (path == null) {
+            throw new IOException("Temporary output path is not set");
+        }
+        TokenCache.obtainTokensForNamenodes(
+                context.getCredentials(),
+                new Path[] { path },
+                context.getConfiguration());
+        if (path.getFileSystem(context.getConfiguration()).exists(path)) {
+            throw new IOException(MessageFormat.format(
+                    "Output directory {0} already exists",
+                    path));
+        }
+    }
+
+    @Override
+    public RecordWriter<NullWritable, T> getRecordWriter(
+            TaskAttemptContext context) throws IOException, InterruptedException {
+        @SuppressWarnings("unchecked")
+        Class<T> valueClass = (Class<T>) context.getOutputValueClass();
+        String name = context.getConfiguration().get(KEY_FILE_NAME, DEFAULT_FILE_NAME);
+        return createRecordWriter(context, name, valueClass);
+    }
+
+    /**
+     * Creates a new {@link RecordWriter} to output temporary data.
+     * @param <V> value type
+     * @param context current context
+     * @param name output name
+     * @param dataType value type
+     * @return the created writer
+     * @throws IOException if failed to create a new {@link RecordWriter}
+     * @throws InterruptedException if interrupted
+     */
+    public <V> RecordWriter<NullWritable, V> createRecordWriter(
+            TaskAttemptContext context,
+            String name,
+            Class<V> dataType) throws IOException, InterruptedException {
+        Configuration conf = context.getConfiguration();
+        FileOutputCommitter committer = (FileOutputCommitter) getOutputCommitter(context);
+        Path file = new Path(
+                committer.getWorkPath(),
+                FileOutputFormat.getUniqueFile(context, name, "")); //$NON-NLS-1$
+        ModelOutput<V> out = TemporaryStorage.openOutput(conf, dataType, file);
+        return new RecordWriter<NullWritable, V>() {
+            @Override
+            public void write(NullWritable key, V value) throws IOException {
+                out.write(value);
+            }
+            @Override
+            public void close(TaskAttemptContext ignored) throws IOException {
+                out.close();
+            }
+            @Override
+            public String toString() {
+                return String.format("TemporaryOutput(%s)", file); //$NON-NLS-1$
+            }
+        };
+    }
+}

--- a/bridge-project/runtime-hadoop/src/main/java/com/asakusafw/bridge/hadoop/temporary/package-info.java
+++ b/bridge-project/runtime-hadoop/src/main/java/com/asakusafw/bridge/hadoop/temporary/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Classes for cross phase temporary file format.
+ */
+package com.asakusafw.bridge.hadoop.temporary;

--- a/bridge-project/runtime-hadoop/src/test/java/com/asakusafw/bridge/hadoop/temporary/TemporaryFileInputFormatTest.java
+++ b/bridge-project/runtime-hadoop/src/test/java/com/asakusafw/bridge/hadoop/temporary/TemporaryFileInputFormatTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.bridge.hadoop.temporary;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.asakusafw.lang.compiler.mapreduce.testing.InputFormatTester;
+import com.asakusafw.lang.compiler.mapreduce.testing.mock.MockData;
+import com.asakusafw.runtime.io.ModelOutput;
+import com.asakusafw.runtime.stage.temporary.TemporaryStorage;
+import com.asakusafw.runtime.windows.WindowsConfigurator;
+
+/**
+ * Test for {@link TemporaryFileInputFormat}.
+ */
+public class TemporaryFileInputFormatTest {
+
+    static {
+        WindowsConfigurator.install();
+    }
+
+    /**
+     * temporary folder.
+     */
+    @Rule
+    public final TemporaryFolder temporary = new TemporaryFolder();
+
+    private final Configuration conf = new Configuration();
+
+    /**
+     * simple case.
+     * @throws Exception if failed
+     */
+    @Test
+    public void simple() throws Exception {
+        File folder = temporary.newFolder();
+        File file = new File(folder, "part-testing");
+        try (ModelOutput<MockData> out = open(new Path(file.toURI()))) {
+            MockData.put(out, "Hello0", "Hello1", "Hello2");
+        }
+        Map<Integer, String> results = collect(new Path(file.toURI()));
+        assertThat(results.keySet(), hasSize(3));
+        assertThat(results, hasEntry(0, "Hello0"));
+        assertThat(results, hasEntry(1, "Hello1"));
+        assertThat(results, hasEntry(2, "Hello2"));
+    }
+
+    private ModelOutput<MockData> open(Path path) throws IOException {
+        return TemporaryStorage.openOutput(conf, MockData.class, path);
+    }
+
+    private Map<Integer, String> collect(Path... expr) throws IOException, InterruptedException {
+        TemporaryFileInputFormat.setInputPaths(conf, expr);
+        InputFormatTester tester = new InputFormatTester(conf, TemporaryFileInputFormat.class);
+        Map<Integer, String> results = new LinkedHashMap<>();
+        tester.collect((MockData object) -> results.put(object.getKey(), object.getValue()));
+        return results;
+    }
+}

--- a/bridge-project/runtime-hadoop/src/test/java/com/asakusafw/bridge/hadoop/temporary/TemporaryFileOutputFormatTest.java
+++ b/bridge-project/runtime-hadoop/src/test/java/com/asakusafw/bridge/hadoop/temporary/TemporaryFileOutputFormatTest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.bridge.hadoop.temporary;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.asakusafw.lang.compiler.mapreduce.testing.OutputFormatTester;
+import com.asakusafw.lang.compiler.mapreduce.testing.mock.MockData;
+import com.asakusafw.runtime.io.ModelInput;
+import com.asakusafw.runtime.io.ModelOutput;
+import com.asakusafw.runtime.stage.temporary.TemporaryStorage;
+import com.asakusafw.runtime.windows.WindowsConfigurator;
+
+/**
+ * Test for {@link TemporaryFileOutputFormat}.
+ */
+public class TemporaryFileOutputFormatTest {
+
+    static {
+        WindowsConfigurator.install();
+    }
+
+    /**
+     * temporary folder.
+     */
+    @Rule
+    public final TemporaryFolder temporary = new TemporaryFolder();
+
+    private final Configuration conf = new Configuration();
+
+    /**
+     * simple case.
+     * @throws Exception if failed
+     */
+    @Test
+    public void simple() throws Exception {
+        File folder = temporary.newFolder();
+        Assume.assumeTrue(folder.delete());
+        try (ModelOutput<MockData> out = open(new Path(folder.toURI()))) {
+            MockData.put(out, "Hello0", "Hello1", "Hello2");
+        }
+        Map<Integer, String> results = collect(folder);
+        assertThat(results.keySet(), hasSize(3));
+        assertThat(results, hasEntry(0, "Hello0"));
+        assertThat(results, hasEntry(1, "Hello1"));
+        assertThat(results, hasEntry(2, "Hello2"));
+    }
+
+    private ModelOutput<MockData> open(Path directory) throws IOException, InterruptedException {
+        TemporaryFileOutputFormat.setOutputPath(conf, directory);
+        OutputFormatTester tester = new OutputFormatTester(conf, TemporaryFileOutputFormat.class);
+        return tester.open();
+    }
+
+    private Map<Integer, String> collect(File directory) throws IOException {
+        Map<Integer, String> results = new LinkedHashMap<>();
+        for (File f : Optional.ofNullable(
+                directory.listFiles(f -> f.isFile() && f.getName().startsWith("part-")))
+                .orElseThrow(AssertionError::new)) {
+            try (ModelInput<MockData> in = TemporaryStorage.openInput(conf, MockData.class, new Path(f.toURI()))) {
+                results.putAll(MockData.collect(in));
+            }
+        }
+        return results;
+    }
+}

--- a/compiler-project/extension-test-moderator/pom.xml
+++ b/compiler-project/extension-test-moderator/pom.xml
@@ -98,6 +98,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.asakusafw.bridge</groupId>
+      <artifactId>asakusa-bridge-runtime-hadoop</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime</artifactId>
       <classifier>tests</classifier>

--- a/compiler-project/mapreduce-testing/src/main/java/com/asakusafw/lang/compiler/mapreduce/testing/InputFormatTester.java
+++ b/compiler-project/mapreduce-testing/src/main/java/com/asakusafw/lang/compiler/mapreduce/testing/InputFormatTester.java
@@ -87,32 +87,12 @@ public class InputFormatTester {
         }
     }
 
-    private InputSplit restore(InputSplit split) throws IOException {
+    private static InputSplit restore(InputSplit split) throws IOException {
         if (split instanceof Writable) {
             DataBuffer buffer = new DataBuffer();
             ((Writable) split).write(buffer);
             ((Writable) split).readFields(buffer);
         }
         return split;
-    }
-
-    /**
-     * Collects values from {@code InputFormat}.
-     * @param <T> the value type
-     * @deprecated Use {@link Consumer} instead
-     */
-    @Deprecated
-    public interface Collector<T> extends Consumer<T> {
-
-        /**
-         * Handles an object.
-         * @param object the target
-         */
-        void handle(T object);
-
-        @Override
-        default void accept(T t) {
-            handle(t);
-        }
     }
 }

--- a/compiler-project/mapreduce-testing/src/main/java/com/asakusafw/lang/compiler/mapreduce/testing/OutputFormatTester.java
+++ b/compiler-project/mapreduce-testing/src/main/java/com/asakusafw/lang/compiler/mapreduce/testing/OutputFormatTester.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.compiler.mapreduce.testing;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.OutputFormat;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
+import org.apache.hadoop.mapreduce.TaskType;
+import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
+import org.apache.hadoop.util.ReflectionUtils;
+
+import com.asakusafw.runtime.io.ModelOutput;
+import com.asakusafw.runtime.windows.WindowsConfigurator;
+
+/**
+ * Testing utilities for {@link OutputFormat}.
+ * @since 0.5.0
+ */
+public class OutputFormatTester {
+
+    static {
+        WindowsConfigurator.install();
+    }
+
+    private final OutputFormat<?, ?> format;
+
+    private final Configuration conf;
+
+    /**
+     *
+     * Creates a new instance.
+     * @param conf the current configuration
+     * @param format the target format class
+     */
+    public OutputFormatTester(Configuration conf, Class<?> format) {
+        this.conf = conf;
+        this.format = (OutputFormat<?, ?>) ReflectionUtils.newInstance(format, conf);
+    }
+
+    /**
+     * Write a series of records.
+     * @param <T> the record type
+     * @return the output sink
+     * @throws IOException if failed
+     * @throws InterruptedException if interrupted
+     */
+    public <T> ModelOutput<T> open() throws IOException, InterruptedException {
+        TaskAttemptContext context = new TaskAttemptContextImpl(conf, new TaskAttemptID("t", 0, TaskType.MAP, 0, 0));
+        format.checkOutputSpecs(context);
+
+        OutputCommitter committer = format.getOutputCommitter(context);
+        committer.setupJob(context);
+        committer.setupTask(context);
+        @SuppressWarnings("unchecked")
+        RecordWriter<Object, T> writer = (RecordWriter<Object, T>) format.getRecordWriter(context);
+        return new ModelOutput<T>() {
+            @Override
+            public void write(T model) throws IOException {
+                try {
+                    writer.write(NullWritable.get(), model);
+                } catch (InterruptedException e) {
+                    throw new AssertionError(e);
+                }
+            }
+            @Override
+            public void close() throws IOException {
+                try {
+                    writer.close(context);
+                } catch (InterruptedException e) {
+                    throw new AssertionError(e);
+                }
+                committer.commitTask(context);
+                committer.commitJob(context);
+            }
+        };
+    }
+}

--- a/compiler-project/test-adapter/pom.xml
+++ b/compiler-project/test-adapter/pom.xml
@@ -68,6 +68,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.asakusafw.bridge</groupId>
+      <artifactId>asakusa-bridge-runtime-hadoop</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.asakusafw</groupId>
       <artifactId>simple-graph</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
## Summary

This PR introduces `TemporaryFile{Input,Output}Format` which are alternatives of `Temporary{Input,Output}Format`. These are inherit standard `File{Input,Output}Format` for newer Spark runtimes.

## Background, Problem or Goal of the patch

The existing `Temporary{Input,Output}Format` does not work correct on Spark `>= 2.2`. It seems that the Spark requires each input/output format inherits standard `File{Input,Output}Format`. Then we have introduced `TemporaryFile{Input,Output}Format`. These are almost compatible the existing format pair, but the introduced may not work with MapReduce `Multiple{Inputs,Outputs}` correctly.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.