### PR TITLE
Add extension for default vanilla assembly

### DIFF
--- a/vanilla/runtime/assembly/pom.xml
+++ b/vanilla/runtime/assembly/pom.xml
@@ -89,6 +89,16 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.asakusafw.dag.runtime</groupId>
+      <artifactId>asakusa-dag-extension-trace</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.asakusafw.dag.runtime</groupId>
+      <artifactId>asakusa-dag-extension-wait</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.asakusafw.bridge</groupId>
       <artifactId>asakusa-bridge-runtime-directio</artifactId>
       <version>${project.version}</version>


### PR DESCRIPTION
## Summary
This PR adds more vanilla default extensions to vanilla runtime assembly.

## Background, Problem or Goal of the patch
This PR enables vanilla runtime extension features useful for debugging and tracing.

## Design of the fix, or a new feature
You can use the following vanilla runtime configuration properties:

* `com.asakusafw.dag.extension.trace`
This option enables to report vanilla runtime trace infomation via Report API. Currently this is only enables to specify `com.asakusafw.dag.extension.trace.PortDigester` that reports digests of each port I/O.
```
com.asakusafw.dag.extension.trace=com.asakusafw.dag.extension.trace.PortDigester
```

* `com.asakusafw.dag.extension.wait.before` , `com.asakusafw.dag.extension.wait.after`
This option specifies to wait time (msec) around DAG executions. For example this is useful for attaching or detaching remote debug connection.
```
com.asakusafw.dag.extension.wait.before=10000
com.asakusafw.dag.extension.wait.after=5000
```

## Related Issue, Pull Request or Code
N/A.