### PR TITLE
replace implementation of `SnappyByteChannelDecorator`.

### DIFF
--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/SnappyByteChannelDecorator.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/SnappyByteChannelDecorator.java
@@ -15,17 +15,10 @@
  */
 package com.asakusafw.vanilla.client.util;
 
-import java.io.IOException;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.xerial.snappy.SnappyFramedInputStream;
-import org.xerial.snappy.SnappyFramedOutputStream;
-
 import com.asakusafw.vanilla.core.io.ByteChannelDecorator;
-import com.asakusafw.vanilla.core.util.SystemProperty;
 
 /**
  * An implementation of {@link ByteChannelDecorator} which using snappy compression.
@@ -33,96 +26,13 @@ import com.asakusafw.vanilla.core.util.SystemProperty;
  */
 public class SnappyByteChannelDecorator implements ByteChannelDecorator {
 
-    private static final Logger LOG = LoggerFactory.getLogger(SnappyByteChannelDecorator.class);
-
-    private static final String KEY_PREFIX = SystemProperty.KEY_PREFIX + "snappy."; //$NON-NLS-1$
-
-    /**
-     * The system property key of snappy compression frame size for framed compressor
-     * ({@value}: {@value #DEFAULT_BLOCK_SIZE}).
-     */
-    public static final String KEY_BLOCK_SIZE = KEY_PREFIX + "frame.size"; //$NON-NLS-1$
-
-    /**
-     * The default value of {@link #KEY_BLOCK_SIZE}.
-     */
-    public static final int DEFAULT_BLOCK_SIZE = SnappyFramedOutputStream.DEFAULT_BLOCK_SIZE;
-
-    /**
-     * The minimum value of {@link #KEY_BLOCK_SIZE}.
-     */
-    public static final int MIN_BLOCK_SIZE = 4 * 1024;
-
-    /**
-     * The maximum value of {@link #KEY_BLOCK_SIZE}.
-     */
-    public static final int MAX_BLOCK_SIZE = SnappyFramedOutputStream.MAX_BLOCK_SIZE;
-
-    /**
-     * The system property key of required minimum compression ratio for each frame.
-     * If a frame was exceeded this ratio, we use its uncompressed data instead of compressed one.
-     * ({@value}: {@value #DEFAULT_COMPRESSION_THRESHOLD}).
-     */
-    public static final String KEY_COMPRESSION_THRESHOLD = KEY_PREFIX + "frame.compressionThreshold"; //$NON-NLS-1$
-
-    /**
-     * The default value of {@link #KEY_COMPRESSION_THRESHOLD}.
-     */
-    public static final double DEFAULT_COMPRESSION_THRESHOLD =
-            SnappyFramedOutputStream.DEFAULT_MIN_COMPRESSION_RATIO;
-
-    /**
-     * The minimum value of {@link #KEY_COMPRESSION_THRESHOLD}.
-     */
-    public static final double MIN_COMPRESSION_THRESHOLD = 0.0;
-
-    /**
-     * The maximum value of {@link #KEY_COMPRESSION_THRESHOLD}.
-     */
-    public static final double MAX_COMPRESSION_THRESHOLD = 1.0;
-
-    /**
-     * The system property key of whether or not verifying compressed data while extraction.
-     * ({@value}: {@value #DEFAULT_VERIFY_CHECKSUM}).
-     */
-    public static final String KEY_VERIFY_CHECKSUM = KEY_PREFIX + "frame.verifyChecksum"; //$NON-NLS-1$
-
-    /**
-     * The default value of {@link #KEY_VERIFY_CHECKSUM}.
-     */
-    public static final boolean DEFAULT_VERIFY_CHECKSUM = false;
-
-    static final int BLOCK_SIZE = Math.max(
-            MIN_BLOCK_SIZE,
-            Math.min(
-                    MAX_BLOCK_SIZE,
-                    SystemProperty.get(KEY_BLOCK_SIZE, DEFAULT_BLOCK_SIZE)));
-
-    static final double COMPRESSION_THRESHOLD = Math.max(
-            MIN_COMPRESSION_THRESHOLD,
-            Math.min(
-                    MAX_COMPRESSION_THRESHOLD,
-                    SystemProperty.get(KEY_COMPRESSION_THRESHOLD, DEFAULT_COMPRESSION_THRESHOLD)));
-
-    static final boolean VERIFY_CHECKSUM =
-            SystemProperty.get(KEY_VERIFY_CHECKSUM, DEFAULT_VERIFY_CHECKSUM);
-
-    static {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("snappy:");
-            LOG.debug("  {}: {}", KEY_BLOCK_SIZE, BLOCK_SIZE);
-            LOG.debug("  {}: {}", KEY_COMPRESSION_THRESHOLD, COMPRESSION_THRESHOLD);
-            LOG.debug("  {}: {}", KEY_VERIFY_CHECKSUM, VERIFY_CHECKSUM);
-        }
+    @Override
+    public ReadableByteChannel decorate(ReadableByteChannel channel) {
+        return new SnappyFramedReadableByteChannel(channel);
     }
 
     @Override
-    public ReadableByteChannel decorate(ReadableByteChannel channel) throws IOException {
-        return new SnappyFramedInputStream(channel, VERIFY_CHECKSUM);
-    }
-
-    @Override
-    public WritableByteChannel decorate(WritableByteChannel channel) throws IOException {
-        return new SnappyFramedOutputStream(channel, BLOCK_SIZE, COMPRESSION_THRESHOLD);
+    public WritableByteChannel decorate(WritableByteChannel channel) {
+        return new SnappyFramedWritableByteChannel(channel);
     }
 }

--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/SnappyFramedReadableByteChannel.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/SnappyFramedReadableByteChannel.java
@@ -59,11 +59,11 @@ public class SnappyFramedReadableByteChannel implements ReadableByteChannel {
         ByteBuffer uncompressed = uncompressedFrameBuffer;
         if (uncompressed == null) {
             int uncompressedFrameSize = readFramedChannelHeader(channel);
-            uncompressed = Buffers.allocate(uncompressedFrameSize);
+            uncompressed = SnappyUtil.allocateBuffer(uncompressedFrameSize);
             uncompressed.flip();
 
             this.uncompressedFrameBuffer = uncompressed;
-            this.compressedFrameBuffer = Buffers.allocate(getMaxCompressedFrameSize(uncompressedFrameSize));
+            this.compressedFrameBuffer = SnappyUtil.allocateBuffer(getMaxCompressedFrameSize(uncompressedFrameSize));
         }
 
         if (!uncompressed.hasRemaining()) {

--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/SnappyFramedReadableByteChannel.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/SnappyFramedReadableByteChannel.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.client.util;
+
+import static com.asakusafw.vanilla.client.util.SnappyUtil.*;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+
+import org.xerial.snappy.Snappy;
+
+import com.asakusafw.vanilla.core.util.Buffers;
+
+/**
+ * A {@link ReadableByteChannel} for written by {@link SnappyFramedWritableByteChannel}.
+ * @since 0.5.3
+ */
+public class SnappyFramedReadableByteChannel implements ReadableByteChannel {
+
+    private final ReadableByteChannel channel;
+
+    private volatile ByteBuffer uncompressedFrameBuffer;
+
+    private ByteBuffer compressedFrameBuffer;
+
+    /**
+     * creates a new instance.
+     * @param channel the destination channel
+     */
+    public SnappyFramedReadableByteChannel(ReadableByteChannel channel) {
+        this.channel = channel;
+    }
+
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+        ByteBuffer src = fill();
+        if (src == null) {
+            return -1;
+        }
+        return Buffers.put(src, dst);
+    }
+
+    private ByteBuffer fill() throws IOException {
+        ByteBuffer uncompressed = uncompressedFrameBuffer;
+        if (uncompressed == null) {
+            int uncompressedFrameSize = readFramedChannelHeader(channel);
+            uncompressed = Buffers.allocate(uncompressedFrameSize);
+            uncompressed.flip();
+
+            this.uncompressedFrameBuffer = uncompressed;
+            this.compressedFrameBuffer = Buffers.allocate(getMaxCompressedFrameSize(uncompressedFrameSize));
+        }
+
+        if (!uncompressed.hasRemaining()) {
+            // first, obtain compressed frame info
+            ByteBuffer compressed = compressedFrameBuffer;
+            compressed.clear();
+            compressed.limit(Integer.BYTES);
+            do {
+                int read = channel.read(compressed);
+                if (read == -1) {
+                    if (compressed.position() == 0) {
+                        // return null if no more compressed frames
+                        return null;
+                    } else {
+                        throw new EOFException();
+                    }
+                }
+            } while (compressed.hasRemaining());
+            compressed.flip();
+            int compressedFrameInfo = compressed.getInt();
+            int compressedDataSize = compressedFrameInfo & COMPRESSED_DATA_SIZE_MASK;
+
+            // next, read the rest of compressed frame
+            compressed.clear();
+            compressed.limit(compressedDataSize);
+            do {
+                int read = channel.read(compressed);
+                if (read < 0) {
+                    throw new EOFException();
+                }
+            } while (compressed.hasRemaining());
+            compressed.flip();
+
+            // finally, uncompress the frame data
+            uncompressed.clear();
+            int uncompressedDataSize = Snappy.uncompress(compressed, uncompressed);
+
+            // Snappy.compress() does not change the destination buffer position
+            Buffers.range(uncompressed, 0, uncompressedDataSize);
+        }
+
+        return uncompressed;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return channel.isOpen();
+    }
+
+    @Override
+    public void close() throws IOException {
+        channel.close();
+    }
+}

--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/SnappyFramedWritableByteChannel.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/SnappyFramedWritableByteChannel.java
@@ -52,7 +52,8 @@ public class SnappyFramedWritableByteChannel implements WritableByteChannel {
      */
     public SnappyFramedWritableByteChannel(WritableByteChannel channel, int frameSize) {
         this.channel = channel;
-        this.uncompressedFrameBuffer = Buffers.allocate(Math.max(MIN_FRAME_SIZE, Math.min(MAX_FRAME_SIZE, frameSize)));
+        int size = Math.max(MIN_FRAME_SIZE, Math.min(MAX_FRAME_SIZE, frameSize));
+        this.uncompressedFrameBuffer = SnappyUtil.allocateBuffer(size);
     }
 
     @Override
@@ -74,7 +75,7 @@ public class SnappyFramedWritableByteChannel implements WritableByteChannel {
         if (dst == null) {
             int uncompressedFrameSize = uncompressedFrameBuffer.capacity();
             writeFramedChannelHeader(channel, uncompressedFrameSize);
-            dst = Buffers.allocate(getMaxCompressedFrameSize(uncompressedFrameSize));
+            dst = SnappyUtil.allocateBuffer(getMaxCompressedFrameSize(uncompressedFrameSize));
             this.compressedFrameBuffer = dst;
         }
         src.flip();

--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/SnappyFramedWritableByteChannel.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/SnappyFramedWritableByteChannel.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.client.util;
+
+import static com.asakusafw.vanilla.client.util.SnappyUtil.*;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
+
+import org.xerial.snappy.Snappy;
+
+import com.asakusafw.vanilla.core.util.Buffers;
+
+/**
+ * A {@link WritableByteChannel} with snappy compression by each frame.
+ * @since 0.5.3
+ */
+public class SnappyFramedWritableByteChannel implements WritableByteChannel {
+
+    private final WritableByteChannel channel;
+
+    private final ByteBuffer uncompressedFrameBuffer;
+
+    private volatile ByteBuffer compressedFrameBuffer;
+
+    /**
+     * creates a new instance.
+     * @param channel the destination channel
+     */
+    public SnappyFramedWritableByteChannel(WritableByteChannel channel) {
+        this(channel, FRAME_SIZE);
+    }
+
+    /**
+     * creates a new instance.
+     * @param channel the destination channel
+     * @param frameSize the compression frame size in bytes
+     */
+    public SnappyFramedWritableByteChannel(WritableByteChannel channel, int frameSize) {
+        this.channel = channel;
+        this.uncompressedFrameBuffer = Buffers.allocate(Math.max(MIN_FRAME_SIZE, Math.min(MAX_FRAME_SIZE, frameSize)));
+    }
+
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+        ByteBuffer dst = uncompressedFrameBuffer;
+        int written = 0;
+        while (src.hasRemaining()) {
+            written += Buffers.put(src, dst);
+            if (!dst.hasRemaining()) {
+                flush();
+            }
+        }
+        return written;
+    }
+
+    private void flush() throws IOException {
+        ByteBuffer src = uncompressedFrameBuffer;
+        ByteBuffer dst = compressedFrameBuffer;
+        if (dst == null) {
+            int uncompressedFrameSize = uncompressedFrameBuffer.capacity();
+            writeFramedChannelHeader(channel, uncompressedFrameSize);
+            dst = Buffers.allocate(getMaxCompressedFrameSize(uncompressedFrameSize));
+            this.compressedFrameBuffer = dst;
+        }
+        src.flip();
+        if (src.hasRemaining()) {
+            dst.clear();
+            dst.position(FRAME_HEADER_SIZE);
+            int compressedDataSize = Snappy.compress(src, dst);
+
+            // Snappy.compress() does not change the destination buffer position
+            Buffers.range(dst, 0, FRAME_HEADER_SIZE + compressedDataSize);
+            dst.putInt(0, compressedDataSize);
+
+            do {
+                channel.write(dst);
+            } while (dst.hasRemaining());
+        }
+        src.clear();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return channel.isOpen();
+    }
+
+    @Override
+    public void close() throws IOException {
+        flush();
+        channel.close();
+    }
+}

--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/SnappyUtil.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/SnappyUtil.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.client.util;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xerial.snappy.Snappy;
+
+import com.asakusafw.vanilla.core.util.Buffers;
+import com.asakusafw.vanilla.core.util.SystemProperty;
+
+/**
+ * Utilities about snappy compression.
+ */
+public final class SnappyUtil {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SnappyUtil.class);
+
+    private static final String KEY_PREFIX = SystemProperty.KEY_PREFIX + "snappy."; //$NON-NLS-1$
+
+    /**
+     * The system property key of snappy compression frame size for framed compressor
+     * ({@value}: {@value #DEFAULT_FRAME_SIZE}).
+     * @see SnappyFramedWritableByteChannel
+     */
+    public static final String KEY_FRAME_SIZE = KEY_PREFIX + "frame.size"; //$NON-NLS-1$
+
+    /**
+     * The default value of {@link #KEY_FRAME_SIZE}.
+     */
+    public static final int DEFAULT_FRAME_SIZE = 16 * 1024;
+
+    /**
+     * The minimum value of {@link #KEY_FRAME_SIZE}.
+     */
+    public static final int MIN_FRAME_SIZE = 4 * 1024;
+
+    /**
+     * The maximum value of {@link #KEY_FRAME_SIZE}.
+     */
+    public static final int MAX_FRAME_SIZE = 1024 * 1024;
+
+    static final int FRAME_SIZE = Math.max(
+            MIN_FRAME_SIZE,
+            Math.min(
+                    MAX_FRAME_SIZE,
+                    SystemProperty.get(KEY_FRAME_SIZE, DEFAULT_FRAME_SIZE)));
+
+    /*
+     * struct framed_file {
+     *   int8_t magic[4];
+     *   int32_t frame_size;
+     *
+     *   struct compressed_frame_t {
+     *     int32_t compressed_frame_info;
+     *     int8_t compressed_data[compressed_frame_info & 0xff_ffff];
+     *   } compressed_frames[...];
+     * }
+     */
+
+    private static final byte[] FRAMED_FILE_HEADER_MAGIC = {
+            (byte) 'S',
+            (byte) 'N',
+            (byte) 'P',
+            (byte) 'f',
+    };
+
+    static final int FRAMED_FILE_HEADER_SIZE = FRAMED_FILE_HEADER_MAGIC.length + Integer.BYTES;
+
+    private static final ThreadLocal<ByteBuffer> BUFFERS = ThreadLocal
+            .withInitial(() -> Buffers.allocate(FRAMED_FILE_HEADER_SIZE));
+
+    static final int FRAME_HEADER_SIZE = Integer.BYTES;
+
+    static final int COMPRESSED_DATA_SIZE_MASK = 0x00ff_ffff;
+
+    static int getMaxCompressedFrameSize(int rawFrameSize) {
+        int maxCompressedDataSize = Snappy.maxCompressedLength(rawFrameSize);
+        assert maxCompressedDataSize <= COMPRESSED_DATA_SIZE_MASK;
+        return FRAME_HEADER_SIZE + maxCompressedDataSize;
+    }
+
+    static void writeFramedChannelHeader(WritableByteChannel channel, int frameSize) throws IOException {
+        ByteBuffer buf = BUFFERS.get();
+        buf.clear();
+        buf.put(FRAMED_FILE_HEADER_MAGIC);
+        buf.putInt(frameSize);
+        buf.flip();
+        do {
+            channel.write(buf);
+        } while (buf.hasRemaining());
+    }
+
+    static int readFramedChannelHeader(ReadableByteChannel channel) throws IOException {
+        ByteBuffer buf = BUFFERS.get();
+        buf.clear();
+        do {
+            int read = channel.read(buf);
+            if (read == -1) {
+                throw new EOFException();
+            }
+        } while (buf.hasRemaining());
+        buf.flip();
+        for (byte h : FRAMED_FILE_HEADER_MAGIC) {
+            byte b = buf.get();
+            if (b != h) {
+                throw new IOException("invalid snappy frame header");
+            }
+        }
+        return buf.getInt();
+    }
+
+    static {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Snappy:");
+            LOG.debug("  {}: {}", KEY_FRAME_SIZE, FRAME_SIZE);
+        }
+    }
+
+    private SnappyUtil() {
+        return;
+    }
+}

--- a/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/SnappyUtil.java
+++ b/vanilla/runtime/client/src/main/java/com/asakusafw/vanilla/client/util/SnappyUtil.java
@@ -18,6 +18,7 @@ package com.asakusafw.vanilla.client.util;
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 
@@ -92,6 +93,10 @@ public final class SnappyUtil {
     static final int FRAME_HEADER_SIZE = Integer.BYTES;
 
     static final int COMPRESSED_DATA_SIZE_MASK = 0x00ff_ffff;
+
+    static ByteBuffer allocateBuffer(int size) {
+        return ByteBuffer.allocateDirect(size).order(ByteOrder.nativeOrder());
+    }
 
     static int getMaxCompressedFrameSize(int rawFrameSize) {
         int maxCompressedDataSize = Snappy.maxCompressedLength(rawFrameSize);

--- a/vanilla/runtime/client/src/test/java/com/asakusafw/vanilla/client/util/SnappyFramedWritableByteChannelTest.java
+++ b/vanilla/runtime/client/src/test/java/com/asakusafw/vanilla/client/util/SnappyFramedWritableByteChannelTest.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vanilla.client.util;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.asakusafw.vanilla.core.util.Buffers;
+
+/**
+ * Test for {@link SnappyFramedWritableByteChannel} and {@link SnappyFramedReadableByteChannel}.
+ */
+public class SnappyFramedWritableByteChannelTest {
+
+    /**
+     * temporary folder.
+     */
+    @Rule
+    public final TemporaryFolder temporary = new TemporaryFolder();
+
+    private static final int FILE_SIZE = 1024 * 1024;
+
+    private static final int DIVISOR = 256;
+
+    private static final int SMALL_PRIME = 256 + 1;
+
+    private static final int LARGE_PRIME = (256 * 1024) - 1;
+
+    /**
+     * simple case.
+     * @throws Exception if failed
+     */
+    @Test
+    public void simple() throws Exception {
+        test(1, 1);
+    }
+
+    /**
+     * empty output.
+     * @throws Exception if failed
+     */
+    @Test
+    public void empty() throws Exception {
+        test(0, DIVISOR);
+    }
+
+    /**
+     * buffer size is divisor of file size.
+     * @throws Exception if failed
+     */
+    @Test
+    public void divisor() throws Exception {
+        test(FILE_SIZE, DIVISOR);
+    }
+
+    /**
+     * small buffer.
+     * @throws Exception if failed
+     */
+    @Test
+    public void small_buffer() throws Exception {
+        test(FILE_SIZE, SMALL_PRIME);
+    }
+
+    /**
+     * large buffer.
+     * @throws Exception if failed
+     */
+    @Test
+    public void large_buffer() throws Exception {
+        test(FILE_SIZE, LARGE_PRIME);
+    }
+
+    private void test(int fileSize, int bufferSize) throws IOException {
+        ByteBuffer buffer = Buffers.allocate(bufferSize);
+        Path file = temporary.newFile().toPath();
+        try (WritableByteChannel c = new SnappyFramedWritableByteChannel(Files.newByteChannel(file, StandardOpenOption.WRITE))) {
+            write(c, buffer, fileSize);
+        }
+        try (ReadableByteChannel c = new SnappyFramedReadableByteChannel(Files.newByteChannel(file, StandardOpenOption.READ))) {
+            verify(c, buffer, fileSize);
+        }
+    }
+
+    private void write(WritableByteChannel channel, ByteBuffer buffer, int size) throws IOException {
+        int position = 0;
+        while (position < size) {
+            buffer.clear();
+            while (position < size && buffer.hasRemaining()) {
+                buffer.put((byte) position++);
+            }
+            buffer.flip();
+            while (buffer.hasRemaining()) {
+                int remain = buffer.remaining();
+                int written = channel.write(buffer);
+                assertEquals(buffer.remaining(), remain - written);
+            }
+        }
+    }
+
+    private void verify(ReadableByteChannel channel, ByteBuffer buffer, int size) throws IOException {
+        int position = 0;
+        while (true) {
+            buffer.clear();
+            int read = channel.read(buffer);
+            if (read < 0) {
+                break;
+            }
+            buffer.flip();
+            while (buffer.hasRemaining()) {
+                byte b = buffer.get();
+                assertEquals(b, (byte) position++);
+            }
+        }
+        assertEquals(position, size);
+    }
+
+}


### PR DESCRIPTION
## Summary

This PR replaces implementation of `SnappyByteChannelDecorator`, and removes some configuration parameters introduced in #194.

## Background, Problem or Goal of the patch

This include the following features:
* improve memory usage
* optimize for off-heap buffers

## Design of the fix, or a new feature

To enable this feature, please put the following engine configuration:
* `com.asakusafw.vanilla.pool.compression=com.asakusafw.vanilla.client.util.SnappyByteChannelDecorator`

To configure each internal behavior, please configure
the following **system properties**:
* `com.asakusafw.vanilla.snappy.frame.size`
    * system property key of compression frame size in bytes
    * default: `16384` (16KB)

Note that, the legacy internal configurations (for internal behavior) are superseded by this commit.

## Related Issue, Pull Request or Code

* #194 