### PR TITLE
fix wrong shuffle operation in Vanilla.

### DIFF
--- a/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/BasicKeyValueSink.java
+++ b/vanilla/runtime/core/src/main/java/com/asakusafw/vanilla/core/io/BasicKeyValueSink.java
@@ -51,6 +51,8 @@ public final class BasicKeyValueSink implements KeyValueSink {
 
     private boolean sawKey = false;
 
+    private boolean written = false;
+
     /**
      * Creates a new instance.
      * @param channel the destination channel
@@ -96,6 +98,7 @@ public final class BasicKeyValueSink implements KeyValueSink {
         addItem(w, key);
         addItem(w, value);
         sawKey = true;
+        written = true;
     }
 
     @Override
@@ -123,7 +126,8 @@ public final class BasicKeyValueSink implements KeyValueSink {
             if (w == null) {
                 return;
             }
-            if (channel != null) {
+            // commit only if any entries exist
+            if (written && channel != null) {
                 channel.commit(w);
             }
         }

--- a/vanilla/runtime/core/src/test/java/com/asakusafw/vanilla/core/engine/BasicEdgeDriverTest.java
+++ b/vanilla/runtime/core/src/test/java/com/asakusafw/vanilla/core/engine/BasicEdgeDriverTest.java
@@ -742,9 +742,12 @@ public class BasicEdgeDriverTest {
 
         GraphMirror graph = GraphMirror.of(info);
         try (EdgeDriver driver = driver(graph)) {
-            try (ObjectWriter writer = (ObjectWriter) driver.acquireOutput(u0)) {
-                for (MockDataModel object : objects) {
-                    writer.putObject(object);
+            try (ObjectWriter w0 = (ObjectWriter) driver.acquireOutput(u0);
+                    ObjectWriter w1 = (ObjectWriter) driver.acquireOutput(u0);
+                    ObjectWriter w2 = (ObjectWriter) driver.acquireOutput(u0)) {
+                ObjectWriter[] ws = { w0, w1, w2 };
+                for (int i = 0, n = objects.size(); i < n; i++) {
+                    ws[i % ws.length].putObject(objects.get(i));
                 }
             }
             complete(driver, u0);
@@ -760,6 +763,10 @@ public class BasicEdgeDriverTest {
                 o2 = collect(r2);
             }
             complete(driver, d0);
+
+            assertThat(o0.size(), greaterThan(objects.size() / (partitions * 2)));
+            assertThat(o1.size(), greaterThan(objects.size() / (partitions * 2)));
+            assertThat(o2.size(), greaterThan(objects.size() / (partitions * 2)));
 
             assertThat(disjoint(keys(o0), keys(o1)), is(true));
             assertThat(disjoint(keys(o0), keys(o2)), is(true));


### PR DESCRIPTION
## Summary

This PR fixes wrong shuffle operation in Vanilla, since #192.

## Background, Problem or Goal of the patch

N/A.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* #192