### PR TITLE
Suppress empty output file in Direct I/O w/ Vanilla.

### DIFF
--- a/dag/compiler/extension-directio/src/test/java/com/asakusafw/dag/compiler/extension/directio/DirectFilePortDriverTest.java
+++ b/dag/compiler/extension-directio/src/test/java/com/asakusafw/dag/compiler/extension/directio/DirectFilePortDriverTest.java
@@ -244,6 +244,53 @@ public class DirectFilePortDriverTest extends VanillaCompilerTesterRoot {
         });
     }
 
+    /**
+     * flat output w/o inputs.
+     * @throws Exception if failed
+     */
+    @Test
+    public void output_flat_empty() throws Exception {
+        testio.input("t", MockDataModel.class, o -> {
+            // no input
+        });
+        enableDirectIo();
+        run(profile, executor, g -> g
+                .input("in", TestInput.of("t", MockDataModel.class))
+                .output("out", DirectFileOutput.of("output", "*.bin", MockDataFormat.class))
+                .connect("in", "out"));
+        helper.output("output", "*.bin", MockDataFormat.class, o -> {
+            assertThat(o, is(empty()));
+        });
+
+        File output = helper.getContext().file("output");
+        assertThat(output.exists(), is(false));
+    }
+
+    /**
+     * group output w/o inputs.
+     * @throws Exception if failed
+     */
+    @Test
+    public void output_group_empty() throws Exception {
+        testio.input("t", MockDataModel.class, o -> {
+            // no input
+        });
+        enableDirectIo();
+        run(profile, executor, g -> g
+                .input("in", TestInput.of("t", MockDataModel.class))
+                .output("out", DirectFileOutput.of("output", "{key}.bin", MockDataFormat.class).withOrder("-value"))
+                .connect("in", "out"));
+        helper.output("output", "0.bin", MockDataFormat.class, o -> {
+            assertThat(o, is(empty()));
+        });
+        helper.output("output", "1.bin", MockDataFormat.class, o -> {
+            assertThat(o, is(empty()));
+        });
+
+        File output = helper.getContext().file("output");
+        assertThat(output.exists(), is(false));
+    }
+
     private void enableDirectIo() {
         Configuration configuration = helper.getContext().newConfiguration();
         profile.forFrameworkInstallation().add(LOCATION_CORE_CONFIGURATION, o -> configuration.writeXml(o));

--- a/dag/runtime/directio/src/test/java/com/asakusafw/dag/runtime/directio/DirectFileOutputPrepareTest.java
+++ b/dag/runtime/directio/src/test/java/com/asakusafw/dag/runtime/directio/DirectFileOutputPrepareTest.java
@@ -93,6 +93,17 @@ public class DirectFileOutputPrepareTest {
         assertThat(results, hasEntry(100, "Hello, world!"));
     }
 
+    /**
+     * flat - no sources.
+     */
+    @Test
+    public void flat_empty() {
+        flat(p -> p.bind("a", "out", "*.bin", MockDataFormat.class));
+        Map<Integer, String> results = collect("out", "", ".bin");
+        assertThat(results.keySet(), hasSize(0));
+        assertThat(directio.file("out").exists(), is(false));
+    }
+
     private Map<Integer, String> collect(String path) {
         try (ModelInput<MockData> in = WritableModelInput.open(directio.file(path))) {
             return MockData.collect(in);


### PR DESCRIPTION
## Summary

This PR fixes Direct I/O with Asakusa Vanilla, which may produce empty output files.

## Background, Problem or Goal of the patch

In the latest implementation, Direct I/O with Asakusa Vanilla may produce empty output files if there are no data to output. This may occur only output resource pattern contains `*`.

## Design of the fix, or a new feature

In this commit, Direct I/O DAG runtime will delay creating output files until obtaining the first element of the output. Note that, the output without `*` in its output pattern does originally not create such files.

## Related Issue, Pull Request or Code

N/A.