### PR TITLE
Avoid cyclic dependencies between broadcasts.

### DIFF
--- a/compiler-project/common/src/main/java/com/asakusafw/lang/compiler/common/Adaptable.java
+++ b/compiler-project/common/src/main/java/com/asakusafw/lang/compiler/common/Adaptable.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2011-2018 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.compiler.common;
+
+import java.util.Optional;
+
+/**
+ * An adaptable object.
+ * @since 0.5.2
+ */
+public interface Adaptable {
+
+    /**
+     * Returns an adapter object for this.
+     * @param <T> the adapter type
+     * @param type the adapter type
+     * @return the target adapter object for the type
+     */
+    default <T> Optional<T> findAdapter(Class<T> type) {
+        if (type.isInstance(this)) {
+            return Optional.of(type.cast(this));
+        }
+        return Optional.empty();
+    }
+}

--- a/compiler-project/common/src/main/java/com/asakusafw/lang/compiler/common/Adaptables.java
+++ b/compiler-project/common/src/main/java/com/asakusafw/lang/compiler/common/Adaptables.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2011-2018 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.lang.compiler.common;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * Utilities for {@link Adaptable}.
+ * @since 0.5.2
+ */
+public final class Adaptables {
+
+    private Adaptables() {
+        return;
+    }
+
+    /**
+     * Returns an adapter from the given stream.
+     * @param <T> the adapter type
+     * @param type the adapter type
+     * @param self the self object
+     * @param elements the source stream
+     * @return an adapter
+     */
+    public static <T> Optional<T> find(Class<T> type, Adaptable self, Stream<?> elements) {
+        if (type.isInstance(self)) {
+            return Optional.of(type.cast(self));
+        }
+        return find(type, elements);
+    }
+
+    /**
+     * Returns an adapter from the given stream.
+     * @param <T> the adapter type
+     * @param type the adapter type
+     * @param source the source stream
+     * @return an adapter
+     */
+    public static <T> Optional<T> find(Class<T> type, Stream<?> source) {
+        return source
+                .flatMap(it -> {
+                    if (type.isInstance(it)) {
+                        return Stream.of(type.cast(it));
+                    }
+                    if (it instanceof Adaptable) {
+                        return ((Adaptable) it).findAdapter(type)
+                                .map(Stream::of)
+                                .orElse(Stream.empty());
+                    }
+                    return Stream.empty();
+                })
+                .findFirst();
+    }
+}

--- a/compiler-project/common/src/main/java/com/asakusafw/lang/compiler/common/BasicDiagnostic.java
+++ b/compiler-project/common/src/main/java/com/asakusafw/lang/compiler/common/BasicDiagnostic.java
@@ -16,6 +16,9 @@
 package com.asakusafw.lang.compiler.common;
 
 import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * A basic implementation of {@link Diagnostic}.
