### PR TITLE
Enable `Connectivity` option for operator output ports.

### DIFF
--- a/compiler-project/analyzer/src/main/java/com/asakusafw/lang/compiler/analyzer/FlowGraphVerifier.java
+++ b/compiler-project/analyzer/src/main/java/com/asakusafw/lang/compiler/analyzer/FlowGraphVerifier.java
@@ -86,10 +86,6 @@ public final class FlowGraphVerifier {
     }
 
     private void verifyElement(FlowElement element) {
-        Connectivity connectivity = element.getAttribute(Connectivity.class);
-        if (connectivity == null) {
-            connectivity = Connectivity.getDefault();
-        }
         element.getInputPorts().stream()
                 .filter(it -> it.getConnected().isEmpty())
                 .forEach(it -> context.error(MessageFormat.format(


### PR DESCRIPTION
## Summary

This PR enables `Connectivity` attribute for individual output ports. It suppresses errors that an output port does not connect to any opposites.

## Background, Problem or Goal of the patch

Generally, all output ports of operators must be connected to other operators' input ports, but operators with `Connectivity.OPTIONAL` can have outputs without any opposites.

This commit also enables their output ports to have `Connectivity` attributes.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw#801
