### PR TITLE
enable buffer spill compression with LZ4 in Asakusa Vanilla.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     <gson.version>2.8.1</gson.version>
     <jackson.version>2.9.7</jackson.version>
     <h2.version>1.4.196</h2.version>
+    <lz4.version>1.5.1</lz4.version>
     <slf4j.version>1.7.25</slf4j.version>
     <logback.version>1.2.3</logback.version>
     <junit.version>4.12</junit.version>
@@ -770,6 +771,11 @@ encoding/<project>=UTF-8
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
         <version>${h2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.lz4</groupId>
+        <artifactId>lz4-java</artifactId>
+        <version>${lz4.version}</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>

--- a/vanilla/runtime/client/pom.xml
+++ b/vanilla/runtime/client/pom.xml
@@ -35,6 +35,11 @@
       <artifactId>hadoop-common</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.lz4</groupId>
+      <artifactId>lz4-java</artifactId>
+      <scope>provided</scope> <!-- FIXME -->
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/vanilla/runtime/client/pom.xml
+++ b/vanilla/runtime/client/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>org.lz4</groupId>
       <artifactId>lz4-java</artifactId>
-      <scope>provided</scope> <!-- FIXME -->
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/VanillaConfiguration.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/VanillaConfiguration.java
@@ -28,7 +28,6 @@ import java.util.function.DoubleConsumer;
 import java.util.function.Function;
 import java.util.function.IntConsumer;
 import java.util.function.LongConsumer;
-import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -286,6 +285,7 @@ public class VanillaConfiguration {
     /**
      * Sets the swap file decorator.
      * @param newValue the decorator class name
+     * @since 0.5.3
      */
     public void setSwapDecorator(String newValue) {
         setSwapDecorator(SupplierInfo.of(newValue));
@@ -294,6 +294,7 @@ public class VanillaConfiguration {
     /**
      * Sets the swap file decorator.
      * @param newValue the decorator class supplier
+     * @since 0.5.3
      */
     public void setSwapDecorator(SupplierInfo newValue) {
         this.swapDecorator = Optional.ofNullable(newValue);
@@ -302,19 +303,10 @@ public class VanillaConfiguration {
     /**
      * Returns the swap file decorator.
      * @return the swap file decorator class information
+     * @since 0.5.3
      */
     public SupplierInfo getSwapDecorator() {
         return swapDecorator.orElse(DEFAULT_SWAP_DECORATOR);
-    }
-
-    /**
-     * Returns the swap file decorator.
-     * @param loader the class loader
-     * @return the swap file decorator
-     */
-    public ByteChannelDecorator getSwapDecorator(ClassLoader loader) {
-        Supplier<?> supplier = getSwapDecorator().newInstance(loader);
-        return (ByteChannelDecorator) supplier.get();
     }
 
     /**

--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/Lz4ByteChannelDecorator.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/Lz4ByteChannelDecorator.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.client.util;
+
+import java.io.IOException;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+
+import com.asakusafw.vanilla.core.io.ByteChannelDecorator;
+
+/**
+ * An implementation of {@link ByteChannelDecorator} which using LZ4 compression.
+ * @since 0.5.3
+ */
+public class Lz4ByteChannelDecorator implements ByteChannelDecorator {
+
+    @Override
+    public ReadableByteChannel decorate(ReadableByteChannel channel) throws IOException {
+        return new Lz4FramedReadableByteChannel(channel);
+    }
+
+    @Override
+    public WritableByteChannel decorate(WritableByteChannel channel) throws IOException {
+        return new Lz4FramedWritableByteChannel(channel);
+    }
+}

--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/Lz4FramedReadableByteChannel.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/Lz4FramedReadableByteChannel.java
@@ -67,7 +67,8 @@ public class Lz4FramedReadableByteChannel implements ReadableByteChannel {
         if (!uncompressed.hasRemaining()) {
             // first, obtain compressed frame info
             ByteBuffer compressed = compressedFrameBuffer;
-            Buffers.range(compressed, 0, Integer.BYTES);
+            compressed.clear();
+            compressed.limit(Integer.BYTES);
             do {
                 int read = channel.read(compressed);
                 if (read == -1) {

--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/Lz4FramedReadableByteChannel.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/Lz4FramedReadableByteChannel.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.client.util;
+
+import static com.asakusafw.vanilla.client.util.Lz4Util.*;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+
+import com.asakusafw.vanilla.core.util.Buffers;
+
+/**
+ * A {@link ReadableByteChannel} for written by {@link Lz4FramedWritableByteChannel}.
+ * @since 0.5.3
+ */
+public class Lz4FramedReadableByteChannel implements ReadableByteChannel {
+
+    private final ReadableByteChannel channel;
+
+    private volatile ByteBuffer uncompressedFrameBuffer;
+
+    private ByteBuffer compressedFrameBuffer;
+
+    /**
+     * creates a new instance.
+     * @param channel the destination channel
+     */
+    public Lz4FramedReadableByteChannel(ReadableByteChannel channel) {
+        this.channel = channel;
+    }
+
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+        ByteBuffer src = fill();
+        if (src == null) {
+            return -1;
+        }
+        return Buffers.put(src, dst);
+    }
+
+    private ByteBuffer fill() throws IOException {
+        ByteBuffer uncompressed = uncompressedFrameBuffer;
+        if (uncompressed == null) {
+            int uncompressedFrameSize = readFramedChannelHeader(channel);
+            uncompressed = Buffers.allocate(uncompressedFrameSize);
+            uncompressed.flip();
+
+            this.uncompressedFrameBuffer = uncompressed;
+            this.compressedFrameBuffer = Buffers.allocate(getMaxCompressedFrameSize(uncompressedFrameSize));
+        }
+
+        if (!uncompressed.hasRemaining()) {
+            // first, obtain compressed frame info
+            ByteBuffer compressed = compressedFrameBuffer;
+            Buffers.range(compressed, 0, Integer.BYTES);
+            do {
+                int read = channel.read(compressed);
+                if (read == -1) {
+                    if (compressed.position() == 0) {
+                        // return null if no more compressed frames
+                        return null;
+                    } else {
+                        throw new EOFException();
+                    }
+                }
+            } while (compressed.hasRemaining());
+            compressed.flip();
+            int compressedFrameInfo = compressed.getInt();
+            int compressedDataSize = compressedFrameInfo & COMPRESSED_DATA_SIZE_MASK;
+            boolean isCompleteFrame = (compressedFrameInfo & INCOMPLETE_FRAME_FLAG) == 0;
+
+            // next, read the rest of compressed frame
+            compressed.clear();
+            compressed.limit(compressedDataSize + (isCompleteFrame ? 0 : Integer.BYTES));
+            do {
+                int read = channel.read(compressed);
+                if (read < 0) {
+                    throw new EOFException();
+                }
+            } while (compressed.hasRemaining());
+            compressed.flip();
+
+            // finally, uncompress the frame data
+            uncompressed.clear();
+            if (!isCompleteFrame) {
+                // limit destination buffer for incomplete frames
+                int uncompresssedFrameSize = compressed.getInt();
+                uncompressed.limit(uncompresssedFrameSize);
+            }
+            FRAME_DECOMPRESSOR.decompress(compressed, uncompressed);
+            uncompressed.flip();
+        }
+
+        return uncompressed;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return channel.isOpen();
+    }
+
+    @Override
+    public void close() throws IOException {
+        channel.close();
+    }
+}

--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/Lz4FramedWritableByteChannel.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/Lz4FramedWritableByteChannel.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.client.util;
+
+import static com.asakusafw.vanilla.client.util.Lz4Util.*;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
+
+import com.asakusafw.vanilla.core.util.Buffers;
+
+/**
+ * A {@link WritableByteChannel} with LZ4 compression by each frame.
+ * @since 0.5.3
+ */
+public class Lz4FramedWritableByteChannel implements WritableByteChannel {
+
+    private final WritableByteChannel channel;
+
+    private final ByteBuffer uncompressedFrameBuffer;
+
+    private volatile ByteBuffer compressedFrameBuffer;
+
+    /**
+     * creates a new instance.
+     * @param channel the destination channel
+     */
+    public Lz4FramedWritableByteChannel(WritableByteChannel channel) {
+        this(channel, FRAME_SIZE);
+    }
+
+    /**
+     * creates a new instance.
+     * @param channel the destination channel
+     * @param frameSize the compression frame size in bytes
+     */
+    public Lz4FramedWritableByteChannel(WritableByteChannel channel, int frameSize) {
+        this.channel = channel;
+        this.uncompressedFrameBuffer = Buffers.allocate(Math.max(MIN_FRAME_SIZE, Math.min(MAX_FRAME_SIZE, frameSize)));
+    }
+
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+        ByteBuffer dst = uncompressedFrameBuffer;
+        int written = 0;
+        while (src.hasRemaining()) {
+            written += Buffers.put(src, dst);
+            if (!dst.hasRemaining()) {
+                flush();
+            }
+        }
+        return written;
+    }
+
+    private void flush() throws IOException {
+        ByteBuffer src = uncompressedFrameBuffer;
+        ByteBuffer dst = compressedFrameBuffer;
+        if (dst == null) {
+            int uncompressedFrameSize = uncompressedFrameBuffer.capacity();
+            writeFramedChannelHeader(channel, uncompressedFrameSize);
+            dst = Buffers.allocate(getMaxCompressedFrameSize(uncompressedFrameSize));
+            this.compressedFrameBuffer = dst;
+        }
+        src.flip();
+        if (src.hasRemaining()) {
+            int uncompressedFrameSize = src.remaining();
+            boolean isCompleteFrame = src.capacity() == uncompressedFrameSize;
+            int headerSize = isCompleteFrame ? COMPLETE_FRAME_HEADER_SIZE : INCOMPLETE_FRAME_HEADER_SIZE;
+
+            dst.clear();
+            dst.position(headerSize);
+            FRAME_COMPRESSOR.compress(src, dst);
+            dst.flip();
+            int compressedDataSize = dst.limit() - headerSize;
+
+            if (isCompleteFrame) {
+                dst.putInt(0, compressedDataSize);
+            } else {
+                dst.putInt(0, compressedDataSize | INCOMPLETE_FRAME_FLAG);
+                dst.putInt(Integer.BYTES, uncompressedFrameSize);
+            }
+
+            do {
+                channel.write(dst);
+            } while (dst.hasRemaining());
+        }
+        src.clear();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return channel.isOpen();
+    }
+
+    @Override
+    public void close() throws IOException {
+        flush();
+        channel.close();
+    }
+}

--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/Lz4Util.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/Lz4Util.java
@@ -1,0 +1,207 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.client.util;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.vanilla.core.util.Buffers;
+import com.asakusafw.vanilla.core.util.SystemProperty;
+
+import net.jpountz.lz4.LZ4Compressor;
+import net.jpountz.lz4.LZ4Factory;
+import net.jpountz.lz4.LZ4FastDecompressor;
+
+/**
+ * Utilities about LZ4 compression.
+ */
+public final class Lz4Util {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Lz4Util.class);
+
+    private static final String KEY_PREFIX = SystemProperty.KEY_PREFIX + "lz4."; //$NON-NLS-1$
+
+    /**
+     * The system property key of whether or not native LZ4 library is enabled if it is available
+     * ({@value}: {@value #DEFAULT_NATIVE}).
+     */
+    public static final String KEY_NATIVE = KEY_PREFIX + "native"; //$NON-NLS-1$
+
+    /**
+     * The default value of {@link #KEY_NATIVE}.
+     */
+    public static final boolean DEFAULT_NATIVE = true;
+
+    /**
+     * The system property key of LZ4 compression frame size for framed compressor
+     * ({@value}: {@value #DEFAULT_FRAME_SIZE}).
+     * @see Lz4FramedWritableByteChannel
+     */
+    public static final String KEY_FRAME_SIZE = KEY_PREFIX + "frame.size"; //$NON-NLS-1$
+
+    /**
+     * The default value of {@link #KEY_FRAME_SIZE}.
+     */
+    public static final int DEFAULT_FRAME_SIZE = 64 * 1024;
+
+    /**
+     * The minimum value of {@link #KEY_FRAME_SIZE}.
+     */
+    public static final int MIN_FRAME_SIZE = 4 * 1024;
+
+    /**
+     * The maximum value of {@link #KEY_FRAME_SIZE}.
+     */
+    public static final int MAX_FRAME_SIZE = 1024 * 1024;
+
+    /**
+     * The system property key of LZ4 compression frame size for framed compressor
+     * ({@value}: {@value #DEFAULT_FRAME_COMPRESSION_LEVEL} - fast compression).
+     * @see Lz4FramedWritableByteChannel
+     */
+    public static final String KEY_FRAME_COMPRESSION_LEVEL = KEY_PREFIX + "frame.compressionLevel"; //$NON-NLS-1$
+
+    /**
+     * The default value of {@link #KEY_FRAME_COMPRESSION_LEVEL}.
+     */
+    public static final int DEFAULT_FRAME_COMPRESSION_LEVEL = 0;
+
+    /**
+     * The minimum value of {@link #KEY_FRAME_COMPRESSION_LEVEL}.
+     */
+    public static final int MIN_FRAME_COMPRESSION_LEVEL = 0;
+
+    /**
+     * The maximum value of {@link #KEY_FRAME_COMPRESSION_LEVEL}.
+     */
+    public static final int MAX_FRAME_COMPRESSION_LEVEL = 17;
+
+    static final boolean NATIVE = SystemProperty.get(KEY_NATIVE, DEFAULT_NATIVE);
+
+    static final int FRAME_SIZE = Math.max(
+            MIN_FRAME_SIZE,
+            Math.min(
+                    MAX_FRAME_SIZE,
+                    SystemProperty.get(KEY_FRAME_SIZE, DEFAULT_FRAME_SIZE)));
+
+    static final int FRAME_COMPRESSION_LEVEL = Math.max(
+            MIN_FRAME_COMPRESSION_LEVEL,
+            Math.min(
+                    MAX_FRAME_COMPRESSION_LEVEL,
+                    SystemProperty.get(KEY_FRAME_COMPRESSION_LEVEL, DEFAULT_FRAME_COMPRESSION_LEVEL)));
+
+    static final LZ4Factory FACTORY = NATIVE ? LZ4Factory.fastestInstance() : LZ4Factory.fastestJavaInstance();
+
+    static final LZ4Compressor FRAME_COMPRESSOR = getCompressor(FRAME_COMPRESSION_LEVEL);
+
+    static final LZ4FastDecompressor FRAME_DECOMPRESSOR = FACTORY.fastDecompressor();
+
+    static LZ4Compressor getCompressor(int compressionLevel) {
+       if (compressionLevel == 0) {
+           return FACTORY.fastCompressor();
+       }
+       return FACTORY.highCompressor(compressionLevel);
+    }
+
+    /*
+     * struct framed_file {
+     *   int8_t magic[4];
+     *   int32_t frame_size;
+     *
+     *   struct compressed_frame_t {
+     *     int32_t compressed_frame_info;
+     *     int32_t uncompressed_frame_size[(compressed_frame_info >> 24) & 0x01];
+     *     int8_t compressed_data[compressed_frame_info & 0xff_ffff];
+     *   } compressed_frames[...];
+     * }
+     */
+
+    private static final byte[] FRAMED_FILE_HEADER_MAGIC = {
+            (byte) 'L',
+            (byte) 'Z',
+            (byte) '4',
+            (byte) 'f',
+    };
+
+    static final int FRAMED_FILE_HEADER_SIZE = FRAMED_FILE_HEADER_MAGIC.length + Integer.BYTES;
+
+    private static final ThreadLocal<ByteBuffer> BUFFERS = ThreadLocal
+            .withInitial(() -> Buffers.allocate(FRAMED_FILE_HEADER_SIZE));
+
+    static final int COMPLETE_FRAME_HEADER_SIZE = Integer.BYTES * 1;
+
+    static final int INCOMPLETE_FRAME_HEADER_SIZE = Integer.BYTES * 2;
+
+    static final int INCOMPLETE_FRAME_FLAG = 0x0100_0000;
+
+    static final int COMPRESSED_DATA_SIZE_MASK = 0x00ff_ffff;
+
+    static int getMaxCompressedFrameSize(int rawFrameSize) {
+        int maxCompressedDataSize = FRAME_COMPRESSOR.maxCompressedLength(rawFrameSize);
+        assert maxCompressedDataSize <= COMPRESSED_DATA_SIZE_MASK;
+        return INCOMPLETE_FRAME_HEADER_SIZE + maxCompressedDataSize;
+    }
+
+    static void writeFramedChannelHeader(WritableByteChannel channel, int frameSize) throws IOException {
+        ByteBuffer buf = BUFFERS.get();
+        buf.clear();
+        buf.put(FRAMED_FILE_HEADER_MAGIC);
+        buf.putInt(frameSize);
+        buf.flip();
+        do {
+            channel.write(buf);
+        } while (buf.hasRemaining());
+    }
+
+    static int readFramedChannelHeader(ReadableByteChannel channel) throws IOException {
+        ByteBuffer buf = BUFFERS.get();
+        buf.clear();
+        do {
+            int read = channel.read(buf);
+            if (read == -1) {
+                throw new EOFException();
+            }
+        } while (buf.hasRemaining());
+        buf.flip();
+        for (byte h : FRAMED_FILE_HEADER_MAGIC) {
+            byte b = buf.get();
+            if (b != h) {
+                throw new IOException("invalid LZ4 frame header");
+            }
+        }
+        return buf.getInt();
+    }
+
+    static {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("LZ4:");
+            LOG.debug("  {}: {}", KEY_NATIVE, NATIVE);
+            LOG.debug("  {}: {}", KEY_FRAME_SIZE, FRAME_SIZE);
+            LOG.debug("  {}: {}", KEY_FRAME_COMPRESSION_LEVEL, FRAME_COMPRESSION_LEVEL);
+            LOG.debug("  active implementation: {}", FACTORY);
+        }
+    }
+
+    private Lz4Util() {
+        return;
+    }
+}

--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/Lz4Util.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/Lz4Util.java
@@ -61,7 +61,7 @@ public final class Lz4Util {
     /**
      * The default value of {@link #KEY_FRAME_SIZE}.
      */
-    public static final int DEFAULT_FRAME_SIZE = 64 * 1024;
+    public static final int DEFAULT_FRAME_SIZE = 16 * 1024;
 
     /**
      * The minimum value of {@link #KEY_FRAME_SIZE}.

--- a/vanilla/runtime/client/src/test/java/com/asakusafw/vanilla/client/VanillaConfigurationTest.java
+++ b/vanilla/runtime/client/src/test/java/com/asakusafw/vanilla/client/VanillaConfigurationTest.java
@@ -45,7 +45,9 @@ public class VanillaConfigurationTest {
         assertThat(conf.getBufferPoolSize(), is(DEFAULT_BUFFER_POOL_SIZE));
         assertThat(conf.getSwapDirectory(), is(DEFAULT_SWAP_DIRECTORY));
         assertThat(conf.getSwapDivision(), is(DEFAULT_SWAP_DIVISION));
-        assertThat(conf.getSwapDecorator(getClass().getClassLoader()), is(instanceOf(BufferedByteChannelDecorator.class)));
+        assertThat(
+                conf.getSwapDecorator().newInstance(getClass().getClassLoader()).get(),
+                is(instanceOf(BufferedByteChannelDecorator.class)));
         assertThat(conf.getOutputBufferSize(), is(DEFAULT_OUTPUT_BUFFER_SIZE));
         assertThat(conf.getOutputBufferMargin(), is(DEFAULT_OUTPUT_BUFFER_MARGIN));
         assertThat(conf.getOutputRecordSize(), is(DEFAULT_OUTPUT_RECORD_SIZE));
@@ -86,7 +88,9 @@ public class VanillaConfigurationTest {
         assertThat(conf.getSwapDirectory().getCanonicalFile(), is(f));
         assertThat(conf.getMergeThreshold(), is(9));
         assertThat(conf.getMergeFactor(), is(10d));
-        assertThat(conf.getSwapDecorator(getClass().getClassLoader()), is(instanceOf(SnappyByteChannelDecorator.class)));
+        assertThat(
+                conf.getSwapDecorator().newInstance(getClass().getClassLoader()).get(),
+                is(instanceOf(SnappyByteChannelDecorator.class)));
     }
 
     /**

--- a/vanilla/runtime/client/src/test/java/com/asakusafw/vanilla/client/util/Lz4ByteChannelDecoratorTest.java
+++ b/vanilla/runtime/client/src/test/java/com/asakusafw/vanilla/client/util/Lz4ByteChannelDecoratorTest.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.client.util;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.asakusafw.vanilla.core.io.ByteChannelDecorator;
+import com.asakusafw.vanilla.core.util.Buffers;
+
+/**
+ * Test for {@link Lz4ByteChannelDecorator}.
+ */
+public class Lz4ByteChannelDecoratorTest {
+
+    /**
+     * temporary folder.
+     */
+    @Rule
+    public final TemporaryFolder temporary = new TemporaryFolder();
+
+    private final ByteChannelDecorator decorator = new Lz4ByteChannelDecorator();
+
+    private static final int FILE_SIZE = 1024 * 1024;
+
+    private static final int DIVISOR = 256;
+
+    private static final int SMALL_PRIME = 256 + 1;
+
+    private static final int LARGE_PRIME = (256 * 1024) - 1;
+
+    /**
+     * simple case.
+     * @throws Exception if failed
+     */
+    @Test
+    public void simple() throws Exception {
+        test(1, 1);
+    }
+
+    /**
+     * empty output.
+     * @throws Exception if failed
+     */
+    @Test
+    public void empty() throws Exception {
+        test(0, DIVISOR);
+    }
+
+    /**
+     * buffer size is divisor of file size.
+     * @throws Exception if failed
+     */
+    @Test
+    public void divisor() throws Exception {
+        test(FILE_SIZE, DIVISOR);
+    }
+
+    /**
+     * small buffer.
+     * @throws Exception if failed
+     */
+    @Test
+    public void small_buffer() throws Exception {
+        test(FILE_SIZE, SMALL_PRIME);
+    }
+
+    /**
+     * large buffer.
+     * @throws Exception if failed
+     */
+    @Test
+    public void large_buffer() throws Exception {
+        test(FILE_SIZE, LARGE_PRIME);
+    }
+
+    private void test(int fileSize, int bufferSize) throws IOException, InterruptedException {
+        ByteBuffer buffer = Buffers.allocate(bufferSize);
+        Path file = temporary.newFile().toPath();
+        try (WritableByteChannel c = decorator.decorate(
+                (WritableByteChannel) Files.newByteChannel(file, StandardOpenOption.WRITE))) {
+            write(c, buffer, fileSize);
+        }
+        try (ReadableByteChannel c = decorator.decorate(
+                (ReadableByteChannel) Files.newByteChannel(file, StandardOpenOption.READ))) {
+            verify(c, buffer, fileSize);
+        }
+    }
+
+    private void write(WritableByteChannel channel, ByteBuffer buffer, int size) throws IOException {
+        int position = 0;
+        while (position < size) {
+            buffer.clear();
+            while (position < size && buffer.hasRemaining()) {
+                buffer.put((byte) position++);
+            }
+            buffer.flip();
+            while (buffer.hasRemaining()) {
+                int remain = buffer.remaining();
+                int written = channel.write(buffer);
+                assertEquals(buffer.remaining(), remain - written);
+            }
+        }
+    }
+
+    private void verify(ReadableByteChannel channel, ByteBuffer buffer, int size) throws IOException {
+        int position = 0;
+        while (true) {
+            buffer.clear();
+            int read = channel.read(buffer);
+            if (read < 0) {
+                break;
+            }
+            buffer.flip();
+            while (buffer.hasRemaining()) {
+                byte b = buffer.get();
+                assertEquals(b, (byte) position++);
+            }
+        }
+        assertEquals(position, size);
+    }
+
+}

--- a/vanilla/runtime/client/src/test/java/com/asakusafw/vanilla/client/util/Lz4FramedWritableByteChannelTest.java
+++ b/vanilla/runtime/client/src/test/java/com/asakusafw/vanilla/client/util/Lz4FramedWritableByteChannelTest.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.client.util;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.asakusafw.vanilla.core.util.Buffers;
+
+/**
+ * Test for {@link Lz4FramedWritableByteChannel} and {@link Lz4FramedReadableByteChannel}.
+ */
+public class Lz4FramedWritableByteChannelTest {
+
+    /**
+     * temporary folder.
+     */
+    @Rule
+    public final TemporaryFolder temporary = new TemporaryFolder();
+
+    private static final int FILE_SIZE = 1024 * 1024;
+
+    private static final int DIVISOR = 256;
+
+    private static final int SMALL_PRIME = 256 + 1;
+
+    private static final int LARGE_PRIME = (256 * 1024) - 1;
+
+    /**
+     * simple case.
+     * @throws Exception if failed
+     */
+    @Test
+    public void simple() throws Exception {
+        test(1, 1);
+    }
+
+    /**
+     * empty output.
+     * @throws Exception if failed
+     */
+    @Test
+    public void empty() throws Exception {
+        test(0, DIVISOR);
+    }
+
+    /**
+     * buffer size is divisor of file size.
+     * @throws Exception if failed
+     */
+    @Test
+    public void divisor() throws Exception {
+        test(FILE_SIZE, DIVISOR);
+    }
+
+    /**
+     * small buffer.
+     * @throws Exception if failed
+     */
+    @Test
+    public void small_buffer() throws Exception {
+        test(FILE_SIZE, SMALL_PRIME);
+    }
+
+    /**
+     * large buffer.
+     * @throws Exception if failed
+     */
+    @Test
+    public void large_buffer() throws Exception {
+        test(FILE_SIZE, LARGE_PRIME);
+    }
+
+    private void test(int fileSize, int bufferSize) throws IOException {
+        ByteBuffer buffer = Buffers.allocate(bufferSize);
+        Path file = temporary.newFile().toPath();
+        try (WritableByteChannel c = new Lz4FramedWritableByteChannel(Files.newByteChannel(file, StandardOpenOption.WRITE))) {
+            write(c, buffer, fileSize);
+        }
+        try (ReadableByteChannel c = new Lz4FramedReadableByteChannel(Files.newByteChannel(file, StandardOpenOption.READ))) {
+            verify(c, buffer, fileSize);
+        }
+    }
+
+    private void write(WritableByteChannel channel, ByteBuffer buffer, int size) throws IOException {
+        int position = 0;
+        while (position < size) {
+            buffer.clear();
+            while (position < size && buffer.hasRemaining()) {
+                buffer.put((byte) position++);
+            }
+            buffer.flip();
+            while (buffer.hasRemaining()) {
+                int remain = buffer.remaining();
+                int written = channel.write(buffer);
+                assertEquals(buffer.remaining(), remain - written);
+            }
+        }
+    }
+
+    private void verify(ReadableByteChannel channel, ByteBuffer buffer, int size) throws IOException {
+        int position = 0;
+        while (true) {
+            buffer.clear();
+            int read = channel.read(buffer);
+            if (read < 0) {
+                break;
+            }
+            buffer.flip();
+            while (buffer.hasRemaining()) {
+                byte b = buffer.get();
+                assertEquals(b, (byte) position++);
+            }
+        }
+        assertEquals(position, size);
+    }
+
+}

--- a/vanilla/runtime/client/src/test/java/com/asakusafw/vanilla/client/util/SnappyByteChannelDecoratorTest.java
+++ b/vanilla/runtime/client/src/test/java/com/asakusafw/vanilla/client/util/SnappyByteChannelDecoratorTest.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.client.util;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.asakusafw.vanilla.core.io.ByteChannelDecorator;
+import com.asakusafw.vanilla.core.util.Buffers;
+
+/**
+ * Test for {@link SnappyByteChannelDecorator}.
+ */
+public class SnappyByteChannelDecoratorTest {
+
+    /**
+     * temporary folder.
+     */
+    @Rule
+    public final TemporaryFolder temporary = new TemporaryFolder();
+
+    private final ByteChannelDecorator decorator = new SnappyByteChannelDecorator();
+
+    private static final int FILE_SIZE = 1024 * 1024;
+
+    private static final int DIVISOR = 256;
+
+    private static final int SMALL_PRIME = 256 + 1;
+
+    private static final int LARGE_PRIME = (256 * 1024) - 1;
+
+    /**
+     * simple case.
+     * @throws Exception if failed
+     */
+    @Test
+    public void simple() throws Exception {
+        test(1, 1);
+    }
+
+    /**
+     * empty output.
+     * @throws Exception if failed
+     */
+    @Test
+    public void empty() throws Exception {
+        test(0, DIVISOR);
+    }
+
+    /**
+     * buffer size is divisor of file size.
+     * @throws Exception if failed
+     */
+    @Test
+    public void divisor() throws Exception {
+        test(FILE_SIZE, DIVISOR);
+    }
+
+    /**
+     * small buffer.
+     * @throws Exception if failed
+     */
+    @Test
+    public void small_buffer() throws Exception {
+        test(FILE_SIZE, SMALL_PRIME);
+    }
+
+    /**
+     * large buffer.
+     * @throws Exception if failed
+     */
+    @Test
+    public void large_buffer() throws Exception {
+        test(FILE_SIZE, LARGE_PRIME);
+    }
+
+    private void test(int fileSize, int bufferSize) throws IOException, InterruptedException {
+        ByteBuffer buffer = Buffers.allocate(bufferSize);
+        Path file = temporary.newFile().toPath();
+        try (WritableByteChannel c = decorator.decorate(
+                (WritableByteChannel) Files.newByteChannel(file, StandardOpenOption.WRITE))) {
+            write(c, buffer, fileSize);
+        }
+        try (ReadableByteChannel c = decorator.decorate(
+                (ReadableByteChannel) Files.newByteChannel(file, StandardOpenOption.READ))) {
+            verify(c, buffer, fileSize);
+        }
+    }
+
+    private void write(WritableByteChannel channel, ByteBuffer buffer, int size) throws IOException {
+        int position = 0;
+        while (position < size) {
+            buffer.clear();
+            while (position < size && buffer.hasRemaining()) {
+                buffer.put((byte) position++);
+            }
+            buffer.flip();
+            while (buffer.hasRemaining()) {
+                int remain = buffer.remaining();
+                int written = channel.write(buffer);
+                assertEquals(buffer.remaining(), remain - written);
+            }
+        }
+    }
+
+    private void verify(ReadableByteChannel channel, ByteBuffer buffer, int size) throws IOException {
+        int position = 0;
+        while (true) {
+            buffer.clear();
+            int read = channel.read(buffer);
+            if (read < 0) {
+                break;
+            }
+            buffer.flip();
+            while (buffer.hasRemaining()) {
+                byte b = buffer.get();
+                assertEquals(b, (byte) position++);
+            }
+        }
+        assertEquals(position, size);
+    }
+
+}

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/ByteBufferReader.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/ByteBufferReader.java
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer;
 import com.asakusafw.lang.utils.common.Arguments;
 import com.asakusafw.lang.utils.common.InterruptibleIo;
 import com.asakusafw.lang.utils.common.Invariants;
+import com.asakusafw.vanilla.core.util.Buffers;
 
 /**
  * An implementation of {@link DataReader} which just wraps {@link ByteBuffer}.
@@ -66,10 +67,7 @@ public class ByteBufferReader implements DataReader {
     @Override
     public void readFully(ByteBuffer destination) {
         Invariants.requireNonNull(buffer);
-        int limit = buffer.limit();
-        buffer.limit(buffer.position() + destination.remaining());
-        destination.put(buffer);
-        buffer.limit(limit);
+        Buffers.put(buffer, destination);
     }
 
     @Override

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/ByteChannelDecorator.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/ByteChannelDecorator.java
@@ -20,11 +20,23 @@ import java.nio.channels.ByteChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 
+import com.asakusafw.dag.api.processor.ProcessorContext;
+
 /**
  * Decorates {@link ByteChannel}s.
  * @since 0.5.3
  */
 public interface ByteChannelDecorator {
+
+    /**
+     * initializes this object.
+     * @param context the current context
+     * @throws IOException if I/O error occurred while initializing the decorator
+     * @throws InterruptedException if interrupted while initializing the decorator
+     */
+    default void initialize(ProcessorContext context) throws IOException, InterruptedException {
+        return;
+    }
 
     /**
      * Decorates the given channel.

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/util/BufferedReadbleByteChannel.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/util/BufferedReadbleByteChannel.java
@@ -54,17 +54,7 @@ public class BufferedReadbleByteChannel implements ReadableByteChannel {
         while (true) {
             // copies buffered contents into the destination buffer if remained
             if (buffer.hasRemaining()) {
-                if (dst.remaining() >= buffer.remaining()) {
-                    int size = buffer.remaining();
-                    dst.put(buffer);
-                    return size;
-                }
-                int size = dst.remaining();
-                int limit = buffer.limit();
-                buffer.limit(buffer.position() + size);
-                dst.put(buffer);
-                buffer.limit(limit);
-                return size;
+                return Buffers.put(buffer, dst);
             }
 
             if (dst.remaining() >= buffer.capacity()) {

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/util/BufferedWritableByteChannel.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/util/BufferedWritableByteChannel.java
@@ -51,19 +51,8 @@ public class BufferedWritableByteChannel implements WritableByteChannel, Flushab
 
     @Override
     public int write(ByteBuffer src) throws IOException {
-        if (buffer.remaining() > src.remaining()) {
-            int size = src.remaining();
-            buffer.put(src);
-            return size;
-        }
-
         if (buffer.hasRemaining()) {
-            int size = buffer.remaining();
-            int limit = src.limit();
-            src.limit(src.position() + size);
-            buffer.put(src);
-            src.limit(limit);
-            return size;
+            return Buffers.put(src, buffer);
         }
 
         flush();

--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/util/Buffers.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/util/Buffers.java
@@ -195,4 +195,27 @@ public final class Buffers {
         compact.flip();
         return compact;
     }
+
+    /**
+     * Puts source contents into the destination buffer until the destination is full.
+     * @param source the source buffer
+     * @param destination the destination buffer
+     * @return the moved size in bytes
+     * @since 0.5.3
+     */
+    public static int put(ByteBuffer source, ByteBuffer destination) {
+        int srcSize = source.remaining();
+        int dstSize = destination.remaining();
+
+        if (dstSize >= srcSize) {
+            destination.put(source);
+            return srcSize;
+        }
+
+        int limit = source.limit();
+        source.limit(source.position() + dstSize);
+        destination.put(source);
+        source.limit(limit);
+        return dstSize;
+    }
 }


### PR DESCRIPTION
## Summary

This PR enables Asakusa Vanilla buffer spill compression to use LZ4.

## Background, Problem or Goal of the patch

This PR introduces a new buffer spill files compression engine. It splits each buffer spill into small frames, and then compresses them using LZ4 compressor.

The base mechanism has been introduced #192, but it only includes Snappy compression.

## Design of the fix, or a new feature

To enable this feature, please pass the following engine configuration to Asakusa Vanilla:

* `com.asakusafw.vanilla.pool.compression=com.asakusafw.vanilla.client.util.Lz4ByteChannelDecorator`

and then the put the [lz4-java](https://github.com/lz4/lz4-java) into classpath of Asakusa Vanilla, for example:

```gradle
configurations {
  lz4
}
dependencies {
  lz4 group: 'org.lz4', name: 'lz4-java', version: '1.5.1'
}
asakusafwOrganizer {
  assembly.into('vanilla/lib') {
    put configurations.lz4
  }
}
```

To configure each internal behavior, please configure
the following **system properties**:
* `com.asakusafw.vanilla.lz4.native`
  * system property key of whether or not LZ4 native library is enabled
  * default: `true` (enabled)
* `com.asakusafw.vanilla.lz4.frame.size`
  * system property key of compression frame size in bytes
  * default: `16384` (16KB)
* `com.asakusafw.vanilla.lz4.frame.compressionLevel`
  * system property key of compression level (`0`..`17`)
  * default: `0` (fastest)

## Related Issue, Pull Request or Code

* #192 