@@ -30,6 +33,8 @@ public final class BasicDiagnostic implements Diagnostic {
 
     private Exception cause;
 
+    private transient List<Object> adapters;
+
     /**
      * Creates a new instance for serializer.
      */
@@ -43,8 +48,7 @@ public final class BasicDiagnostic implements Diagnostic {
      * @param message the diagnostic message
      */
     public BasicDiagnostic(Level level, String message) {
-        this.level = level;
-        this.message = message;
+        this(level, message, null);
     }
 
     /**
@@ -72,6 +76,24 @@ public final class BasicDiagnostic implements Diagnostic {
     @Override
     public Exception getException() {
         return cause;
+    }
+
+    /**
+     * Adds an adapter object.
+     * @param adapter adapter object
+     * @return this
+     */
+    public BasicDiagnostic with(Object adapter) {
+        if (adapters == null) {
+            adapters = new ArrayList<>();
+        }
+        adapters.add(adapter);
+        return this;
+    }
+
+    @Override
+    public <T> Optional<T> findAdapter(Class<T> type) {
+        return Adaptables.find(type, this, adapters.stream());
     }
 
     @Override

--- a/compiler-project/common/src/main/java/com/asakusafw/lang/compiler/common/Diagnostic.java
+++ b/compiler-project/common/src/main/java/com/asakusafw/lang/compiler/common/Diagnostic.java
@@ -19,8 +19,10 @@ import java.io.Serializable;
 
 /**
  * Represents a diagnostic information.
+ * @since 0.1.0
+ * @version 0.5.2
  */
-public interface Diagnostic extends Serializable {
+public interface Diagnostic extends Serializable, Adaptable {
 
     /**
      * Returns the severity of this.

--- a/compiler-project/common/src/main/java/com/asakusafw/lang/compiler/common/DiagnosticException.java
+++ b/compiler-project/common/src/main/java/com/asakusafw/lang/compiler/common/DiagnosticException.java
@@ -20,12 +20,13 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Represents an exception with {@link Diagnostic}s.
  * The compiler may throw this exception from anywhere.
  */
-public class DiagnosticException extends RuntimeException {
+public class DiagnosticException extends RuntimeException implements Adaptable {
 
     private static final long serialVersionUID = 1L;
 
@@ -121,5 +122,10 @@ public class DiagnosticException extends RuntimeException {
             }
         }
         return null;
+    }
+
+    @Override
+    public <T> Optional<T> findAdapter(Class<T> type) {
+        return Adaptables.find(type, this, Arrays.stream(diagnostics));
     }
 }

--- a/compiler-project/inspection/src/main/java/com/asakusafw/lang/compiler/inspection/InspectionExtension.java
+++ b/compiler-project/inspection/src/main/java/com/asakusafw/lang/compiler/inspection/InspectionExtension.java
@@ -15,6 +15,7 @@
  */
 package com.asakusafw.lang.compiler.inspection;
 
+import java.nio.file.Path;
 import java.text.MessageFormat;
 
 import org.slf4j.Logger;
@@ -26,10 +27,12 @@ import com.asakusafw.lang.compiler.common.Location;
 
 /**
  * A compiler extension for inspecting support.
+ * @since 0.1.0
+ * @version 0.5.2
  */
 public abstract class InspectionExtension {
 
-    static final Logger LOG = LoggerFactory.getLogger(InspectionExtension.class);
+    private static final Logger LOG = LoggerFactory.getLogger(InspectionExtension.class);
 
     /**
      * Inspects the target element only if inspection is supported in this session.
@@ -54,6 +57,28 @@ public abstract class InspectionExtension {
     }
 
     /**
+     * Inspects the target element only if inspection is supported in this session.
+     * @param extensions the extension container
+     * @param path the output path of inspection information
+     * @param element the target element
+     * @throws DiagnosticException if failed to inspect the target element
+     */
+    public static void inspect(ExtensionContainer extensions, Path path, Object element) {
+        InspectionExtension extension = extensions.getExtension(InspectionExtension.class);
+        if (extension == null) {
+            LOG.warn("inspection support is not enabled");
+            return;
+        }
+        if (extension.isSupported(element) == false) {
+            LOG.warn(MessageFormat.format(
+                    "this session does not support inspection: {0}",
+                    element.getClass().getName()));
+            return;
+        }
+        extension.inspect(path, element);
+    }
+
+    /**
      * Returns whether this supports to inspect the target element.
      * @param element the target element
      * @return {@code true} if this supports the target element, otherwise {@code false}
@@ -67,4 +92,13 @@ public abstract class InspectionExtension {
      * @throws DiagnosticException if failed to inspect the target element
      */
     public abstract void inspect(Location location, Object element);
+
+    /**
+     * Inspects the target element.
+     * @param path the output path of inspection information
+     * @param element the target element
+     * @throws DiagnosticException if failed to inspect the target element
+     * @since 0.5.2
+     */
+    public abstract void inspect(Path path, Object element);
 }

--- a/compiler-project/inspection/src/test/java/com/asakusafw/lang/compiler/inspection/InspectionExtensionTest.java
+++ b/compiler-project/inspection/src/test/java/com/asakusafw/lang/compiler/inspection/InspectionExtensionTest.java
@@ -18,6 +18,7 @@ package com.asakusafw.lang.compiler.inspection;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
+import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
@@ -47,6 +48,10 @@ public class InspectionExtensionTest {
                 assertThat(location, is(Location.of("testing")));
                 assertThat(ref.compareAndSet(null, element), is(true));
             }
+            @Override
+            public void inspect(Path path, Object element) {
+                throw new AssertionError();
+            }
         });
         Object object = new Object();
         InspectionExtension.inspect(container, Location.of("testing"), object);
@@ -65,6 +70,10 @@ public class InspectionExtensionTest {
             }
             @Override
             public void inspect(Location location, Object element) {
+                throw new AssertionError();
+            }
+            @Override
+            public void inspect(Path path, Object element) {
                 throw new AssertionError();
             }
         });

