### PR TITLE
change default multi-stage merge factor to `0.75` in Vanilla.

### DIFF
--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/VanillaConfiguration.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/VanillaConfiguration.java
@@ -170,7 +170,7 @@ public class VanillaConfiguration {
      * The default value of {@link #KEY_MERGE_FACTOR}.
      * @since 0.5.3
      */
-    public static final double DEFAULT_MERGE_FACTOR = 1.0;
+    public static final double DEFAULT_MERGE_FACTOR = 0.75;
 
     static final Logger LOG = LoggerFactory.getLogger(VanillaConfiguration.class);
 


### PR DESCRIPTION
## Summary

This PR revises the default configuration of multiple stage merge factor in Asakusa Vanilla.

## Background, Problem or Goal of the patch

In #192, multiple stage merging often merges wastefully huge files in default settings. This PR will reduce this problem.

## Design of the fix, or a new feature

* `com.asakusafw.vanilla.merge.factor`
  * if the scatter/gather input chunks are exceeded, the engine will decide the number of target files at the rate of the above threshold
  * default: `{1.0=>0.75}` (merge `75%` of `com.asakusafw.vanilla.merge.threshold`)

Note that, this may improve performance until intermediate data size (for each thread) of scatter/gather operation:

```
intermediate-data-size < (buffer-size - buffer-margin) * merge-threshold * (1.0 - merge-factor)
where
  buffer-size = conf: com.asakusafw.vanilla.output.buffer.size,
  buffer-margin = conf: com.asakusafw.vanilla.output.buffer.margin,
  merge-threshold = conf: com.asakusafw.vanilla.merge.threshold, and
  merge-factor = conf: com.asakusafw.vanilla.merge.factor.
```

## Related Issue, Pull Request or Code

* #192