### PR TITLE
Asakusa Vanilla organizer should be enabled in default.

### DIFF
--- a/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaOrganizerPlugin.groovy
+++ b/vanilla/gradle/src/main/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaOrganizerPlugin.groovy
@@ -63,7 +63,7 @@ class AsakusaVanillaOrganizerPlugin implements Plugin<Project> {
         AsakusafwOrganizerPluginConvention convention = project.asakusafwOrganizer
         AsakusafwOrganizerVanillaExtension extension = convention.extensions.create('vanilla', AsakusafwOrganizerVanillaExtension)
         extension.conventionMapping.with {
-            enabled = { false }
+            enabled = { true }
         }
         PluginUtils.injectVersionProperty(extension, { base.featureVersion })
     }

--- a/vanilla/gradle/src/test/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaOrganizerPluginTest.groovy
+++ b/vanilla/gradle/src/test/groovy/com/asakusafw/vanilla/gradle/plugins/internal/AsakusaVanillaOrganizerPluginTest.groovy
@@ -65,15 +65,15 @@ class AsakusaVanillaOrganizerPluginTest {
         AsakusafwOrganizerVanillaExtension extension = root.vanilla
         assert extension != null
 
-        assert extension.enabled == false
+        assert extension.enabled == true
 
-        assert root.profiles.dev.vanilla.enabled == false
-        assert root.profiles.prod.vanilla.enabled == false
+        assert root.profiles.dev.vanilla.enabled == true
+        assert root.profiles.prod.vanilla.enabled == true
 
         root.profiles.testing {
             // ok
         }
-        assert root.profiles.testing.vanilla.enabled == false
+        assert root.profiles.testing.vanilla.enabled == true
     }
 
     /**
@@ -96,20 +96,20 @@ class AsakusaVanillaOrganizerPluginTest {
         AsakusafwOrganizerPluginConvention root = project.asakusafwOrganizer
         AsakusafwOrganizerVanillaExtension extension = root.vanilla
 
-        extension.enabled = true
+        extension.enabled = false
 
-        assert root.profiles.dev.vanilla.enabled == true
-        assert root.profiles.prod.vanilla.enabled == true
-
-        root.profiles.prod.vanilla.enabled = false
-        assert extension.enabled == true
-        assert root.profiles.dev.vanilla.enabled == true
+        assert root.profiles.dev.vanilla.enabled == false
         assert root.profiles.prod.vanilla.enabled == false
+
+        root.profiles.prod.vanilla.enabled = true
+        assert extension.enabled == false
+        assert root.profiles.dev.vanilla.enabled == false
+        assert root.profiles.prod.vanilla.enabled == true
 
         root.profiles.testing {
             // ok
         }
-        assert root.profiles.testing.vanilla.enabled == true
+        assert root.profiles.testing.vanilla.enabled == false
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR enables Asakusa Vanilla organizer even if `asakusafwOrganizer.vanilla.enabled true` was not set.

## Background, Problem or Goal of the patch

The latest implementation, enabling Asakusa Vanilla applications was required two steps:
1. `apply: 'asakusafw-vanilla'`
2. `asakusafwOrganizer.vanilla.enabled true`

It is because the Asakusa Vanilla testkit had been required the above first step, but the testkit was enabled without the first step in the latest version (`0.10.0`).

This PR removes the second step to obtain the Asakusa Vanilla applications, and change the default value of `asakusafwOrganizer.vanilla.enabled` to `true`.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.