### PR TITLE
make `SnappyByteChannelDecorator` more configurable.

### DIFF
--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/SnappyByteChannelDecorator.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/SnappyByteChannelDecorator.java
@@ -19,10 +19,13 @@ import java.io.IOException;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xerial.snappy.SnappyFramedInputStream;
 import org.xerial.snappy.SnappyFramedOutputStream;
 
 import com.asakusafw.vanilla.core.io.ByteChannelDecorator;
+import com.asakusafw.vanilla.core.util.SystemProperty;
 
 /**
  * An implementation of {@link ByteChannelDecorator} which using snappy compression.
@@ -30,13 +33,96 @@ import com.asakusafw.vanilla.core.io.ByteChannelDecorator;
  */
 public class SnappyByteChannelDecorator implements ByteChannelDecorator {
 
+    private static final Logger LOG = LoggerFactory.getLogger(SnappyByteChannelDecorator.class);
+
+    private static final String KEY_PREFIX = SystemProperty.KEY_PREFIX + "snappy."; //$NON-NLS-1$
+
+    /**
+     * The system property key of snappy compression frame size for framed compressor
+     * ({@value}: {@value #DEFAULT_BLOCK_SIZE}).
+     */
+    public static final String KEY_BLOCK_SIZE = KEY_PREFIX + "frame.size"; //$NON-NLS-1$
+
+    /**
+     * The default value of {@link #KEY_BLOCK_SIZE}.
+     */
+    public static final int DEFAULT_BLOCK_SIZE = SnappyFramedOutputStream.DEFAULT_BLOCK_SIZE;
+
+    /**
+     * The minimum value of {@link #KEY_BLOCK_SIZE}.
+     */
+    public static final int MIN_BLOCK_SIZE = 4 * 1024;
+
+    /**
+     * The maximum value of {@link #KEY_BLOCK_SIZE}.
+     */
+    public static final int MAX_BLOCK_SIZE = SnappyFramedOutputStream.MAX_BLOCK_SIZE;
+
+    /**
+     * The system property key of required minimum compression ratio for each frame.
+     * If a frame was exceeded this ratio, we use its uncompressed data instead of compressed one.
+     * ({@value}: {@value #DEFAULT_COMPRESSION_THRESHOLD}).
+     */
+    public static final String KEY_COMPRESSION_THRESHOLD = KEY_PREFIX + "frame.compressionThreshold"; //$NON-NLS-1$
+
+    /**
+     * The default value of {@link #KEY_COMPRESSION_THRESHOLD}.
+     */
+    public static final double DEFAULT_COMPRESSION_THRESHOLD =
+            SnappyFramedOutputStream.DEFAULT_MIN_COMPRESSION_RATIO;
+
+    /**
+     * The minimum value of {@link #KEY_COMPRESSION_THRESHOLD}.
+     */
+    public static final double MIN_COMPRESSION_THRESHOLD = 0.0;
+
+    /**
+     * The maximum value of {@link #KEY_COMPRESSION_THRESHOLD}.
+     */
+    public static final double MAX_COMPRESSION_THRESHOLD = 1.0;
+
+    /**
+     * The system property key of whether or not verifying compressed data while extraction.
+     * ({@value}: {@value #DEFAULT_VERIFY_CHECKSUM}).
+     */
+    public static final String KEY_VERIFY_CHECKSUM = KEY_PREFIX + "frame.verifyChecksum"; //$NON-NLS-1$
+
+    /**
+     * The default value of {@link #KEY_VERIFY_CHECKSUM}.
+     */
+    public static final boolean DEFAULT_VERIFY_CHECKSUM = false;
+
+    static final int BLOCK_SIZE = Math.max(
+            MIN_BLOCK_SIZE,
+            Math.min(
+                    MAX_BLOCK_SIZE,
+                    SystemProperty.get(KEY_BLOCK_SIZE, DEFAULT_BLOCK_SIZE)));
+
+    static final double COMPRESSION_THRESHOLD = Math.max(
+            MIN_COMPRESSION_THRESHOLD,
+            Math.min(
+                    MAX_COMPRESSION_THRESHOLD,
+                    SystemProperty.get(KEY_COMPRESSION_THRESHOLD, DEFAULT_COMPRESSION_THRESHOLD)));
+
+    static final boolean VERIFY_CHECKSUM =
+            SystemProperty.get(KEY_VERIFY_CHECKSUM, DEFAULT_VERIFY_CHECKSUM);
+
+    static {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("snappy:");
+            LOG.debug("  {}: {}", KEY_BLOCK_SIZE, BLOCK_SIZE);
+            LOG.debug("  {}: {}", KEY_COMPRESSION_THRESHOLD, COMPRESSION_THRESHOLD);
+            LOG.debug("  {}: {}", KEY_VERIFY_CHECKSUM, VERIFY_CHECKSUM);
+        }
+    }
+
     @Override
     public ReadableByteChannel decorate(ReadableByteChannel channel) throws IOException {
-        return new SnappyFramedInputStream(channel, false);
+        return new SnappyFramedInputStream(channel, VERIFY_CHECKSUM);
     }
 
     @Override
     public WritableByteChannel decorate(WritableByteChannel channel) throws IOException {
-        return new SnappyFramedOutputStream(channel);
+        return new SnappyFramedOutputStream(channel, BLOCK_SIZE, COMPRESSION_THRESHOLD);
     }
 }


### PR DESCRIPTION
## Summary

This PR makes `SnappyByteChannelDecorator` more configurable.

## Background, Problem or Goal of the patch

This introduces some configuration properties into  `SnappyByteChannelDecorator` since #192, like as following:

* frame size (like as #193)
* required compression ratio
* input verifying

## Design of the fix, or a new feature

To configure each internal behavior, please configure the following **system properties**:

* `com.asakusafw.vanilla.snappy.frame.size`
  * snappy compression frame size in bytes
    * this must be `[4096, 65536]`
  * default: `65536` (64KB)
* `com.asakusafw.vanilla.snappy.frame.compressionThreshold`
  * required minimum compression ratio for each frame
    * If a (`compressed-size` / `original-size`) was exceeded, this will store the uncompressed data instead of compressed one
  * default: `0.85` (require 15% size saved)
* `com.asakusafw.vanilla.snappy.frame.verifyChecksum`
  * whether or not verifying compressed data while extraction
  * default: `false` (disabled)

And then, to check your current configurations, please set log level of `com.asakusafw.vanilla.client.util.SnappyByteChannelDecorator` to `DEBUG`.

## Related Issue, Pull Request or Code

* #192 