### PR TITLE
`asakusa run` on win cannot load libs in src/main/libs.

### DIFF
--- a/vanilla/runtime/bootstrap/src/main/java/com/asakusafw/vanilla/bootstrap/VanillaBootstrap.java
+++ b/vanilla/runtime/bootstrap/src/main/java/com/asakusafw/vanilla/bootstrap/VanillaBootstrap.java
@@ -68,7 +68,7 @@ public class VanillaBootstrap {
 
         Path application = getApplication(environment, context.getBatchId());
         cp.add(getAppJobflowLibFile(application, context.getFlowId()), true);
-        cp.add(application.resolve(PATH_APP_USER_LIB_DIR), false);
+        cp.addEntries(application.resolve(PATH_APP_USER_LIB_DIR), false);
 
         Path home = getHome(environment);
         cp.add(home.resolve(PATH_VANILLA_CONF_DIR), false);


### PR DESCRIPTION
## Summary

This PR fixes `asakusa run` command on Windows cannot load JAR files in batch shared libraries (originally in `src/main/libs`).

## Background, Problem or Goal of the patch

See asakusafw/asakusafw#813.

## Design of the fix, or a new feature

This commit is only for `asakusa run` for Asakusa Vanilla tasks.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw#813