--- a/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/graph/Operators.java
+++ b/compiler-project/model/src/main/java/com/asakusafw/lang/compiler/model/graph/Operators.java
@@ -15,9 +15,10 @@
  */
 package com.asakusafw.lang.compiler.model.graph;
 
+import java.util.ArrayDeque;
 import java.util.Collection;
+import java.util.Deque;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -146,7 +147,7 @@ public final class Operators {
      */
     public static Set<Operator> getTransitiveSuccessors(Collection<OperatorOutput> ports) {
         Set<Operator> results = new HashSet<>();
-        LinkedList<Operator> work = new LinkedList<>(getSuccessors(ports));
+        Deque<Operator> work = new ArrayDeque<>(getSuccessors(ports));
         while (work.isEmpty() == false) {
             Operator operator = work.removeFirst();
             if (results.contains(operator)) {
@@ -171,7 +172,7 @@ public final class Operators {
      */
     public static Set<Operator> getTransitivePredecessors(Collection<OperatorInput> ports) {
         Set<Operator> results = new HashSet<>();
-        LinkedList<Operator> work = new LinkedList<>(getPredecessors(ports));
+        Deque<Operator> work = new ArrayDeque<>(getPredecessors(ports));
         while (work.isEmpty() == false) {
             Operator operator = work.removeFirst();
             if (results.contains(operator)) {
@@ -196,7 +197,7 @@ public final class Operators {
      */
     public static Set<Operator> getTransitiveConnected(Collection<? extends Operator> operators) {
         Set<Operator> results = new HashSet<>(operators);
-        LinkedList<Operator> work = new LinkedList<>(operators);
+        Deque<Operator> work = new ArrayDeque<>(operators);
         while (work.isEmpty() == false) {
             Operator current = work.removeFirst();
             for (OperatorPort port : current.getInputs()) {
@@ -234,7 +235,7 @@ public final class Operators {
             Predicate<? super Operator> predicate) {
         Set<Operator> results = new HashSet<>();
         Set<Operator> saw = new HashSet<>();
-        LinkedList<Operator> work = new LinkedList<>(getSuccessors(ports));
+        Deque<Operator> work = new ArrayDeque<>(getSuccessors(ports));
         while (work.isEmpty() == false) {
             Operator operator = work.removeFirst();
             if (saw.contains(operator)) {
@@ -262,7 +263,7 @@ public final class Operators {
             Predicate<? super Operator> predicate) {
         Set<Operator> results = new HashSet<>();
         Set<Operator> saw = new HashSet<>();
-        LinkedList<Operator> work = new LinkedList<>(getPredecessors(ports));
+        Deque<Operator> work = new ArrayDeque<>(getPredecessors(ports));
         while (work.isEmpty() == false) {
             Operator operator = work.removeFirst();
             if (saw.contains(operator)) {
@@ -292,7 +293,7 @@ public final class Operators {
             boolean inclusive) {
         Set<Operator> results = new HashSet<>();
         Set<Operator> saw = new HashSet<>();
-        LinkedList<Operator> work = new LinkedList<>(getSuccessors(ports));
+        Deque<Operator> work = new ArrayDeque<>(getSuccessors(ports));
         while (work.isEmpty() == false) {
             Operator operator = work.removeFirst();
             if (saw.contains(operator)) {
@@ -325,7 +326,7 @@ public final class Operators {
             boolean inclusive) {
         Set<Operator> results = new HashSet<>();
         Set<Operator> saw = new HashSet<>();
-        LinkedList<Operator> work = new LinkedList<>(getPredecessors(ports));
+        Deque<Operator> work = new ArrayDeque<>(getPredecessors(ports));
         while (work.isEmpty() == false) {
             Operator operator = work.removeFirst();
             if (saw.contains(operator)) {

--- a/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/PlanDetail.java
+++ b/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/PlanDetail.java
@@ -20,14 +20,16 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
+import com.asakusafw.lang.compiler.common.Adaptable;
 import com.asakusafw.lang.compiler.model.graph.Operator;
 
 /**
  * Detail information for {@link Plan} for re-organizing execution plans.
  */
-public class PlanDetail {
+public class PlanDetail implements Adaptable {
 
     private final Plan plan;
 
@@ -159,6 +161,14 @@ public class PlanDetail {
             return null;
         }
         return mapping.owner;
+    }
+
+    @Override
+    public <T> Optional<T> findAdapter(Class<T> type) {
+        if (type.isInstance(plan)) {
+            return Optional.of(type.cast(plan));
+        }
+        return Adaptable.super.findAdapter(type);
     }
 
     private static final class Mapping {

--- a/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/Planning.java
+++ b/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/Planning.java
@@ -17,10 +17,13 @@ package com.asakusafw.lang.compiler.planning;
 
 import java.text.MessageFormat;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import com.asakusafw.lang.compiler.model.graph.ExternalInput;
 import com.asakusafw.lang.compiler.model.graph.ExternalOutput;
@@ -51,6 +54,14 @@ public final class Planning {
      * A predicate only accepts plan markers.
      */
     public static final Predicate<Operator> PLAN_MARKERS = PlanMarkers::exists;
+
+    /**
+     * A basic operator comparator.
+     * @since 0.5.2
+     */
+    public static final Comparator<Operator> OPERATOR_ORDER = Comparator
+            .comparingLong(Operator::getOriginalSerialNumber)
+            .thenComparingLong(Operator::getSerialNumber);
 
     private Planning() {
         return;
@@ -293,6 +304,62 @@ public final class Planning {
         }
         results.addAll(Operators.getTransitivePredecessors(edges));
         return results;
+    }
+
+    /**
+     * Collects potentially cyclic broadcast operators.
+     * @param operators the source operators
+     * @return a broadcast marker operator which potentially organizes cyclic dependencies
+     * @since 0.5.2
+     */
+    public static MarkerOperator findPotentiallyCyclicBroadcast(Collection<Operator> operators) {
+        List<MarkerOperator> primaries = operators.stream()
+                .filter(it -> it instanceof MarkerOperator)
+                .map(it -> (MarkerOperator) it)
+                .filter(it -> PlanMarkers.get(it) != PlanMarker.BROADCAST)
+                .filter(it -> PlanMarkers.get(it) != PlanMarker.END)
+                .collect(Collectors.toList());
+
+        Graph<MarkerOperator> dependencies = Graphs.newInstance();
+        for (MarkerOperator primary : primaries) {
+            Set<Operator> downstreams = Operators.findNearestReachableSuccessors(
+                    primary.getOutputs(), PlanMarkers::exists);
+            Operators.findNearestReachablePredecessors(
+                    downstreams.stream().flatMap(it -> it.getInputs().stream()).collect(Collectors.toList()),
+                    PlanMarkers::exists).stream()
+                    .filter(it -> PlanMarkers.get(it) == PlanMarker.BROADCAST)
+                    .map(it -> (MarkerOperator) it)
+                    .forEach(upstream -> downstreams.stream()
+                            .filter(it -> PlanMarkers.get(it) == PlanMarker.BROADCAST)
+                            .map(it -> (MarkerOperator) it)
+                            .forEach(downstream -> dependencies.addEdge(upstream, downstream)));
+        }
+
+        // pick up a cyclic element
+        return Graphs.findCircuit(dependencies).stream()
+                // NOTE: self cyclic dependency will remove another phase
+                .filter(it -> it.size() >= 2)
+                .flatMap(it -> it.stream())
+                .distinct()
+                // require at least one non-primary operator in the successors
+                .filter(op -> Operators.getSuccessors(op).stream()
+                        .anyMatch(it -> isPrimaryOperator(it) == false))
+                .min(Comparator
+                        .comparingLong((MarkerOperator op) -> Operators.getSuccessors(op).stream()
+                                .filter(it -> isPrimaryOperator(it) == false)
+                                .count())
+                        .thenComparing((Comparator<MarkerOperator>) (a, b) -> {
+                            Operator as = Operators.getSuccessors(a).stream().min(Planning.OPERATOR_ORDER).orElse(a);
+                            Operator bs = Operators.getSuccessors(b).stream().min(Planning.OPERATOR_ORDER).orElse(a);
+                            return Planning.OPERATOR_ORDER.compare(as, bs);
+                        }))
+                .orElse(null);
+    }
+
+    private static boolean isPrimaryOperator(Operator operator) {
+        return Operators.getPredecessors(operator).stream()
+                .filter(op -> PlanMarkers.get(op) != PlanMarker.BROADCAST)
+                .anyMatch(PlanMarkers::exists);
     }
 
     /**

--- a/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/Planning.java
+++ b/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/Planning.java
@@ -42,6 +42,8 @@ import com.asakusafw.utils.graph.Graphs;
  * Utilities for execution planning.
  * @see Operators
  * @see PlanMarkers
+ * @since 0.1.0
+ * @version 0.5.2
  */
 public final class Planning {
 
@@ -507,6 +509,23 @@ public final class Planning {
      */
     public static PlanAssembler startAssemblePlan(PlanDetail detail) {
         return new PlanAssembler(detail);
+    }
+
+    /**
+     * Returns a sub-plan dependency graph for the specified operator graph.
+     * @param operators the target operator graph
+     * @return a operator dependency graph ({@code operator -> its predecessors})
+     * @since 0.5.2
+     */
+    public static Graph<Operator> toDependencyGraph(OperatorGraph operators) {
+        Graph<Operator> results = Graphs.newInstance();
+        for (Operator element : operators.getOperators(false)) {
+            results.addNode(element);
+            for (Operator pred : Operators.getPredecessors(element)) {
+                results.addEdge(element, pred);
+            }
+        }
+        return results;
     }
 
     /**

--- a/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/basic/BasicPlan.java
+++ b/compiler-project/plan/src/main/java/com/asakusafw/lang/compiler/planning/basic/BasicPlan.java
@@ -141,8 +141,8 @@ public class BasicPlan extends BasicAttributeContainer implements Plan {
             List<Diagnostic> diagnostics = new ArrayList<>();
             for (Set<BasicSubPlan> loop : circuits) {
                 diagnostics.add(new BasicDiagnostic(Diagnostic.Level.ERROR, MessageFormat.format(
-                        "plan must by acyclic: {0}",
-                        loop)));
+                        "plan must be acyclic: {0}",
+                        loop)).with(this));
             }
             throw new DiagnosticException(diagnostics);
         }

--- a/dag/compiler/plan/src/main/java/com/asakusafw/dag/compiler/planner/PlanningContext.java
+++ b/dag/compiler/plan/src/main/java/com/asakusafw/dag/compiler/planner/PlanningContext.java
@@ -124,6 +124,8 @@ public class PlanningContext {
 
     /**
      * Represents an option for planning.
+     * @since 0.4.0
+     * @version 0.5.2
      */
     public enum Option {
 
@@ -136,6 +138,12 @@ public class PlanningContext {
          * Inserts {@code CHECKPOINT} after external inputs.
          */
         CHECKPOINT_AFTER_EXTERNAL_INPUTS(false),
+
+        /**
+         * Removes cyclic broadcast operations.
+         * @since 0.5.2
+         */
+        REMOVE_CYCLIC_BROADCASTS(true),
 
         /**
          * Enables {@link GraphStatistics}.

--- a/dag/compiler/plan/src/test/java/com/asakusafw/dag/compiler/planner/DagPlanningTest.java
+++ b/dag/compiler/plan/src/test/java/com/asakusafw/dag/compiler/planner/DagPlanningTest.java
@@ -390,6 +390,60 @@ in0 --- *B -/
     }
 
     /**
+     * with broadcast from cross origin.
+<pre>{@code
+in0 --\ /-- o0 --- out0
+       +
+in1 --/ \-- o1 --- out1
+
+==>
+
+in0 \-- *C [C0]
+     \
+      +- *B --\
+               \
+        in1 \---+ x0 --- *C --- out1
+             \
+              \   [C0] ---+ x1 --- *C ---out2
+               \         /
+                +- *B --/
+}</pre>
+     */
+    @Test
+    public void broadcast_cross_origin() {
+        MockOperators m = new MockOperators();
+        PlanDetail detail = DagPlanning.plan(context(), m
+                .input("in0", DataSize.TINY)
+                .input("in1", DataSize.TINY)
+                .bless("x0", newJoin(m))
+                .bless("x1", newJoin(m))
+                .connect("in0", "x0.t")
+                .connect("in0", "x1.m")
+                .connect("in1", "x0.m")
+                .connect("in1", "x1.t")
+                .output("out0").connect("x0.f", "out0")
+                .output("out1").connect("x1.f", "out1")
+                .toGraph());
+        MockOperators mock = restore(detail);
+        Plan plan = detail.getPlan();
+        assertThat(plan.getElements(), hasSize(5));
+
+        SubPlan si0 = ownerOf(detail, mock.get("in0"));
+        SubPlan si1 = ownerOf(detail, mock.get("in1"));
+        SubPlan sx0 = ownerOf(detail, mock.get("x0"));
+        SubPlan sx1 = ownerOf(detail, mock.get("x1"));
+        SubPlan so0 = ownerOf(detail, mock.get("out0"));
+        SubPlan so1 = ownerOf(detail, mock.get("out1"));
+
+        assertThat(si0, either(is(sx0)).or(isIn(pred(sx0))));
+        assertThat(si0, isIn(pred(sx1)));
+        assertThat(si1, either(is(sx1)).or(isIn(pred(sx1))));
+        assertThat(si1, isIn(pred(sx0)));
+        assertThat(sx0, isIn(pred(so0)));
+        assertThat(sx1, isIn(pred(so1)));
+    }
+
+    /**
      * multiple broadcast inputs.
 <pre>{@code
 in0 --+ o0 --+ o1 --+ o2 --- out


### PR DESCRIPTION
## Summary

This PR fixes compilation error that some broadcast operations will organize cyclic dependencies.

## Background, Problem or Goal of the patch

Broadcast operations (e.g. views, join with TINY input) sometimes had organized invalid cyclic dependencies.
This PR will resolve this problem by introducing extra checkpoints in front of operators which directly consume the (potentially) problematic broadcast inputs.

## Design of the fix, or a new feature

This feature is currently experimental but **enabled in default**.
To disable this feature, please specify a compiler property `dag.planning.option.removeCyclicBroadcasts=false` in your build script.

## Related Issue, Pull Request or Code

N/A.