### PR TITLE
revise Vanilla buffer spilling.

### DIFF
--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/VanillaConfiguration.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/VanillaConfiguration.java
@@ -82,14 +82,17 @@ public class VanillaConfiguration {
     public static final String KEY_SWAP_DECORATOR = KEY_ENGINE_PREFIX + "pool.compression"; //$NON-NLS-1$
 
     /**
-     * The configuration key of output buffer size in bytes({@value}: {@value #DEFAULT_OUTPUT_BUFFER_SIZE}).
+     * The configuration key of output buffer size in bytes ({@value}: {@value #DEFAULT_OUTPUT_BUFFER_SIZE}).
      */
     public static final String KEY_OUTPUT_BUFFER_SIZE = KEY_ENGINE_PREFIX + "output.buffer.size"; //$NON-NLS-1$
 
     /**
-     * The configuration key of output buffer flush factor ({@value}: {@value #DEFAULT_OUTPUT_BUFFER_FLUSH}).
+     * The configuration key of output buffer margin size in bytes ({@value}: {@value #DEFAULT_OUTPUT_BUFFER_MARGIN}).
+     * If {@link #KEY_OUTPUT_BUFFER_SIZE} - {@link #KEY_OUTPUT_BUFFER_MARGIN} was used,
+     * the output buffer will be flushed.
+     * @since 0.5.3
      */
-    public static final String KEY_OUTPUT_BUFFER_FLUSH = KEY_ENGINE_PREFIX + "output.buffer.flush"; //$NON-NLS-1$
+    public static final String KEY_OUTPUT_BUFFER_MARGIN = KEY_ENGINE_PREFIX + "output.buffer.margin"; //$NON-NLS-1$
 
     /**
      * The configuration key of the estimated average output record size
@@ -153,9 +156,9 @@ public class VanillaConfiguration {
     public static final int DEFAULT_OUTPUT_RECORD_SIZE = 64;
 
     /**
-     * The default value of {@link #KEY_OUTPUT_BUFFER_FLUSH}.
+     * The default value of {@link #KEY_OUTPUT_BUFFER_MARGIN}.
      */
-    public static final double DEFAULT_OUTPUT_BUFFER_FLUSH = 0.90;
+    public static final int DEFAULT_OUTPUT_BUFFER_MARGIN = 1 * 1024 * 1024;
 
     /**
      * The default value of {@link #KEY_MERGE_THRESHOLD}.
@@ -185,7 +188,7 @@ public class VanillaConfiguration {
 
     private OptionalInt outputBufferSize = OptionalInt.empty();
 
-    private OptionalDouble outputBufferFlush = OptionalDouble.empty();
+    private OptionalInt outputBufferMargin = OptionalInt.empty();
 
     private OptionalInt outputRecordSize = OptionalInt.empty();
 
@@ -331,20 +334,22 @@ public class VanillaConfiguration {
     }
 
     /**
-     * Returns the individual output buffer size.
-     * @return the output buffer size, in bytes
-     * @see #KEY_OUTPUT_BUFFER_FLUSH
+     * Returns the individual output buffer margin size.
+     * @return the output buffer margin size, in bytes
+     * @see #KEY_OUTPUT_BUFFER_MARGIN
+     * @since 0.5.3
      */
-    public double getOutputBufferFlush() {
-        return outputBufferFlush.orElse(DEFAULT_OUTPUT_BUFFER_FLUSH);
+    public int getOutputBufferMargin() {
+        return outputBufferMargin.orElse(DEFAULT_OUTPUT_BUFFER_MARGIN);
     }
 
     /**
-     * Sets the individual output buffer size.
+     * Sets the individual output buffer margin size.
      * @param newValue the new value
+     * @since 0.5.3
      */
-    public void setOutputBufferFlush(double newValue) {
-        this.outputBufferFlush = OptionalDouble.of(newValue);
+    public void setOutputBufferMargin(int newValue) {
+        this.outputBufferMargin = OptionalInt.of(newValue);
     }
 
     /**
@@ -426,7 +431,7 @@ public class VanillaConfiguration {
         configureInt(conf::setSwapDivision, options, KEY_SWAP_DIVISION);
         configureString(conf::setSwapDecorator, options, KEY_SWAP_DECORATOR);
         configureInt(conf::setOutputBufferSize, options, KEY_OUTPUT_BUFFER_SIZE);
-        configureDouble(conf::setOutputBufferFlush, options, KEY_OUTPUT_BUFFER_FLUSH);
+        configureInt(conf::setOutputBufferMargin, options, KEY_OUTPUT_BUFFER_MARGIN);
         configureInt(conf::setOutputRecordSize, options, KEY_OUTPUT_RECORD_SIZE);
         configureInt(conf::setMergeThreshold, options, KEY_MERGE_THRESHOLD);
         configureDouble(conf::setMergeFactor, options, KEY_MERGE_FACTOR);
@@ -440,7 +445,7 @@ public class VanillaConfiguration {
             LOG.debug(MessageFormat.format("{0}: {1}", //$NON-NLS-1$
                     KEY_OUTPUT_BUFFER_SIZE, conf.getOutputBufferSize()));
             LOG.debug(MessageFormat.format("{0}: {1}", //$NON-NLS-1$
-                    KEY_OUTPUT_BUFFER_FLUSH, conf.getOutputBufferFlush()));
+                    KEY_OUTPUT_BUFFER_MARGIN, conf.getOutputBufferMargin()));
             LOG.debug(MessageFormat.format("{0}: {1}", //$NON-NLS-1$
                     KEY_OUTPUT_RECORD_SIZE, conf.getOutputRecordSize()));
             LOG.debug(MessageFormat.format("{0}: {1}", //$NON-NLS-1$

--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/VanillaConfiguration.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/VanillaConfiguration.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import com.asakusafw.dag.api.common.SupplierInfo;
 import com.asakusafw.lang.utils.common.Arguments;
 import com.asakusafw.lang.utils.common.Optionals;
+import com.asakusafw.vanilla.core.io.BufferedByteChannelDecorator;
 import com.asakusafw.vanilla.core.io.ByteChannelDecorator;
 import com.asakusafw.vanilla.core.util.SystemProperty;
 
@@ -138,12 +139,12 @@ public class VanillaConfiguration {
     public static final int DEFAULT_SWAP_DIVISION = 0;
 
     /**
-     * The default value of {@link #KEY_SWAP_DECORATOR} (uncompressed).
+     * The default value of {@link #KEY_SWAP_DECORATOR} (only buffered).
      * @since 0.5.3
-     * @see ByteChannelDecorator#THROUGH
+     * @see BufferedByteChannelDecorator
      */
     public static final SupplierInfo DEFAULT_SWAP_DECORATOR =
-            SupplierInfo.of(ByteChannelDecorator.Through.class.getName());
+            SupplierInfo.of(BufferedByteChannelDecorator.class.getName());
 
     /**
      * The default value of {@link #KEY_OUTPUT_BUFFER_SIZE}.
@@ -295,7 +296,7 @@ public class VanillaConfiguration {
      * @param newValue the decorator class supplier
      */
     public void setSwapDecorator(SupplierInfo newValue) {
-        this.swapDecorator = Optional.of(newValue);
+        this.swapDecorator = Optional.ofNullable(newValue);
     }
 
     /**

--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/VanillaLauncher.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/VanillaLauncher.java
@@ -222,10 +222,13 @@ public class VanillaLauncher {
                         context.getClassLoader(),
                         mirror,
                         new BasicBufferPool(configuration.getBufferPoolSize(), store),
+                        store.getBlobStore(),
                         configuration.getNumberOfPartitions(),
                         configuration.getOutputBufferSize(),
                         configuration.getOutputBufferFlush(),
-                        configuration.getNumberOfOutputRecords());
+                        configuration.getNumberOfOutputRecords(),
+                        configuration.getMergeThreshold(),
+                        configuration.getMergeFactor());
                 ResourceSession session = LaunchUtil.attachSession(context, ResourceBroker.Scope.VM)) {
             if (RuntimeContext.get().isSimulation() == false) {
                 new GraphExecutor(context, mirror,

--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/VanillaLauncher.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/VanillaLauncher.java
@@ -35,7 +35,6 @@ import com.asakusafw.dag.api.processor.basic.BasicProcessorContext;
 import com.asakusafw.dag.api.processor.extension.ProcessorContextExtension;
 import com.asakusafw.lang.utils.common.Arguments;
 import com.asakusafw.lang.utils.common.InterruptibleIo;
-import com.asakusafw.lang.utils.common.Optionals;
 import com.asakusafw.runtime.core.context.RuntimeContext;
 import com.asakusafw.vanilla.core.engine.BasicEdgeDriver;
 import com.asakusafw.vanilla.core.engine.BasicVertexScheduler;
@@ -48,7 +47,7 @@ import com.asakusafw.vanilla.core.mirror.GraphMirror;
 /**
  * Asakusa Vanilla application entry.
  * @since 0.4.0
- * @version 0.4.2
+ * @version 0.5.3
  */
 public class VanillaLauncher {
 
@@ -212,8 +211,10 @@ public class VanillaLauncher {
         Arguments.requireNonNull(context);
         Arguments.requireNonNull(configuration);
         Arguments.requireNonNull(graph);
-        BasicBufferStore.Builder storeBuilder = BasicBufferStore.builder();
-        Optionals.of(configuration.getSwapDirectory()).ifPresent(storeBuilder::withDirectory);
+        BasicBufferStore.Builder storeBuilder = BasicBufferStore.builder()
+                .withDirectory(configuration.getSwapDirectory())
+                .withDivision(configuration.getSwapDivision())
+                .withDecorator(configuration.getSwapDecorator(context.getClassLoader()));
 
         GraphMirror mirror = GraphMirror.of(graph);
         VertexScheduler scheduler = new BasicVertexScheduler();

--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/VanillaLauncher.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/VanillaLauncher.java
@@ -226,7 +226,7 @@ public class VanillaLauncher {
                         store.getBlobStore(),
                         configuration.getNumberOfPartitions(),
                         configuration.getOutputBufferSize(),
-                        configuration.getOutputBufferFlush(),
+                        configuration.getOutputBufferMargin(),
                         configuration.getNumberOfOutputRecords(),
                         configuration.getMergeThreshold(),
                         configuration.getMergeFactor());

--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/SnappyByteChannelDecorator.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/SnappyByteChannelDecorator.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.client.util;
+
+import java.io.IOException;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+
+import org.xerial.snappy.SnappyFramedInputStream;
+import org.xerial.snappy.SnappyFramedOutputStream;
+
+import com.asakusafw.vanilla.core.io.ByteChannelDecorator;
+
+/**
+ * An implementation of {@link ByteChannelDecorator} which using snappy compression.
+ * @since 0.5.3
+ */
+public class SnappyByteChannelDecorator implements ByteChannelDecorator {
+
+    @Override
+    public ReadableByteChannel decorate(ReadableByteChannel channel) throws IOException {
+        return new SnappyFramedInputStream(channel, false);
+    }
+
+    @Override
+    public WritableByteChannel decorate(WritableByteChannel channel) throws IOException {
+        return new SnappyFramedOutputStream(channel);
+    }
+}

--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/package-info.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Asakusa Vanilla client utilities.
+ */
+package com.asakusafw.vanilla.client.util;

--- a/vanilla/runtime/client/src/test/java/com/asakusafw/vanilla/client/VanillaConfigurationTest.java
+++ b/vanilla/runtime/client/src/test/java/com/asakusafw/vanilla/client/VanillaConfigurationTest.java
@@ -47,7 +47,7 @@ public class VanillaConfigurationTest {
         assertThat(conf.getSwapDivision(), is(DEFAULT_SWAP_DIVISION));
         assertThat(conf.getSwapDecorator(getClass().getClassLoader()), is(instanceOf(ByteChannelDecorator.Through.class)));
         assertThat(conf.getOutputBufferSize(), is(DEFAULT_OUTPUT_BUFFER_SIZE));
-        assertThat(conf.getOutputBufferFlush(), closeTo(DEFAULT_OUTPUT_BUFFER_FLUSH, 0.01));
+        assertThat(conf.getOutputBufferMargin(), is(DEFAULT_OUTPUT_BUFFER_MARGIN));
         assertThat(conf.getOutputRecordSize(), is(DEFAULT_OUTPUT_RECORD_SIZE));
         assertThat(conf.getMergeThreshold(), is(DEFAULT_MERGE_THRESHOLD));
         assertThat(conf.getMergeFactor(), is(DEFAULT_MERGE_FACTOR));
@@ -65,7 +65,7 @@ public class VanillaConfigurationTest {
         pairs.put(KEY_PARTITION_COUNT, 3);
         pairs.put(KEY_BUFFER_POOL_SIZE, 4);
         pairs.put(KEY_OUTPUT_BUFFER_SIZE, 5);
-        pairs.put(KEY_OUTPUT_BUFFER_FLUSH, 6);
+        pairs.put(KEY_OUTPUT_BUFFER_MARGIN, 6);
         pairs.put(KEY_OUTPUT_RECORD_SIZE, 7);
         pairs.put(KEY_SWAP_DIVISION, 8);
         pairs.put(KEY_SWAP_DIRECTORY, f);
@@ -80,7 +80,7 @@ public class VanillaConfigurationTest {
         assertThat(conf.getNumberOfPartitions(), is(3));
         assertThat(conf.getBufferPoolSize(), is(4L));
         assertThat(conf.getOutputBufferSize(), is(5));
-        assertThat(conf.getOutputBufferFlush(), is(6d));
+        assertThat(conf.getOutputBufferMargin(), is(6));
         assertThat(conf.getOutputRecordSize(), is(7));
         assertThat(conf.getSwapDivision(), is(8));
         assertThat(conf.getSwapDirectory().getCanonicalFile(), is(f));

--- a/vanilla/runtime/client/src/test/java/com/asakusafw/vanilla/client/VanillaConfigurationTest.java
+++ b/vanilla/runtime/client/src/test/java/com/asakusafw/vanilla/client/VanillaConfigurationTest.java
@@ -46,6 +46,8 @@ public class VanillaConfigurationTest {
         assertThat(conf.getOutputBufferSize(), is(DEFAULT_OUTPUT_BUFFER_SIZE));
         assertThat(conf.getOutputBufferFlush(), closeTo(DEFAULT_OUTPUT_BUFFER_FLUSH, 0.01));
         assertThat(conf.getOutputRecordSize(), is(DEFAULT_OUTPUT_RECORD_SIZE));
+        assertThat(conf.getMergeThreshold(), is(DEFAULT_MERGE_THRESHOLD));
+        assertThat(conf.getMergeFactor(), is(DEFAULT_MERGE_FACTOR));
     }
 
     /**
@@ -64,6 +66,8 @@ public class VanillaConfigurationTest {
         pairs.put(KEY_OUTPUT_RECORD_SIZE, 7);
         pairs.put(KEY_SWAP_DIVISION, 8);
         pairs.put(KEY_SWAP_DIRECTORY, f);
+        pairs.put(KEY_MERGE_THRESHOLD, 9);
+        pairs.put(KEY_MERGE_FACTOR, 10);
 
         VanillaConfiguration conf = VanillaConfiguration.extract(key -> Optionals.get(pairs, key)
                 .map(String::valueOf));
@@ -76,6 +80,8 @@ public class VanillaConfigurationTest {
         assertThat(conf.getOutputRecordSize(), is(7));
         assertThat(conf.getSwapDivision(), is(8));
         assertThat(conf.getSwapDirectory().getCanonicalFile(), is(f));
+        assertThat(conf.getMergeThreshold(), is(9));
+        assertThat(conf.getMergeFactor(), is(10d));
     }
 
     /**

--- a/vanilla/runtime/client/src/test/java/com/asakusafw/vanilla/client/VanillaConfigurationTest.java
+++ b/vanilla/runtime/client/src/test/java/com/asakusafw/vanilla/client/VanillaConfigurationTest.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import org.junit.Test;
 
 import com.asakusafw.lang.utils.common.Optionals;
+import com.asakusafw.vanilla.client.util.SnappyByteChannelDecorator;
+import com.asakusafw.vanilla.core.io.ByteChannelDecorator;
 
 /**
  * Test for {@link VanillaConfiguration}.
@@ -43,6 +45,7 @@ public class VanillaConfigurationTest {
         assertThat(conf.getBufferPoolSize(), is(DEFAULT_BUFFER_POOL_SIZE));
         assertThat(conf.getSwapDirectory(), is(DEFAULT_SWAP_DIRECTORY));
         assertThat(conf.getSwapDivision(), is(DEFAULT_SWAP_DIVISION));
+        assertThat(conf.getSwapDecorator(getClass().getClassLoader()), is(instanceOf(ByteChannelDecorator.Through.class)));
         assertThat(conf.getOutputBufferSize(), is(DEFAULT_OUTPUT_BUFFER_SIZE));
         assertThat(conf.getOutputBufferFlush(), closeTo(DEFAULT_OUTPUT_BUFFER_FLUSH, 0.01));
         assertThat(conf.getOutputRecordSize(), is(DEFAULT_OUTPUT_RECORD_SIZE));
@@ -68,6 +71,7 @@ public class VanillaConfigurationTest {
         pairs.put(KEY_SWAP_DIRECTORY, f);
         pairs.put(KEY_MERGE_THRESHOLD, 9);
         pairs.put(KEY_MERGE_FACTOR, 10);
+        pairs.put(KEY_SWAP_DECORATOR, SnappyByteChannelDecorator.class.getName());
 
         VanillaConfiguration conf = VanillaConfiguration.extract(key -> Optionals.get(pairs, key)
                 .map(String::valueOf));
@@ -82,6 +86,7 @@ public class VanillaConfigurationTest {
         assertThat(conf.getSwapDirectory().getCanonicalFile(), is(f));
         assertThat(conf.getMergeThreshold(), is(9));
         assertThat(conf.getMergeFactor(), is(10d));
+        assertThat(conf.getSwapDecorator(getClass().getClassLoader()), is(instanceOf(SnappyByteChannelDecorator.class)));
     }
 
     /**

--- a/vanilla/runtime/client/src/test/java/com/asakusafw/vanilla/client/VanillaConfigurationTest.java
+++ b/vanilla/runtime/client/src/test/java/com/asakusafw/vanilla/client/VanillaConfigurationTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 
 import com.asakusafw.lang.utils.common.Optionals;
 import com.asakusafw.vanilla.client.util.SnappyByteChannelDecorator;
-import com.asakusafw.vanilla.core.io.ByteChannelDecorator;
+import com.asakusafw.vanilla.core.io.BufferedByteChannelDecorator;
 
 /**
  * Test for {@link VanillaConfiguration}.
@@ -45,7 +45,7 @@ public class VanillaConfigurationTest {
         assertThat(conf.getBufferPoolSize(), is(DEFAULT_BUFFER_POOL_SIZE));
         assertThat(conf.getSwapDirectory(), is(DEFAULT_SWAP_DIRECTORY));
         assertThat(conf.getSwapDivision(), is(DEFAULT_SWAP_DIVISION));
-        assertThat(conf.getSwapDecorator(getClass().getClassLoader()), is(instanceOf(ByteChannelDecorator.Through.class)));
+        assertThat(conf.getSwapDecorator(getClass().getClassLoader()), is(instanceOf(BufferedByteChannelDecorator.class)));
         assertThat(conf.getOutputBufferSize(), is(DEFAULT_OUTPUT_BUFFER_SIZE));
         assertThat(conf.getOutputBufferMargin(), is(DEFAULT_OUTPUT_BUFFER_MARGIN));
         assertThat(conf.getOutputRecordSize(), is(DEFAULT_OUTPUT_RECORD_SIZE));

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/engine/BasicEdgeDriver.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/engine/BasicEdgeDriver.java
@@ -92,7 +92,7 @@ public class BasicEdgeDriver extends EdgeDriver.Abstract {
 
     private final int bufferSizeLimit;
 
-    private final double bufferFlushFactor;
+    private final int bufferMarginSize;
 
     private final int recordCountLimit;
 
@@ -112,7 +112,7 @@ public class BasicEdgeDriver extends EdgeDriver.Abstract {
      * @param blobs the BLOB store
      * @param numberOfPartitions the number of partitions in scatter-gather operations
      * @param bufferSizeLimit each output buffer size threshold in bytes
-     * @param bufferFlushFactor the output buffer flush factor
+     * @param bufferMarginSize the output buffer margin size
      * @param recordCountLimit the number of limit records in each output buffer
      * @param mergeThreshold the maximum number of merging scatter/gather input chunks
      * @param mergeFactor the fraction to merge scatter/gather input with {@code mergeThreshold}
@@ -121,7 +121,7 @@ public class BasicEdgeDriver extends EdgeDriver.Abstract {
             ClassLoader classLoader,
             GraphMirror graph, BufferPool pool, BlobStore blobs,
             int numberOfPartitions,
-            int bufferSizeLimit, double bufferFlushFactor, int recordCountLimit,
+            int bufferSizeLimit, int bufferMarginSize, int recordCountLimit,
             int mergeThreshold, double mergeFactor) {
         Arguments.requireNonNull(classLoader);
         Arguments.requireNonNull(graph);
@@ -134,7 +134,7 @@ public class BasicEdgeDriver extends EdgeDriver.Abstract {
         this.pool = pool;
         this.numberOfPartitions = numberOfPartitions;
         this.bufferSizeLimit = bufferSizeLimit;
-        this.bufferFlushFactor = bufferFlushFactor;
+        this.bufferMarginSize = bufferMarginSize;
         this.recordCountLimit = recordCountLimit;
         int mergeCount = Math.max(2, Math.min(mergeThreshold, (int) (mergeThreshold * mergeFactor)));
         Function<PortMirror, FragmentStore> fstore =
@@ -199,7 +199,7 @@ public class BasicEdgeDriver extends EdgeDriver.Abstract {
         return new StreamObjectWriter(
                 BasicRecordSink.stream(Invariants.requireNonNull(sinks.get(port))),
                 serde,
-                bufferSizeLimit, bufferFlushFactor, recordCountLimit,
+                bufferSizeLimit, bufferMarginSize, recordCountLimit,
                 pool.reserve(bufferSizeLimit));
     }
 
@@ -217,7 +217,7 @@ public class BasicEdgeDriver extends EdgeDriver.Abstract {
         return new StreamObjectWriter(
                 BasicRecordSink.stream(Invariants.requireNonNull(sinks.get(port))),
                 serde,
-                bufferSizeLimit, bufferFlushFactor, recordCountLimit,
+                bufferSizeLimit, bufferMarginSize, recordCountLimit,
                 pool.reserve(bufferSizeLimit));
     }
 
@@ -239,7 +239,7 @@ public class BasicEdgeDriver extends EdgeDriver.Abstract {
         return new StreamGroupWriter(
                 KeyValuePartitioner.stream(Arrays.asList(Invariants.requireNonNull(partSinks.get(port)).partitions)),
                 serde, comparator,
-                bufferSizeLimit, bufferFlushFactor, recordCountLimit,
+                bufferSizeLimit, bufferMarginSize, recordCountLimit,
                 pool.reserve(bufferSizeLimit));
     }
 

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/engine/BasicEdgeDriver.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/engine/BasicEdgeDriver.java
@@ -17,14 +17,16 @@ package com.asakusafw.vanilla.core.engine;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.LinkedList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -47,8 +49,10 @@ import com.asakusafw.lang.utils.common.Invariants;
 import com.asakusafw.lang.utils.common.Lang;
 import com.asakusafw.vanilla.core.io.BasicGroupReader;
 import com.asakusafw.vanilla.core.io.BasicKeyValueCursor;
+import com.asakusafw.vanilla.core.io.BasicKeyValueSink;
 import com.asakusafw.vanilla.core.io.BasicRecordCursor;
 import com.asakusafw.vanilla.core.io.BasicRecordSink;
+import com.asakusafw.vanilla.core.io.BlobStore;
 import com.asakusafw.vanilla.core.io.BufferPool;
 import com.asakusafw.vanilla.core.io.DataReader;
 import com.asakusafw.vanilla.core.io.DataReader.Provider;
@@ -72,6 +76,7 @@ import com.asakusafw.vanilla.core.util.Buffers;
 /**
  * A basic implementation of {@link EdgeDriver}.
  * @since 0.4.0
+ * @version 0.5.3
  */
 public class BasicEdgeDriver extends EdgeDriver.Abstract {
 
@@ -104,16 +109,20 @@ public class BasicEdgeDriver extends EdgeDriver.Abstract {
      * @param classLoader the current class loader
      * @param graph the target graph
      * @param pool the buffer pool
+     * @param blobs the BLOB store
      * @param numberOfPartitions the number of partitions in scatter-gather operations
      * @param bufferSizeLimit each output buffer size threshold in bytes
      * @param bufferFlushFactor the output buffer flush factor
      * @param recordCountLimit the number of limit records in each output buffer
+     * @param mergeThreshold the maximum number of merging scatter/gather input chunks
+     * @param mergeFactor the fraction to merge scatter/gather input with {@code mergeThreshold}
      */
     public BasicEdgeDriver(
             ClassLoader classLoader,
-            GraphMirror graph, BufferPool pool,
+            GraphMirror graph, BufferPool pool, BlobStore blobs,
             int numberOfPartitions,
-            int bufferSizeLimit, double bufferFlushFactor, int recordCountLimit) {
+            int bufferSizeLimit, double bufferFlushFactor, int recordCountLimit,
+            int mergeThreshold, double mergeFactor) {
         Arguments.requireNonNull(classLoader);
         Arguments.requireNonNull(graph);
         Arguments.requireNonNull(pool);
@@ -127,11 +136,17 @@ public class BasicEdgeDriver extends EdgeDriver.Abstract {
         this.bufferSizeLimit = bufferSizeLimit;
         this.bufferFlushFactor = bufferFlushFactor;
         this.recordCountLimit = recordCountLimit;
-        this.sources = edges(graph, VertexMirror::getInputs, p -> new FragmentSource());
-        this.sinks = edges(graph, VertexMirror::getOutputs, p -> new FragmentSink(pool, p.getOpposites().size()));
-        this.partSources = parts(graph, VertexMirror::getInputs, p -> new PartitionedSource(numberOfPartitions));
+        int mergeCount = Math.max(2, Math.min(mergeThreshold, (int) (mergeThreshold * mergeFactor)));
+        Function<PortMirror, FragmentStore> fstore =
+                p -> new FragmentStore(blobs, p.newComparator(classLoader), mergeThreshold, mergeCount);
+        this.sources = edges(graph, VertexMirror::getInputs,
+                p -> new FragmentSource());
+        this.sinks = edges(graph, VertexMirror::getOutputs,
+                p -> new FragmentSink(pool, p.getOpposites().size()));
+        this.partSources = parts(graph, VertexMirror::getInputs,
+                p -> new PartitionedSource(numberOfPartitions, fstore.apply(p)));
         this.partSinks = parts(graph, VertexMirror::getOutputs,
-                p -> new PartitionedSink(pool, numberOfPartitions, p.getOpposites().size()));
+                p -> new PartitionedSink(pool, numberOfPartitions, p.getOpposites().size(), fstore.apply(p)));
     }
 
     private static <K extends PortMirror, V> Map<K, V> edges(
@@ -305,55 +320,57 @@ public class BasicEdgeDriver extends EdgeDriver.Abstract {
 
     private static final class FragmentSource implements InterruptibleIo {
 
-        private final Queue<DataReader.Provider> queue = new ConcurrentLinkedQueue<>();
+        private final FragmentStore store;
 
         FragmentSource() {
-            return;
+            this(new FragmentStore());
         }
 
-        public void offer(DataReader.Provider contents) {
-            queue.offer(contents);
+        FragmentSource(FragmentStore store) {
+            this.store = store;
+        }
+
+        public void offer(Fragment fragment) throws IOException, InterruptedException {
+            store.offer(fragment);
         }
 
         public RecordCursor.Stream openOneToOne() {
             // share chunks
-            Queue<DataReader.Provider> q = queue;
+            FragmentStore s = store;
             return () -> {
-                DataReader.Provider data = q.poll();
-                if (data == null) {
+                Fragment fragment = s.poll();
+                if (fragment == null) {
                     return null;
                 }
-                return new InternalRecordCursor(data);
+                return new InternalRecordCursor(fragment.source);
             };
         }
 
         public RecordCursor.Stream openBroadcast() {
             // repeatable
-            Queue<DataReader.Provider> q = new LinkedList<>(queue);
+            Queue<Fragment> s = store.entries();
             return () -> {
-                DataReader.Provider data = q.poll();
-                if (data == null) {
+                Fragment fragment = s.poll();
+                if (fragment == null) {
                     return null;
                 }
-                return BasicRecordCursor.newInstance(data.open());
+                return BasicRecordCursor.newInstance(fragment.source.open());
             };
         }
 
         public KeyValueCursor openScatterGather(DataComparator comparator) throws IOException, InterruptedException {
             // only once per fragment
-            List<DataReader.Provider> all = new ArrayList<>();
-            synchronized (this) {
-                all.addAll(queue);
-                queue.clear();
-            }
             List<KeyValueCursor> cursors = new ArrayList<>();
             try (Closer closer = new Closer()) {
-                for (DataReader.Provider data : all) {
-                    cursors.add(closer.add(new InternalKeyValueCursor(data)));
+                while (true) {
+                    Fragment fragment = store.poll();
+                    if (fragment == null) {
+                        break;
+                    }
+                    cursors.add(closer.add(new InternalKeyValueCursor(fragment.source)));
                 }
                 closer.keep();
             }
-            all.clear();
             switch (cursors.size()) {
             case 0:
                 return new VoidKeyValueCursor();
@@ -366,16 +383,7 @@ public class BasicEdgeDriver extends EdgeDriver.Abstract {
 
         @Override
         public void close() throws IOException, InterruptedException {
-            try (Closer closer = new Closer()) {
-                while (true) {
-                    Provider next = queue.poll();
-                    if (next == null) {
-                        break;
-                    } else {
-                        closer.add(next);
-                    }
-                }
-            }
+            store.close();
         }
     }
 
@@ -385,11 +393,16 @@ public class BasicEdgeDriver extends EdgeDriver.Abstract {
 
         private final int priority;
 
-        private final Queue<DataReader.Provider> queue = new ConcurrentLinkedQueue<>();
+        private final FragmentStore store;
 
         FragmentSink(BufferPool pool, int numberOfConsumers) {
+            this(pool, numberOfConsumers, new FragmentStore());
+        }
+
+        FragmentSink(BufferPool pool, int numberOfConsumers, FragmentStore store) {
             this.pool = pool;
             this.priority = numberOfConsumers;
+            this.store = store;
         }
 
         @Override
@@ -403,20 +416,125 @@ public class BasicEdgeDriver extends EdgeDriver.Abstract {
             Arguments.requireNonNull(written);
             Arguments.require(written instanceof InternalWriter);
             InternalWriter writer = (InternalWriter) written;
-            queue.offer(writer.save(pool, priority));
+            store.offer(writer.save(pool, priority));
         }
 
-        public void migrateTo(List<FragmentSource> downstreams) {
+        public void migrateTo(List<FragmentSource> downstreams) throws IOException, InterruptedException {
             while (true) {
-                DataReader.Provider next = queue.poll();
+                Fragment next = store.poll();
                 if (next == null) {
                     break;
                 }
-                List<DataReader.Provider> shared = SharedBuffer.wrap(next, downstreams.size());
+                List<DataReader.Provider> shared = SharedBuffer.wrap(next.source, downstreams.size());
                 int index = 0;
                 for (FragmentSource downstream : downstreams) {
-                    downstream.offer(shared.get(index++));
+                    downstream.offer(new Fragment(shared.get(index++), next.size));
                 }
+            }
+        }
+
+        @Override
+        public void close() throws IOException, InterruptedException {
+            store.close();
+        }
+    }
+
+    private static final class FragmentStore implements InterruptibleIo {
+
+        private final BlobStore blobs;
+
+        private final DataComparator comparator;
+
+        private final int mergeThreshold;
+
+        private final int mergeCount;
+
+        private final Queue<Fragment> queue = new ConcurrentLinkedQueue<>();
+
+        private final AtomicInteger count = new AtomicInteger();
+
+        FragmentStore() {
+            this(null, null, 0, 0);
+        }
+
+        public FragmentStore(BlobStore blobs, DataComparator comparator, int mergeThreshold, int mergeCount) {
+            this.blobs = blobs;
+            this.comparator = comparator;
+            this.mergeThreshold = mergeThreshold;
+            this.mergeCount = mergeCount;
+        }
+
+        void offer(Fragment fragment) throws IOException, InterruptedException {
+            queue.offer(fragment);
+            count.incrementAndGet();
+            merge();
+        }
+
+        Fragment poll() {
+            Fragment result = queue.poll();
+            if (result == null) {
+                return null;
+            }
+            count.decrementAndGet();
+            return result;
+        }
+
+        Queue<Fragment> entries() {
+            return new ArrayDeque<>(queue);
+        }
+
+        private void merge() throws IOException, InterruptedException {
+            while (mergeThreshold > 1 && count.get() > mergeThreshold) {
+                ArrayList<Fragment> fragments;
+                synchronized (queue) {
+                    if (queue.size() <= mergeThreshold) {
+                        return;
+                    }
+                    fragments = new ArrayList<>();
+                    while (true) {
+                        Fragment fragment = queue.poll();
+                        if (fragment == null) {
+                            break;
+                        }
+                        fragments.add(fragment);
+                        count.decrementAndGet();
+                    }
+                }
+                fragments.sort(Comparator.comparing((Fragment f) -> f.size));
+                int mergeTargets = Math.min(fragments.size(), mergeCount);
+                for (int i = mergeTargets, n = fragments.size(); i < n; i++) {
+                    queue.offer(fragments.remove(fragments.size() - 1));
+                    count.incrementAndGet();
+                }
+                Fragment merged = doMerge(fragments);
+                queue.offer(merged);
+                count.incrementAndGet();
+            }
+        }
+
+        private Fragment doMerge(List<Fragment> fragments) throws IOException, InterruptedException {
+            List<KeyValueCursor> cursors = new ArrayList<>(fragments.size());
+            try (Closer closer = new Closer()) {
+                for (Fragment fragment : fragments) {
+                    cursors.add(closer.add(new InternalKeyValueCursor(fragment.source)));
+                }
+                closer.keep();
+            }
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("start merging scatter/gather input chunks: count={}, size={}",
+                        fragments.size(),
+                        fragments.stream().mapToLong(it -> it.size).sum());
+            }
+            try (KeyValueMerger merger = new KeyValueMerger(cursors, comparator);
+                    DataWriter writer = blobs.create()) {
+                long size = BasicKeyValueSink.copy(merger, writer);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("finish merging scatter/gather input chunks: count={}->1, size={}->{}",
+                            fragments.size(),
+                            fragments.stream().mapToLong(it -> it.size).sum(),
+                            size);
+                }
+                return new Fragment(blobs.commit(writer), size);
             }
         }
 
@@ -424,7 +542,7 @@ public class BasicEdgeDriver extends EdgeDriver.Abstract {
         public void close() throws IOException, InterruptedException {
             try (Closer closer = new Closer()) {
                 while (true) {
-                    Provider next = queue.poll();
+                    Fragment next = queue.poll();
                     if (next == null) {
                         break;
                     } else {
@@ -435,17 +553,34 @@ public class BasicEdgeDriver extends EdgeDriver.Abstract {
         }
     }
 
+    private static final class Fragment implements InterruptibleIo {
+
+        final DataReader.Provider source;
+
+        long size;
+
+        Fragment(Provider source, long size) {
+            this.source = source;
+            this.size = size;
+        }
+
+        @Override
+        public void close() throws IOException, InterruptedException {
+            source.close();
+        }
+    }
+
     private static final class PartitionedSource implements InterruptibleIo {
 
         final FragmentSource[] partitions;
 
-        PartitionedSource(int numberOfPartitions) {
-            this.partitions = Stream.generate(FragmentSource::new)
+        PartitionedSource(int numberOfPartitions, FragmentStore store) {
+            this.partitions = Stream.generate(() -> new FragmentSource(store))
                     .limit(numberOfPartitions)
                     .toArray(FragmentSource[]::new);
         }
 
-        public KeyValueCursor openScatterGather(
+        KeyValueCursor openScatterGather(
                 DataComparator comparator, int taskIndex) throws IOException, InterruptedException {
             if (taskIndex >= partitions.length) {
                 return new VoidKeyValueCursor();
@@ -465,14 +600,14 @@ public class BasicEdgeDriver extends EdgeDriver.Abstract {
 
         final FragmentSink[] partitions;
 
-        PartitionedSink(BufferPool pool, int numberOfPartitions, int numerOfConsumers) {
+        PartitionedSink(BufferPool pool, int numberOfPartitions, int numerOfConsumers, FragmentStore store) {
             this.partitions = new FragmentSink[numberOfPartitions];
             for (int i = 0; i < partitions.length; i++) {
-                partitions[i] = new FragmentSink(pool, numerOfConsumers);
+                partitions[i] = new FragmentSink(pool, numerOfConsumers, store);
             }
         }
 
-        public void migrateTo(List<PartitionedSource> destinations) {
+        void migrateTo(List<PartitionedSource> destinations) throws IOException, InterruptedException {
             PartitionedSource[] dests = destinations.toArray(new PartitionedSource[destinations.size()]);
             FragmentSink[] parts = partitions;
             FragmentSource[][] shuffle = new FragmentSource[parts.length][dests.length];
@@ -578,14 +713,15 @@ public class BasicEdgeDriver extends EdgeDriver.Abstract {
             this.buffer = buffer;
         }
 
-        public DataReader.Provider save(BufferPool pool, int priority) throws IOException, InterruptedException {
+        Fragment save(BufferPool pool, int priority) throws IOException, InterruptedException {
             ByteBuffer b = buffer;
             Invariants.requireNonNull(b);
             buffer = null;
             b = Buffers.duplicate(b);
             b.flip();
+            long size = b.remaining();
             DataReader.Provider result = pool.register(ticket.move(), b, priority);
-            return result;
+            return new Fragment(result, size);
         }
 
         @Override

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/engine/BasicEdgeDriver.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/engine/BasicEdgeDriver.java
@@ -464,7 +464,7 @@ public class BasicEdgeDriver extends EdgeDriver.Abstract {
             this(null, null, 0, 0);
         }
 
-        public FragmentStore(BlobStore blobs, DataComparator comparator, int mergeThreshold, int mergeCount) {
+        FragmentStore(BlobStore blobs, DataComparator comparator, int mergeThreshold, int mergeCount) {
             this.blobs = blobs;
             this.comparator = comparator;
             this.mergeThreshold = mergeThreshold;
@@ -493,7 +493,7 @@ public class BasicEdgeDriver extends EdgeDriver.Abstract {
         private void merge() throws IOException, InterruptedException {
             while (mergeThreshold > 1 && count.get() > mergeThreshold) {
                 ArrayList<Fragment> fragments;
-                synchronized (queue) {
+                synchronized (this) {
                     if (queue.size() <= mergeThreshold) {
                         return;
                     }

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/engine/VertexExecutor.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/engine/VertexExecutor.java
@@ -17,9 +17,10 @@ package com.asakusafw.vanilla.core.engine;
 
 import java.io.IOException;
 import java.text.MessageFormat;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
+import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -177,7 +178,7 @@ public class VertexExecutor implements InterruptibleIo.IoRunnable {
                     numberOfThreads);
         }
         BlockingQueue<TaskProcessorContext> queue = new LinkedBlockingQueue<>(tasks);
-        LinkedList<Future<?>> futures = Lang.let(new LinkedList<>(), it -> Lang.repeat(concurrency, () -> {
+        Deque<Future<?>> futures = Lang.let(new ArrayDeque<>(), it -> Lang.repeat(concurrency, () -> {
             TaskExecutor child = new TaskExecutor(vertex, processor, queue);
             it.add(executor.submit(() -> {
                 // this block must be a callable to throw exceptions

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/BasicBufferStore.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/BasicBufferStore.java
@@ -52,7 +52,7 @@ public class BasicBufferStore implements BufferStore, InterruptibleIo {
      * Creates a new instance.
      */
     public BasicBufferStore() {
-        this(null, DEFAULT_PARTITION, ByteChannelDecorator.THROUGH);
+        this(null, DEFAULT_PARTITION, NullByteChannelDecorator.INSTANCE);
     }
 
     /**
@@ -60,7 +60,7 @@ public class BasicBufferStore implements BufferStore, InterruptibleIo {
      * @param base the base directory
      */
     public BasicBufferStore(File base) {
-        this(base, DEFAULT_PARTITION, ByteChannelDecorator.THROUGH);
+        this(base, DEFAULT_PARTITION, NullByteChannelDecorator.INSTANCE);
     }
 
     /**
@@ -70,7 +70,7 @@ public class BasicBufferStore implements BufferStore, InterruptibleIo {
      * @since 0.4.1
      */
     public BasicBufferStore(File base, int division) {
-        this(base, division, ByteChannelDecorator.THROUGH);
+        this(base, division, NullByteChannelDecorator.INSTANCE);
     }
 
     /**
@@ -179,7 +179,7 @@ public class BasicBufferStore implements BufferStore, InterruptibleIo {
 
         private int division = DEFAULT_PARTITION;
 
-        private ByteChannelDecorator decorator = ByteChannelDecorator.THROUGH;
+        private ByteChannelDecorator decorator = NullByteChannelDecorator.INSTANCE;
 
         /**
          * Sets the directory.

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/BasicBufferStore.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/BasicBufferStore.java
@@ -106,12 +106,13 @@ public class BasicBufferStore implements BufferStore, InterruptibleIo {
 
     @Override
     public DataReader.Provider store(ByteBuffer buffer) throws IOException, InterruptedException {
+        long rawSize = buffer.remaining();
         File file = prepare();
         try (DataWriter writer = ByteChannelWriter.open(file.toPath(), decorator)) {
             writer.writeFully(buffer);
         }
         if (LOG.isTraceEnabled()) {
-            LOG.trace("saving buffer: {}bytes -> {}", buffer.remaining(), file);
+            LOG.trace("saving buffer: {}bytes -> {} ({}bytes)", rawSize, file, file.length());
         }
         return new FileEntry(file, decorator);
     }

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/BasicBufferStore.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/BasicBufferStore.java
@@ -15,15 +15,10 @@
  */
 package com.asakusafw.vanilla.core.io;
 
-import static java.nio.file.StandardOpenOption.*;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.channels.WritableByteChannel;
-import java.nio.file.Files;
 import java.text.MessageFormat;
-import java.util.EnumSet;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -37,7 +32,7 @@ import com.asakusafw.vanilla.core.util.SystemProperty;
 /**
  * A basic implementation of {@link BufferStore}.
  * @since 0.4.0
- * @version 0.4.1
+ * @version 0.5.3
  */
 public class BasicBufferStore implements BufferStore, InterruptibleIo {
 
@@ -51,11 +46,13 @@ public class BasicBufferStore implements BufferStore, InterruptibleIo {
 
     private final int division;
 
+    final ByteChannelDecorator decorator;
+
     /**
      * Creates a new instance.
      */
     public BasicBufferStore() {
-        this(null, DEFAULT_PARTITION);
+        this(null, DEFAULT_PARTITION, ByteChannelDecorator.THROUGH);
     }
 
     /**
@@ -63,7 +60,7 @@ public class BasicBufferStore implements BufferStore, InterruptibleIo {
      * @param base the base directory
      */
     public BasicBufferStore(File base) {
-        this(base, DEFAULT_PARTITION);
+        this(base, DEFAULT_PARTITION, ByteChannelDecorator.THROUGH);
     }
 
     /**
@@ -73,10 +70,22 @@ public class BasicBufferStore implements BufferStore, InterruptibleIo {
      * @since 0.4.1
      */
     public BasicBufferStore(File base, int division) {
+        this(base, division, ByteChannelDecorator.THROUGH);
+    }
+
+    /**
+     * Creates a new instance.
+     * @param base the base directory
+     * @param division the maximum number of files in each sub-directory, or {@code 0} to disabled
+     * @param decorator the decorator for load/store operation
+     * @since 0.5.3
+     */
+    public BasicBufferStore(File base, int division, ByteChannelDecorator decorator) {
         this.directory = new File(
                 base != null ? base : SystemProperty.getTemporaryDirectory(),
                 String.format("asakusa-%s.tmp", UUID.randomUUID()));
         this.division = division;
+        this.decorator = decorator;
     }
 
     /**
@@ -98,13 +107,13 @@ public class BasicBufferStore implements BufferStore, InterruptibleIo {
     @Override
     public DataReader.Provider store(ByteBuffer buffer) throws IOException, InterruptedException {
         File file = prepare();
-        try (WritableByteChannel channel = Files.newByteChannel(file.toPath(), EnumSet.of(WRITE, CREATE_NEW))) {
-            channel.write(buffer);
+        try (DataWriter writer = ByteChannelWriter.open(file.toPath(), decorator)) {
+            writer.writeFully(buffer);
         }
         if (LOG.isTraceEnabled()) {
             LOG.trace("saving buffer: {}bytes -> {}", buffer.remaining(), file);
         }
-        return new FileEntry(file);
+        return new FileEntry(file, decorator);
     }
 
     /**
@@ -161,12 +170,15 @@ public class BasicBufferStore implements BufferStore, InterruptibleIo {
     /**
      * A builder for {@link BasicBufferStore}.
      * @since 0.4.1
+     * @version 0.5.3
      */
     public static final class Builder {
 
         private File directory;
 
         private int division = DEFAULT_PARTITION;
+
+        private ByteChannelDecorator decorator = ByteChannelDecorator.THROUGH;
 
         /**
          * Sets the directory.
@@ -189,11 +201,22 @@ public class BasicBufferStore implements BufferStore, InterruptibleIo {
         }
 
         /**
+         * Sets the decorator.
+         * @param newValue the decorator
+         * @return this
+         * @since 0.5.3
+         */
+        public Builder withDecorator(ByteChannelDecorator newValue) {
+            this.decorator = newValue;
+            return this;
+        }
+
+        /**
          * Builds a {@link BasicBufferStore}.
          * @return the created instance
          */
         public BasicBufferStore build() {
-            return new BasicBufferStore(directory, division);
+            return new BasicBufferStore(directory, division, decorator);
         }
     }
 
@@ -209,18 +232,18 @@ public class BasicBufferStore implements BufferStore, InterruptibleIo {
             if (LOG.isTraceEnabled()) {
                 LOG.trace("prepare BLOB: {}", file);
             }
-            return new FileWriter(file, ByteChannelWriter.open(file.toPath()));
+            return new FileWriter(file, ByteChannelWriter.open(file.toPath(), decorator));
         }
 
         @Override
         public DataReader.Provider commit(DataWriter writer) throws IOException, InterruptedException {
             Arguments.requireNonNull(writer);
             Arguments.require(writer instanceof FileWriter);
-            FileEntry entry = ((FileWriter) writer).release();
+            File file = ((FileWriter) writer).release();
             if (LOG.isTraceEnabled()) {
-                LOG.trace("commit BLOB: {} ({}bytes)", entry.file, entry.file.length());
+                LOG.trace("commit BLOB: {} ({}bytes)", file, file.length());
             }
-            return entry;
+            return new FileEntry(file, decorator);
         }
 
     }
@@ -259,11 +282,11 @@ public class BasicBufferStore implements BufferStore, InterruptibleIo {
             }
         }
 
-        FileEntry release() throws IOException, InterruptedException {
-            writer.close();
+        File release() throws IOException, InterruptedException {
             File f = file;
+            writer.close();
             file = null;
-            return new FileEntry(f);
+            return f;
         }
     }
 
@@ -271,13 +294,16 @@ public class BasicBufferStore implements BufferStore, InterruptibleIo {
 
         final File file;
 
-        FileEntry(File file) {
+        private final ByteChannelDecorator decorator;
+
+        FileEntry(File file, ByteChannelDecorator decorator) {
             this.file = file;
+            this.decorator = decorator;
         }
 
         @Override
-        public DataReader open() throws IOException {
-            return ByteChannelReader.open(file.toPath());
+        public DataReader open() throws IOException, InterruptedException {
+            return ByteChannelReader.open(file.toPath(), decorator);
         }
 
         @Override

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/BlobStore.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/BlobStore.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.core.io;
+
+import java.io.IOException;
+
+/**
+ * Provides binary large object.
+ * @since 0.5.3
+ */
+public interface BlobStore {
+
+    /**
+     * Creates a new BLOB and returns a writer of it.
+     * @return the created writer
+     * @throws IOException if I/O error was occurred while preparing the BLOB
+     * @throws InterruptedException if interrupted while preparing the BLOB
+     * @see #commit(DataWriter)
+     */
+    DataWriter create() throws IOException, InterruptedException;
+
+    /**
+     * Commits a created BLOB data created by {@link #create()}.
+     * This operation must be called BEFORE the given writer was closed,
+     * and the writer will be disabled after this operation.
+     * @param writer the BLOB writer
+     * @return the BLOB data
+     * @throws IOException if I/O error was occurred while saving the BLOB
+     * @throws InterruptedException if interrupted while saving the BLOB
+     */
+    DataReader.Provider commit(DataWriter writer) throws IOException, InterruptedException;
+}

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/BufferedByteChannelDecorator.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/BufferedByteChannelDecorator.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.core.io;
+
+import java.io.IOException;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+
+import com.asakusafw.vanilla.core.util.BufferedReadbleByteChannel;
+import com.asakusafw.vanilla.core.util.BufferedWritableByteChannel;
+
+/**
+ * An implementation of {@link ByteChannelDecorator} which provides buffers into byte channels.
+ * @since 0.5.3
+ */
+public class BufferedByteChannelDecorator implements ByteChannelDecorator {
+
+    @Override
+    public ReadableByteChannel decorate(ReadableByteChannel channel) throws IOException {
+        return new BufferedReadbleByteChannel(channel);
+    }
+
+    @Override
+    public WritableByteChannel decorate(WritableByteChannel channel) throws IOException {
+        return new BufferedWritableByteChannel(channel);
+    }
+}

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/ByteChannelDecorator.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/ByteChannelDecorator.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.core.io;
+
+import java.io.IOException;
+import java.nio.channels.ByteChannel;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+
+/**
+ * Decorates {@link ByteChannel}s.
+ * @since 0.5.3
+ */
+public interface ByteChannelDecorator {
+
+    /**
+     * The identity implementation of {@link ByteChannelDecorator}.
+     */
+    class Through implements ByteChannelDecorator {
+
+        @Override
+        public ReadableByteChannel decorate(ReadableByteChannel channel) {
+            return channel;
+        }
+
+        @Override
+        public WritableByteChannel decorate(WritableByteChannel channel) {
+            return channel;
+        }
+    }
+
+    /**
+     * The identity implementation of {@link ByteChannelDecorator}.
+     */
+    ByteChannelDecorator THROUGH = new Through();
+
+    /**
+     * Decorates the given channel.
+     * @param channel the source channel
+     * @return the decorated channel
+     * @throws IOException if I/O error was occurred while decorating the channel
+     * @throws InterruptedException if interrupted while decorating the channel
+     */
+    ReadableByteChannel decorate(ReadableByteChannel channel) throws IOException, InterruptedException;
+
+    /**
+     * Decorates the given channel.
+     * @param channel the source channel
+     * @return the decorated channel
+     * @throws IOException if I/O error was occurred while decorating the channel
+     * @throws InterruptedException if interrupted while decorating the channel
+     */
+    WritableByteChannel decorate(WritableByteChannel channel) throws IOException, InterruptedException;
+}

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/ByteChannelDecorator.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/ByteChannelDecorator.java
@@ -27,27 +27,6 @@ import java.nio.channels.WritableByteChannel;
 public interface ByteChannelDecorator {
 
     /**
-     * The identity implementation of {@link ByteChannelDecorator}.
-     */
-    class Through implements ByteChannelDecorator {
-
-        @Override
-        public ReadableByteChannel decorate(ReadableByteChannel channel) {
-            return channel;
-        }
-
-        @Override
-        public WritableByteChannel decorate(WritableByteChannel channel) {
-            return channel;
-        }
-    }
-
-    /**
-     * The identity implementation of {@link ByteChannelDecorator}.
-     */
-    ByteChannelDecorator THROUGH = new Through();
-
-    /**
      * Decorates the given channel.
      * @param channel the source channel
      * @return the decorated channel

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/ByteChannelReader.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/ByteChannelReader.java
@@ -31,6 +31,7 @@ import com.asakusafw.vanilla.core.util.Buffers;
 /**
  * An implementation of {@link DataReader} which just wraps {@link ReadableByteChannel}.
  * @since 0.4.0
+ * @since 0.5.3
  */
 public class ByteChannelReader implements DataReader {
 
@@ -55,7 +56,25 @@ public class ByteChannelReader implements DataReader {
      */
     public static DataReader open(Path path) throws IOException {
         Arguments.requireNonNull(path);
-        return new ByteChannelReader(Files.newByteChannel(path, EnumSet.of(READ)));
+        return new ByteChannelReader(open0(path));
+    }
+
+    /**
+     * Opens a file on the given path.
+     * @param path the target path
+     * @param decorator the decorator
+     * @return the related writer
+     * @throws IOException if I/O error was occurred while opening the file
+     * @throws InterruptedException if interrupted while opening the file
+     * @since 0.5.3
+     */
+    public static DataReader open(Path path, ByteChannelDecorator decorator) throws IOException, InterruptedException {
+        Arguments.requireNonNull(path);
+        return new ByteChannelReader(decorator.decorate(open0(path)));
+    }
+
+    private static ReadableByteChannel open0(Path path) throws IOException {
+        return Files.newByteChannel(path, EnumSet.of(READ));
     }
 
     @Override

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/ByteChannelWriter.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/ByteChannelWriter.java
@@ -30,6 +30,7 @@ import com.asakusafw.vanilla.core.util.Buffers;
 /**
  * An implementation of {@link DataWriter} which just wraps {@link WritableByteChannel}.
  * @since 0.4.0
+ * @version 0.5.3
  */
 public class ByteChannelWriter implements DataWriter {
 
@@ -54,7 +55,25 @@ public class ByteChannelWriter implements DataWriter {
      */
     public static DataWriter open(Path path) throws IOException {
         Arguments.requireNonNull(path);
-        return new ByteChannelWriter(Files.newByteChannel(path, EnumSet.of(WRITE, CREATE, TRUNCATE_EXISTING)));
+        return new ByteChannelWriter(open0(path));
+    }
+
+    /**
+     * Opens a file on the given path.
+     * @param path the target path
+     * @param decorator the decorator
+     * @return the related writer
+     * @throws IOException if I/O error was occurred while opening the file
+     * @throws InterruptedException if interrupted while opening the file
+     * @since 0.5.3
+     */
+    public static DataWriter open(Path path, ByteChannelDecorator decorator) throws IOException, InterruptedException {
+        Arguments.requireNonNull(path);
+        return new ByteChannelWriter(decorator.decorate(open0(path)));
+    }
+
+    private static WritableByteChannel open0(Path path) throws IOException {
+        return Files.newByteChannel(path, EnumSet.of(WRITE, CREATE, TRUNCATE_EXISTING));
     }
 
     @Override

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/DataWriter.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/DataWriter.java
@@ -67,6 +67,8 @@ public interface DataWriter extends InterruptibleIo {
 
         /**
          * Commits the written data.
+         * This operation must be called BEFORE the given writer was closed,
+         * and the writer will be disabled after this operation.
          * @param written the writer
          * @throws IOException if I/O error was occurred while committing the writer
          * @throws InterruptedException if interrupted while committing the writer

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/NullByteChannelDecorator.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/NullByteChannelDecorator.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.core.io;
+
+import java.io.IOException;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+
+/**
+ * An implementation of {@link ByteChannelDecorator} which decorates nothing and just returns the bare channels.
+ * @since 0.5.3
+ */
+public class NullByteChannelDecorator implements ByteChannelDecorator {
+
+    /**
+     * an instance of this class.
+     */
+    public static final NullByteChannelDecorator INSTANCE = new NullByteChannelDecorator();
+
+    @Override
+    public ReadableByteChannel decorate(ReadableByteChannel channel) throws IOException {
+        return channel;
+    }
+
+    @Override
+    public WritableByteChannel decorate(WritableByteChannel channel) throws IOException {
+        return channel;
+    }
+}

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/StreamGroupWriter.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/StreamGroupWriter.java
@@ -67,7 +67,7 @@ public class StreamGroupWriter implements ObjectWriter {
             KeyValueSerializer serializer, DataComparator comparator,
             int bufferSizeLimit, int recordCountLimit) {
         this(sinks, serializer, comparator,
-                bufferSizeLimit, Util.DEFAULT_BUFFER_FLUSH_FACTOR, recordCountLimit,
+                bufferSizeLimit, Util.DEFAULT_BUFFER_MARGIN_SIZE, recordCountLimit,
                 null);
     }
 
@@ -77,14 +77,14 @@ public class StreamGroupWriter implements ObjectWriter {
      * @param serializer the object serializer
      * @param comparator the value comparator (nullable)
      * @param bufferSizeLimit the internal buffer size limit in bytes
-     * @param bufferFlushFactor the internal buffer flush factor in the limit
+     * @param bufferMarginSize the internal buffer margin size in bytes
      * @param recordCountLimit the number of limit records in each page
      * @param resource the attached resource (nullable)
      */
     public StreamGroupWriter(
             KeyValueSink.Stream sinks,
             KeyValueSerializer serializer, DataComparator comparator,
-            int bufferSizeLimit, double bufferFlushFactor, int recordCountLimit,
+            int bufferSizeLimit, int bufferMarginSize, int recordCountLimit,
             InterruptibleIo resource) {
         Arguments.requireNonNull(sinks);
         Arguments.requireNonNull(serializer);
@@ -93,7 +93,7 @@ public class StreamGroupWriter implements ObjectWriter {
         this.sinks = sinks;
         this.serializer = serializer;
         this.comparator = comparator;
-        this.bufferSizeThreshold = Util.getBufferThreshold(bufferSizeLimit, bufferFlushFactor);
+        this.bufferSizeThreshold = Util.getBufferThreshold(bufferSizeLimit, bufferMarginSize);
         this.recordCountLimit = recordCountLimit;
         this.buffer = Util.newDataBuffer(bufferSizeLimit);
         this.resource = resource;

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/StreamObjectWriter.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/StreamObjectWriter.java
@@ -60,7 +60,7 @@ public class StreamObjectWriter implements ObjectWriter {
             Serializer serializer,
             int bufferSizeLimit, int recordCountLimit) {
         this(sinks, serializer,
-                bufferSizeLimit, Util.DEFAULT_BUFFER_FLUSH_FACTOR, recordCountLimit,
+                bufferSizeLimit, Util.DEFAULT_BUFFER_MARGIN_SIZE, recordCountLimit,
                 null);
     }
 
@@ -69,14 +69,14 @@ public class StreamObjectWriter implements ObjectWriter {
      * @param sinks the next sink provider
      * @param serializer the object serializer
      * @param bufferSizeLimit the internal buffer size limit in bytes
-     * @param bufferFlushFactor the internal buffer flush factor in the limit
+     * @param bufferMarginSize the internal buffer margin size in bytes
      * @param recordCountLimit the number of limit records in each page
      * @param resource the attached resource (nullable)
      */
     public StreamObjectWriter(
             RecordSink.Stream sinks,
             Serializer serializer,
-            int bufferSizeLimit, double bufferFlushFactor, int recordCountLimit,
+            int bufferSizeLimit, int bufferMarginSize, int recordCountLimit,
             InterruptibleIo resource) {
         Arguments.requireNonNull(sinks);
         Arguments.requireNonNull(serializer);
@@ -84,7 +84,7 @@ public class StreamObjectWriter implements ObjectWriter {
         Arguments.require(recordCountLimit > 0);
         this.sinks = sinks;
         this.serializer = serializer;
-        this.bufferSizeSoftLimit = Util.getBufferThreshold(bufferSizeLimit, bufferFlushFactor);
+        this.bufferSizeSoftLimit = Util.getBufferThreshold(bufferSizeLimit, bufferMarginSize);
         this.recordCountLimit = recordCountLimit;
         this.buffer = Util.newDataBuffer(bufferSizeLimit);
         this.resource = resource;

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/Util.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/Util.java
@@ -21,11 +21,9 @@ final class Util {
 
     static final int MIN_BUFFER_SIZE = 64 * 1024;
 
-    private static final double MIN_BUFFER_FLUSH_FACTOR = 0.10;
+    private static final int MIN_BUFFER_MARGIN_SIZE = 256;
 
-    private static final double MAX_BUFFER_FLUSH_FACTOR = 0.99;
-
-    static final double DEFAULT_BUFFER_FLUSH_FACTOR = 0.90;
+    static final int DEFAULT_BUFFER_MARGIN_SIZE = 256 * 1024;
 
     static int getBufferSize(int limit) {
         return Math.max(limit, MIN_BUFFER_SIZE);
@@ -35,10 +33,9 @@ final class Util {
         return new ExtensibleDataBuffer(MIN_BUFFER_SIZE, getBufferSize(limit));
     }
 
-    static int getBufferThreshold(int limit, double flushFactor) {
-        double factor = Math.min(Math.max(flushFactor, MIN_BUFFER_FLUSH_FACTOR), MAX_BUFFER_FLUSH_FACTOR);
-        int size = getBufferSize(limit);
-        return (int) (size * factor);
+    static int getBufferThreshold(int limit, int marginSize) {
+        int margin = Math.min(Math.max(marginSize, MIN_BUFFER_MARGIN_SIZE), (limit + 1) / 2);
+        return limit - margin;
     }
 
     private Util() {

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/mirror/MockDataChannel.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/mirror/MockDataChannel.java
@@ -42,6 +42,7 @@ public class MockDataChannel implements DataWriter.Channel {
         ByteBuffer buffer = Buffers.duplicate(w.getBuffer());
         buffer.flip();
         committed.add(buffer);
+        written.close();
     }
 
     /**

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/util/BufferedReadbleByteChannel.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/util/BufferedReadbleByteChannel.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.core.util;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+
+/**
+ * A {@link ReadableByteChannel} with I/O buffer.
+ * @since 0.5.3
+ */
+public class BufferedReadbleByteChannel implements ReadableByteChannel {
+
+    private final ReadableByteChannel channel;
+
+    private final ByteBuffer buffer;
+
+    /**
+     * Creates a new instance.
+     * @param channel the source channel
+     * @see Buffers#KEY_INPUT_CHANNEL_BUFFER_SIZE
+     */
+    public BufferedReadbleByteChannel(ReadableByteChannel channel) {
+        this(channel, Buffers.INPUT_CHANNEL_BUFFER_SIZE);
+    }
+
+    /**
+     * Creates a new instance.
+     * @param channel the source channel
+     * @param bufferSize the buffer size in bytes
+     */
+    public BufferedReadbleByteChannel(ReadableByteChannel channel, int bufferSize) {
+        this.channel = channel;
+        this.buffer = Buffers.allocate(bufferSize);
+        buffer.flip();
+    }
+
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+        while (true) {
+            // copies buffered contents into the destination buffer if remained
+            if (buffer.hasRemaining()) {
+                if (dst.remaining() >= buffer.remaining()) {
+                    int size = buffer.remaining();
+                    dst.put(buffer);
+                    return size;
+                }
+                int size = dst.remaining();
+                int limit = buffer.limit();
+                buffer.limit(buffer.position() + size);
+                dst.put(buffer);
+                buffer.limit(limit);
+                return size;
+            }
+
+            if (dst.remaining() >= buffer.capacity()) {
+                return channel.read(dst);
+            }
+
+            buffer.clear();
+            int read = channel.read(buffer);
+            buffer.flip();
+            if (read <= 0) {
+                return read;
+            }
+        }
+    }
+
+    @Override
+    public boolean isOpen() {
+        return channel.isOpen();
+    }
+
+    @Override
+    public void close() throws IOException {
+        channel.close();
+    }
+}

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/util/BufferedWritableByteChannel.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/util/BufferedWritableByteChannel.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.core.util;
+
+import java.io.Flushable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
+
+/**
+ * A {@link WritableByteChannel} with I/O buffer.
+ * @since 0.5.3
+ */
+public class BufferedWritableByteChannel implements WritableByteChannel, Flushable {
+
+    private final WritableByteChannel channel;
+
+    private final ByteBuffer buffer;
+
+    /**
+     * Creates a new instance.
+     * @param channel the destination channel
+     * @see Buffers#KEY_OUTPUT_CHANNEL_BUFFER_SIZE
+     */
+    public BufferedWritableByteChannel(WritableByteChannel channel) {
+        this(channel, Buffers.OUTPUT_CHANNEL_BUFFER_SIZE);
+    }
+
+    /**
+     * Creates a new instance.
+     * @param channel the destination channel
+     * @param bufferSize the buffer size in bytes
+     */
+    public BufferedWritableByteChannel(WritableByteChannel channel, int bufferSize) {
+        this.channel = channel;
+        this.buffer = Buffers.allocate(bufferSize);
+    }
+
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+        if (buffer.remaining() > src.remaining()) {
+            int size = src.remaining();
+            buffer.put(src);
+            return size;
+        }
+
+        if (buffer.hasRemaining()) {
+            int size = buffer.remaining();
+            int limit = src.limit();
+            src.limit(src.position() + size);
+            buffer.put(src);
+            src.limit(limit);
+            return size;
+        }
+
+        flush();
+        if (src.remaining() >= buffer.remaining()) {
+            return channel.write(src);
+        }
+
+        int size = src.remaining();
+        buffer.put(src);
+        return size;
+    }
+
+    @Override
+    public void flush() throws IOException {
+        buffer.flip();
+        while (buffer.hasRemaining()) {
+            channel.write(buffer);
+        }
+        buffer.clear();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return channel.isOpen();
+    }
+
+    @Override
+    public void close() throws IOException {
+        flush();
+        channel.close();
+    }
+}

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/util/Buffers.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/util/Buffers.java
@@ -90,7 +90,7 @@ public final class Buffers {
      * The default value of {@link #KEY_INPUT_CHANNEL_BUFFER_SIZE}.
      * @since 0.5.3
      */
-    public static final int DEFAULT_INPUT_CHANNEL_BUFFER_SIZE = 64 * 1024;
+    public static final int DEFAULT_INPUT_CHANNEL_BUFFER_SIZE = 8 * 1024;
 
     /**
      * The system property key of output channel buffer size in bytes
@@ -103,7 +103,7 @@ public final class Buffers {
      * The default value of {@link #KEY_OUTPUT_CHANNEL_BUFFER_SIZE}.
      * @since 0.5.3
      */
-    public static final int DEFAULT_OUTPUT_CHANNEL_BUFFER_SIZE = 64 * 1024;
+    public static final int DEFAULT_OUTPUT_CHANNEL_BUFFER_SIZE = 8 * 1024;
 
     static final int MIN_SIZE = 64 * 1024;
 

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/util/Buffers.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/util/Buffers.java
@@ -26,6 +26,7 @@ import com.asakusafw.vanilla.core.engine.BasicVertexScheduler;
 /**
  * Utilities about {@link ByteBuffer}.
  * @since 0.4.0
+ * @version 0.5.3
  */
 public final class Buffers {
 
@@ -78,6 +79,32 @@ public final class Buffers {
      */
     public static final int DEFAULT_MIN_SHRINK_CAPACITY = 64 * 1024;
 
+    /**
+     * The system property key of input channel buffer size in bytes
+     * ({@value}: {@value #DEFAULT_INPUT_CHANNEL_BUFFER_SIZE}}).
+     * @since 0.5.3
+     */
+    public static final String KEY_INPUT_CHANNEL_BUFFER_SIZE = KEY_PREFIX + "channel.input.size"; //$NON-NLS-1$
+
+    /**
+     * The default value of {@link #KEY_INPUT_CHANNEL_BUFFER_SIZE}.
+     * @since 0.5.3
+     */
+    public static final int DEFAULT_INPUT_CHANNEL_BUFFER_SIZE = 64 * 1024;
+
+    /**
+     * The system property key of output channel buffer size in bytes
+     * ({@value}: {@value #DEFAULT_OUTPUT_CHANNEL_BUFFER_SIZE}}).
+     * @since 0.5.3
+     */
+    public static final String KEY_OUTPUT_CHANNEL_BUFFER_SIZE = KEY_PREFIX + "channel.output.size"; //$NON-NLS-1$
+
+    /**
+     * The default value of {@link #KEY_OUTPUT_CHANNEL_BUFFER_SIZE}.
+     * @since 0.5.3
+     */
+    public static final int DEFAULT_OUTPUT_CHANNEL_BUFFER_SIZE = 64 * 1024;
+
     static final int MIN_SIZE = 64 * 1024;
 
     static final boolean HEAP = SystemProperty.get(KEY_HEAP, DEFAULT_HEAP);
@@ -88,13 +115,20 @@ public final class Buffers {
 
     static final int MIN_SHRINK_CAPACITY = SystemProperty.get(KEY_MIN_SHRINK_CAPACITY, DEFAULT_MIN_SHRINK_CAPACITY);
 
+    static final int INPUT_CHANNEL_BUFFER_SIZE =
+            SystemProperty.get(KEY_INPUT_CHANNEL_BUFFER_SIZE, DEFAULT_INPUT_CHANNEL_BUFFER_SIZE);
+
+    static final int OUTPUT_CHANNEL_BUFFER_SIZE =
+            SystemProperty.get(KEY_OUTPUT_CHANNEL_BUFFER_SIZE, DEFAULT_OUTPUT_CHANNEL_BUFFER_SIZE);
+
     static {
         if (LOG.isDebugEnabled()) {
             LOG.debug("buffers:");
             LOG.debug("  {}: {}", KEY_HEAP, HEAP);
             LOG.debug("  {}: {}", KEY_EXPANSION_FACTOR, EXPANSION_FACTOR);
             LOG.debug("  {}: {}", KEY_MAX_SHRINK_UTILITY, MAX_SHRINK_UTILITY);
-            LOG.debug("  {}: {}", KEY_MIN_SHRINK_CAPACITY, MIN_SHRINK_CAPACITY);
+            LOG.debug("  {}: {}", KEY_INPUT_CHANNEL_BUFFER_SIZE, INPUT_CHANNEL_BUFFER_SIZE);
+            LOG.debug("  {}: {}", KEY_OUTPUT_CHANNEL_BUFFER_SIZE, OUTPUT_CHANNEL_BUFFER_SIZE);
         }
     }
 

--- a/vanilla/runtime/core/src/test/java/com/asakusafw/vanilla/core/engine/BasicEdgeDriverTest.java
+++ b/vanilla/runtime/core/src/test/java/com/asakusafw/vanilla/core/engine/BasicEdgeDriverTest.java
@@ -87,7 +87,7 @@ public class BasicEdgeDriverTest {
 
     private final int bufferSize = 10_000;
 
-    private final double flushFactor = 0.9;
+    private final int bufferMargin = 1_000;
 
     private final int recordCount = 10_000;
 
@@ -825,7 +825,7 @@ public class BasicEdgeDriverTest {
                 graph,
                 pool, store.getBlobStore(),
                 partitions,
-                bufferSize, flushFactor, recordCount,
+                bufferSize, bufferMargin, recordCount,
                 mergeThreshold, mergeFactor);
     }
 

--- a/vanilla/runtime/core/src/test/java/com/asakusafw/vanilla/core/engine/BasicEdgeDriverTest.java
+++ b/vanilla/runtime/core/src/test/java/com/asakusafw/vanilla/core/engine/BasicEdgeDriverTest.java
@@ -776,7 +776,7 @@ public class BasicEdgeDriverTest {
     }
 
     private static void complete(EdgeDriver edges, PortId id) throws IOException, InterruptedException {
-        LOG.debug("complete {} ({})", id, edges.toString());
+        LOG.debug("complete {} ({})", id, edges);
         edges.complete(id);
     }
 

--- a/vanilla/runtime/core/src/test/java/com/asakusafw/vanilla/core/engine/BasicEdgeDriverTest.java
+++ b/vanilla/runtime/core/src/test/java/com/asakusafw/vanilla/core/engine/BasicEdgeDriverTest.java
@@ -67,7 +67,8 @@ public class BasicEdgeDriverTest {
     public final ExternalResource lifecycle = new ExternalResource() {
         @Override
         protected void before() throws Throwable {
-            store = new BasicBufferStore();
+            store = BasicBufferStore.builder()
+                    .build();
             pool = new BasicBufferPool(1_000_000, store);
         }
         @Override

--- a/vanilla/runtime/core/src/test/java/com/asakusafw/vanilla/core/io/BasicBufferStoreTest.java
+++ b/vanilla/runtime/core/src/test/java/com/asakusafw/vanilla/core/io/BasicBufferStoreTest.java
@@ -99,4 +99,31 @@ public class BasicBufferStoreTest {
         }
         assertThat(directory.exists(), is(false));
     }
+
+    /**
+     * using BlobStore.
+     * @throws Exception if failed
+     */
+    @Test
+    public void blob() throws Exception {
+        File directory;
+        try (BasicBufferStore store = new BasicBufferStore()) {
+            directory = store.getDirectory();
+            BlobStore blobs = store.getBlobStore();
+            DataReader.Provider provider;
+            try (DataWriter writer = blobs.create()) {
+                writer.writeInt(100);
+                writer.writeInt(200);
+                writer.writeInt(300);
+                provider = blobs.commit(writer);
+            }
+            try (DataReader.Provider p = provider;
+                    DataReader reader = p.open()) {
+                assertThat(reader.readInt(), is(100));
+                assertThat(reader.readInt(), is(200));
+                assertThat(reader.readInt(), is(300));
+            }
+        }
+        assertThat(directory.exists(), is(false));
+    }
 }

--- a/vanilla/runtime/core/src/test/java/com/asakusafw/vanilla/core/io/BasicBufferStoreTest.java
+++ b/vanilla/runtime/core/src/test/java/com/asakusafw/vanilla/core/io/BasicBufferStoreTest.java
@@ -101,6 +101,25 @@ public class BasicBufferStoreTest {
     }
 
     /**
+     * w/ decorator.
+     * @throws Exception if failed
+     */
+    @Test
+    public void decorator() throws Exception {
+        File directory;
+        try (BasicBufferStore store = BasicBufferStore.builder()
+                .withDecorator(new MockByteChannelDecorator())
+                .build()) {
+            directory = store.getDirectory();
+            try (DataReader.Provider entry = store.store(buffer("Hello, world!"))) {
+                assertThat(read(entry), is("Hello, world!"));
+                assertThat(read(entry), is("Hello, world!"));
+            }
+        }
+        assertThat(directory.exists(), is(false));
+    }
+
+    /**
      * using BlobStore.
      * @throws Exception if failed
      */
@@ -108,6 +127,35 @@ public class BasicBufferStoreTest {
     public void blob() throws Exception {
         File directory;
         try (BasicBufferStore store = new BasicBufferStore()) {
+            directory = store.getDirectory();
+            BlobStore blobs = store.getBlobStore();
+            DataReader.Provider provider;
+            try (DataWriter writer = blobs.create()) {
+                writer.writeInt(100);
+                writer.writeInt(200);
+                writer.writeInt(300);
+                provider = blobs.commit(writer);
+            }
+            try (DataReader.Provider p = provider;
+                    DataReader reader = p.open()) {
+                assertThat(reader.readInt(), is(100));
+                assertThat(reader.readInt(), is(200));
+                assertThat(reader.readInt(), is(300));
+            }
+        }
+        assertThat(directory.exists(), is(false));
+    }
+
+    /**
+     * using BlobStore.
+     * @throws Exception if failed
+     */
+    @Test
+    public void blob_decorator() throws Exception {
+        File directory;
+        try (BasicBufferStore store = BasicBufferStore.builder()
+                .withDecorator(new MockByteChannelDecorator())
+                .build()) {
             directory = store.getDirectory();
             BlobStore blobs = store.getBlobStore();
             DataReader.Provider provider;

--- a/vanilla/runtime/core/src/test/java/com/asakusafw/vanilla/core/io/ByteChannelWriterTest.java
+++ b/vanilla/runtime/core/src/test/java/com/asakusafw/vanilla/core/io/ByteChannelWriterTest.java
@@ -52,4 +52,22 @@ public class ByteChannelWriterTest {
             assertThat(read(reader), is(value));
         }
     }
+
+    /**
+     * w/ decorator.
+     * @throws Exception if failed
+     */
+    @Test
+    public void decorate() throws Exception {
+        String value = "Hello, world!";
+        File file = folder.newFile();
+        ByteChannelDecorator  decorator = new MockByteChannelDecorator();
+        try (DataWriter writer = ByteChannelWriter.open(file.toPath(), decorator)) {
+            assertThat(writer.getBuffer(), is(nullValue()));
+            write(writer, value);
+        }
+        try (DataReader reader = ByteChannelReader.open(file.toPath(), decorator)) {
+            assertThat(read(reader), is(value));
+        }
+    }
 }

--- a/vanilla/runtime/core/src/test/java/com/asakusafw/vanilla/core/io/MockByteChannelDecorator.java
+++ b/vanilla/runtime/core/src/test/java/com/asakusafw/vanilla/core/io/MockByteChannelDecorator.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.core.io;
+
+import java.io.IOException;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+
+import org.xerial.snappy.SnappyFramedInputStream;
+import org.xerial.snappy.SnappyFramedOutputStream;
+
+import com.asakusafw.vanilla.core.io.ByteChannelDecorator;
+
+/**
+ * An implementation of {@link ByteChannelDecorator} which using snappy compression.
+ * @since 0.5.3
+ */
+public class MockByteChannelDecorator implements ByteChannelDecorator {
+
+    @Override
+    public ReadableByteChannel decorate(ReadableByteChannel channel) throws IOException {
+        return new SnappyFramedInputStream(channel, false);
+    }
+
+    @Override
+    public WritableByteChannel decorate(WritableByteChannel channel) throws IOException {
+        return new SnappyFramedOutputStream(channel);
+    }
+}

--- a/vanilla/runtime/core/src/test/java/com/asakusafw/vanilla/core/util/BufferedReadbleByteChannelTest.java
+++ b/vanilla/runtime/core/src/test/java/com/asakusafw/vanilla/core/util/BufferedReadbleByteChannelTest.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.core.util;
+
+import static org.junit.Assert.*;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Test for {@link BufferedReadbleByteChannel}.
+ */
+public class BufferedReadbleByteChannelTest {
+
+    /**
+     * temporary folder.
+     */
+    @Rule
+    public final TemporaryFolder temporary = new TemporaryFolder();
+
+    /**
+     * simple case.
+     * @throws Exception if failed
+     */
+    @Test
+    public void simple() throws Exception {
+        int size = 1_024_000;
+        File file = create(size);
+        try (BufferedReadbleByteChannel c = new BufferedReadbleByteChannel(
+                Files.newByteChannel(file.toPath(), StandardOpenOption.READ), 256)) {
+            ByteBuffer buf = Buffers.allocate(1);
+            for (int i = 0; i < size; i++) {
+                buf.clear();
+                int read = c.read(buf);
+                assertEquals(read, 1);
+                assertFalse(buf.hasRemaining());
+                buf.flip();
+                assertEquals(buf.get(), (byte) i);
+            }
+
+            buf.clear();
+            int read = c.read(buf);
+            assertEquals(read, -1);
+            assertTrue(buf.hasRemaining());
+        }
+    }
+
+    /**
+     * w/ small buffer.
+     * @throws Exception if failed
+     */
+    @Test
+    public void small_buffer() throws Exception {
+        int size = 1_024_000;
+        File file = create(size);
+        try (BufferedReadbleByteChannel c = new BufferedReadbleByteChannel(
+                Files.newByteChannel(file.toPath(), StandardOpenOption.READ), 256)) {
+            ByteBuffer buf = Buffers.allocate(99);
+            int position = readAll(c, buf);
+            assertEquals(position, size);
+        }
+    }
+
+    /**
+     * w/ large buffer.
+     * @throws Exception if failed
+     */
+    @Test
+    public void large_buffer() throws Exception {
+        int size = 1_024_000;
+        File file = create(size);
+        try (BufferedReadbleByteChannel c = new BufferedReadbleByteChannel(
+                Files.newByteChannel(file.toPath(), StandardOpenOption.READ), 256)) {
+            ByteBuffer buf = Buffers.allocate(1025);
+            int position = readAll(c, buf);
+            assertEquals(position, size);
+        }
+    }
+
+    private static int readAll(BufferedReadbleByteChannel channel, ByteBuffer buffer) throws IOException {
+        int position = 0;
+        while (true) {
+            buffer.clear();
+            int read = channel.read(buffer);
+            if (read == -1) {
+                break;
+            }
+            buffer.flip();
+            while (buffer.hasRemaining()) {
+                assertEquals(buffer.get(), (byte) position++);
+            }
+        }
+        return position;
+    }
+
+    private File create(int size) throws IOException {
+        File file = temporary.newFile();
+        try (OutputStream w = new BufferedOutputStream(new FileOutputStream(file))) {
+            for (int i = 0; i < size; i++) {
+                w.write(i);
+            }
+        }
+        return file;
+    }
+}

--- a/vanilla/runtime/core/src/test/java/com/asakusafw/vanilla/core/util/BufferedWritableByteChannelTest.java
+++ b/vanilla/runtime/core/src/test/java/com/asakusafw/vanilla/core/util/BufferedWritableByteChannelTest.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.core.util;
+
+import static org.junit.Assert.*;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Test for {@link BufferedWritableByteChannel}.
+ */
+public class BufferedWritableByteChannelTest {
+
+    /**
+     * temporary folder.
+     */
+    @Rule
+    public final TemporaryFolder temporary = new TemporaryFolder();
+
+    /**
+     * simple cast.
+     * @throws Exception if failed
+     */
+    @Test
+    public void simple() throws Exception {
+        File file = temporary.newFile();
+        int size = 1_024_000;
+        try (BufferedWritableByteChannel c = new BufferedWritableByteChannel(
+                Files.newByteChannel(file.toPath(), StandardOpenOption.WRITE), 256)) {
+            ByteBuffer buf = Buffers.allocate(1);
+            for (int i = 0; i < size; i++) {
+                buf.clear();
+                buf.put((byte) i);
+                buf.flip();
+                int written = c.write(buf);
+                assertEquals(written, 1);
+                assertFalse(buf.hasRemaining());
+            }
+        }
+        verify(file, size);
+    }
+
+    /**
+     * w/ small buffer.
+     * @throws Exception if failed
+     */
+    @Test
+    public void small_buffer() throws Exception {
+        File file = temporary.newFile();
+        int size = 1_024_000;
+        try (BufferedWritableByteChannel c = new BufferedWritableByteChannel(
+                Files.newByteChannel(file.toPath(), StandardOpenOption.WRITE), 256)) {
+            ByteBuffer buf = Buffers.allocate(65);
+            writeAll(c, buf, size);
+        }
+        verify(file, size);
+    }
+
+    /**
+     * w/ large buffer.
+     * @throws Exception if failed
+     */
+    @Test
+    public void large_buffer() throws Exception {
+        File file = temporary.newFile();
+        int size = 1_024_000;
+        try (BufferedWritableByteChannel c = new BufferedWritableByteChannel(
+                Files.newByteChannel(file.toPath(), StandardOpenOption.WRITE), 256)) {
+            ByteBuffer buf = Buffers.allocate(1025);
+            writeAll(c, buf, size);
+        }
+        verify(file, size);
+    }
+
+    private void writeAll(BufferedWritableByteChannel channel, ByteBuffer buffer, int size) throws IOException {
+        int position = 0;
+        while (position < size) {
+            buffer.clear();
+            while (position < size && buffer.hasRemaining()) {
+                buffer.put((byte) position++);
+            }
+            buffer.flip();
+            while (buffer.hasRemaining()) {
+                int remain = buffer.remaining();
+                int written = channel.write(buffer);
+                assertEquals(buffer.remaining(), remain - written);
+            }
+        }
+    }
+
+    private void verify(File file, int size) throws IOException {
+        int position = 0;
+        try (BufferedInputStream in = new BufferedInputStream(new FileInputStream(file))) {
+            while (true) {
+                int c = in.read();
+                if (c < 0) {
+                    break;
+                }
+                assertEquals(c, position++ & 0xff);
+            }
+        }
+        assertEquals(position, size);
+    }
+}


### PR DESCRIPTION
## Summary

This PR revises buffer spilling mechanism in Asakusa Vanilla.

## Background, Problem or Goal of the patch

This introduces the following features:

* spill files compression
* improve spill file I/O
* multiple stage merging (on scatter/gather)

## Design of the fix, or a new feature

The series of commits in this PR introduce the following configurations (as Asakusa Vanilla engine configurations):

* `com.asakusafw.vanilla.merge.threshold`
    * the maximum number of merging scatter/gather input chunks at one time per thread
    * default: `0` (disable multi stage merging)
* `com.asakusafw.vanilla.merge.factor`
    * if the scatter/gather input chunks are exceeded, the engine will decide the number of target files at the rate of the above threshold
    * default: `1.0` (merge the same number of `com.asakusafw.vanilla.merge.threshold`)
* `com.asakusafw.vanilla.pool.compression`
  * a decorator class for spill file I/O
    * must be a sub-class name of `com.asakusafw.vanilla.core.io.ByteChannelDecorator`
  * available values:
    * `com.asakusafw.vanilla.client.util.SnappyByteChannelDecorator`
      * compress spill files by snappy
    * `com.asakusafw.vanilla.core.io.BufferedByteChannelDecorator` (default)
      * never compress spill files with I/O buffering
      * feature configuration (by **system** properties)
        * `com.asakusafw.vanilla.buffer.channel.input.size`
          * system property key of input channel buffer size in bytes
          * default: `8192` (8KB)
        * `com.asakusafw.vanilla.buffer.channel.output.size`
          * system property key of output channel buffer size in bytes
          * default: `8192` (8KB)
    * `com.asakusafw.vanilla.core.io.NullByteChannelDecorator`
      * never compress spill files **without** I/O buffering (for testing purpose)

This also introduces `com.asakusafw.vanilla.output.buffer.margin` option.

* `com.asakusafw.vanilla.output.buffer.margin`
    * output buffer margin size in bytes
    * if the output buffer usage was exceeded
        `(..output.buffer.size - output.buffer.margin)`, then its buffer will be
        flushed and the engine will use another new buffer.
    * this should be greater than the maximum record size
    * default: `1048576` (1MB)

Note that, `com.asakusafw.vanilla.output.buffer.flush` was superseded. Additionally, `..factor` in official document looks typo of `..flush`.

## Related Issue, Pull Request or Code

N/A.
