### PR TITLE
Check operator graph invariant in FlowPartTester.

### DIFF
--- a/compiler-project/test-adapter/src/main/java/com/asakusafw/lang/compiler/testdriver/adapter/CompilerSessionAdapter.java
+++ b/compiler-project/test-adapter/src/main/java/com/asakusafw/lang/compiler/testdriver/adapter/CompilerSessionAdapter.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import com.asakusafw.lang.compiler.analyzer.FlowGraphVerifier;
 import com.asakusafw.lang.compiler.api.reference.CommandTaskReference;
 import com.asakusafw.lang.compiler.api.reference.JobflowReference;
 import com.asakusafw.lang.compiler.api.reference.TaskReference;
@@ -128,6 +129,7 @@ class CompilerSessionAdapter implements CompilerSession {
         }
         try (CompilerTester tester = configuration.start(flow.getClass())) {
             FlowGraph graph = ((FlowPortMapAdapter) portMap).resolve(flow);
+            FlowGraphVerifier.verify(graph);
             OperatorGraph analyzed = analyzeFlow(tester, flow, graph);
             JobflowInfo info = new JobflowInfo.Basic("flowpart", Descriptions.classOf(flow.getClass())); //$NON-NLS-1$
             Jobflow jobflow = new Jobflow(info, analyzed);


### PR DESCRIPTION
## Summary

This PR fixes `FlowPartTester` which should check operator graph invariant (e.g. each output port should connects to opposites).

## Background, Problem or Goal of the patch

`FlowPartTester` does not invoke `FlowGraphVerifier` which verifies `FlowGraph` invariants. Note that, `JobflowTester` and `BatchTester` checks correctly.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.