### PR TITLE
add more integration test about Direct I/O Hive.

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -13,7 +13,7 @@ This integration test requires both development and runtime environment of Asaku
 * `PATH`
   * no `hadoop` command on the path
 * `JAVA_HOME`
-  * refer to Java SDK `>= 1.8`
+  * refer to Java SDK `= 1.8`
 
 ## How to run tests
 

--- a/integration/src/integration-test/data/ksv-hive/src/main/dmdl/hive.dmdl
+++ b/integration/src/integration-test/data/ksv-hive/src/main/dmdl/hive.dmdl
@@ -1,3 +1,4 @@
+@directio.csv
 @directio.hive.orc
 @directio.hive.parquet
 ksv_hive = {

--- a/integration/src/integration-test/data/ksv-hive/src/main/java/com/example/hive/CsvInputDescription.java
+++ b/integration/src/integration-test/data/ksv-hive/src/main/java/com/example/hive/CsvInputDescription.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.hive;
+
+import com.example.modelgen.dmdl.csv.AbstractKsvHiveCsvInputDescription;
+
+/**
+ * Input Key-Sort-Value data-set from <code>${input}</code>.
+ */
+public class CsvInputDescription extends AbstractKsvHiveCsvInputDescription {
+
+    @Override
+    public String getBasePath() {
+        return "${csv.input}";
+    }
+
+    @Override
+    public String getResourcePattern() {
+        return "*.csv";
+    }
+}

--- a/integration/src/integration-test/data/ksv-hive/src/main/java/com/example/hive/CsvOutputDescription.java
+++ b/integration/src/integration-test/data/ksv-hive/src/main/java/com/example/hive/CsvOutputDescription.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.hive;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.example.modelgen.dmdl.csv.AbstractKsvHiveCsvOutputDescription;
+
+/**
+ * Output Key-Sort-Value data-set into <code>${output}</code>.
+ */
+public class CsvOutputDescription extends AbstractKsvHiveCsvOutputDescription {
+
+    @Override
+    public String getBasePath() {
+        return "${csv.output}";
+    }
+
+    @Override
+    public String getResourcePattern() {
+        return "*.csv";
+    }
+
+    @Override
+    public List<String> getDeletePatterns() {
+        return Arrays.asList(getResourcePattern());
+    }
+}

--- a/integration/src/integration-test/data/ksv-hive/src/main/java/com/example/hive/CsvToOrcJob.java
+++ b/integration/src/integration-test/data/ksv-hive/src/main/java/com/example/hive/CsvToOrcJob.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.hive;
+
+import static com.asakusafw.vocabulary.flow.util.CoreOperators.*;
+
+import com.asakusafw.vocabulary.flow.Export;
+import com.asakusafw.vocabulary.flow.FlowDescription;
+import com.asakusafw.vocabulary.flow.Import;
+import com.asakusafw.vocabulary.flow.In;
+import com.asakusafw.vocabulary.flow.JobFlow;
+import com.asakusafw.vocabulary.flow.Out;
+import com.asakusafw.vocabulary.flow.Source;
+import com.example.hive.KsvHiveOperatorFactory;
+import com.example.modelgen.dmdl.model.KsvHive;
+
+/**
+ * Partitioned sort using {@link KsvHive}.
+ */
+@JobFlow(name = "CsvToOrc")
+public class CsvToOrcJob extends FlowDescription {
+
+    final In<KsvHive> in;
+
+    final Out<KsvHive> out;
+
+    /**
+     * Creates a new instance.
+     * @param in the input
+     * @param out the output
+     */
+    public CsvToOrcJob(
+            @Import(name = "ksv", description = CsvInputDescription.class) In<KsvHive> in,
+            @Export(name = "ksv", description = OrcOutputDescription.class) Out<KsvHive> out) {
+        this.in = in;
+        this.out = out;
+    }
+
+    @Override
+    protected void describe() {
+        out.add(in);
+    }
+}

--- a/integration/src/integration-test/data/ksv-hive/src/main/java/com/example/hive/CsvToParquetJob.java
+++ b/integration/src/integration-test/data/ksv-hive/src/main/java/com/example/hive/CsvToParquetJob.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.hive;
+
+import static com.asakusafw.vocabulary.flow.util.CoreOperators.*;
+
+import com.asakusafw.vocabulary.flow.Export;
+import com.asakusafw.vocabulary.flow.FlowDescription;
+import com.asakusafw.vocabulary.flow.Import;
+import com.asakusafw.vocabulary.flow.In;
+import com.asakusafw.vocabulary.flow.JobFlow;
+import com.asakusafw.vocabulary.flow.Out;
+import com.asakusafw.vocabulary.flow.Source;
+import com.example.hive.KsvHiveOperatorFactory;
+import com.example.modelgen.dmdl.model.KsvHive;
+
+/**
+ * Partitioned sort using {@link KsvHive}.
+ */
+@JobFlow(name = "CsvToParquet")
+public class CsvToParquetJob extends FlowDescription {
+
+    final In<KsvHive> in;
+
+    final Out<KsvHive> out;
+
+    /**
+     * Creates a new instance.
+     * @param in the input
+     * @param out the output
+     */
+    public CsvToParquetJob(
+            @Import(name = "ksv", description = CsvInputDescription.class) In<KsvHive> in,
+            @Export(name = "ksv", description = ParquetOutputDescription.class) Out<KsvHive> out) {
+        this.in = in;
+        this.out = out;
+    }
+
+    @Override
+    protected void describe() {
+        out.add(in);
+    }
+}

--- a/integration/src/integration-test/data/ksv-hive/src/main/java/com/example/hive/OrcIoBatch.java
+++ b/integration/src/integration-test/data/ksv-hive/src/main/java/com/example/hive/OrcIoBatch.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.hive;
+
+import com.asakusafw.vocabulary.batch.Batch;
+import com.asakusafw.vocabulary.batch.Batch.Parameter;
+import com.asakusafw.vocabulary.batch.BatchDescription;
+import com.asakusafw.vocabulary.batch.Work;
+
+/**
+ * The average application of exchanging file format.
+ */
+@Batch(
+        name = "perf.orc.io",
+        parameters = {
+                @Parameter(key = "csv.input", comment = "input base path"),
+                @Parameter(key = "output", comment = "temporary output directory"),
+                @Parameter(key = "input", comment = "must be equal to \"output\""),
+                @Parameter(key = "csv.output", comment = "output base path")
+        },
+        strict = true
+)
+public class OrcIoBatch extends BatchDescription {
+
+    @Override
+    protected void describe() {
+        Work w0 = run(CsvToOrcJob.class).soon();
+        run(OrcToCsvJob.class).after(w0);
+    }
+}

--- a/integration/src/integration-test/data/ksv-hive/src/main/java/com/example/hive/OrcToCsvJob.java
+++ b/integration/src/integration-test/data/ksv-hive/src/main/java/com/example/hive/OrcToCsvJob.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.hive;
+
+import static com.asakusafw.vocabulary.flow.util.CoreOperators.*;
+
+import com.asakusafw.vocabulary.flow.Export;
+import com.asakusafw.vocabulary.flow.FlowDescription;
+import com.asakusafw.vocabulary.flow.Import;
+import com.asakusafw.vocabulary.flow.In;
+import com.asakusafw.vocabulary.flow.JobFlow;
+import com.asakusafw.vocabulary.flow.Out;
+import com.asakusafw.vocabulary.flow.Source;
+import com.example.hive.KsvHiveOperatorFactory;
+import com.example.modelgen.dmdl.model.KsvHive;
+
+/**
+ * Partitioned sort using {@link KsvHive}.
+ */
+@JobFlow(name = "OrcToCsv")
+public class OrcToCsvJob extends FlowDescription {
+
+    final In<KsvHive> in;
+
+    final Out<KsvHive> out;
+
+    /**
+     * Creates a new instance.
+     * @param in the input
+     * @param out the output
+     */
+    public OrcToCsvJob(
+            @Import(name = "ksv", description = OrcInputDescription.class) In<KsvHive> in,
+            @Export(name = "ksv", description = CsvOutputDescription.class) Out<KsvHive> out) {
+        this.in = in;
+        this.out = out;
+    }
+
+    @Override
+    protected void describe() {
+        out.add(in);
+    }
+}

--- a/integration/src/integration-test/data/ksv-hive/src/main/java/com/example/hive/ParquetIoBatch.java
+++ b/integration/src/integration-test/data/ksv-hive/src/main/java/com/example/hive/ParquetIoBatch.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.hive;
+
+import com.asakusafw.vocabulary.batch.Batch;
+import com.asakusafw.vocabulary.batch.Batch.Parameter;
+import com.asakusafw.vocabulary.batch.BatchDescription;
+import com.asakusafw.vocabulary.batch.Work;
+
+/**
+ * The average application of exchanging file format.
+ */
+@Batch(
+        name = "perf.parquet.io",
+        parameters = {
+                @Parameter(key = "csv.input", comment = "input base path"),
+                @Parameter(key = "output", comment = "temporary output directory"),
+                @Parameter(key = "input", comment = "must be equal to \"output\""),
+                @Parameter(key = "csv.output", comment = "output base path")
+        },
+        strict = true
+)
+public class ParquetIoBatch extends BatchDescription {
+
+    @Override
+    protected void describe() {
+        Work w0 = run(CsvToParquetJob.class).soon();
+        run(ParquetToCsvJob.class).after(w0);
+    }
+}

--- a/integration/src/integration-test/data/ksv-hive/src/main/java/com/example/hive/ParquetToCsvJob.java
+++ b/integration/src/integration-test/data/ksv-hive/src/main/java/com/example/hive/ParquetToCsvJob.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.hive;
+
+import static com.asakusafw.vocabulary.flow.util.CoreOperators.*;
+
+import com.asakusafw.vocabulary.flow.Export;
+import com.asakusafw.vocabulary.flow.FlowDescription;
+import com.asakusafw.vocabulary.flow.Import;
+import com.asakusafw.vocabulary.flow.In;
+import com.asakusafw.vocabulary.flow.JobFlow;
+import com.asakusafw.vocabulary.flow.Out;
+import com.asakusafw.vocabulary.flow.Source;
+import com.example.hive.KsvHiveOperatorFactory;
+import com.example.modelgen.dmdl.model.KsvHive;
+
+/**
+ * Partitioned sort using {@link KsvHive}.
+ */
+@JobFlow(name = "ParquetToCsv")
+public class ParquetToCsvJob extends FlowDescription {
+
+    final In<KsvHive> in;
+
+    final Out<KsvHive> out;
+
+    /**
+     * Creates a new instance.
+     * @param in the input
+     * @param out the output
+     */
+    public ParquetToCsvJob(
+            @Import(name = "ksv", description = ParquetInputDescription.class) In<KsvHive> in,
+            @Export(name = "ksv", description = CsvOutputDescription.class) Out<KsvHive> out) {
+        this.in = in;
+        this.out = out;
+    }
+
+    @Override
+    protected void describe() {
+        out.add(in);
+    }
+}

--- a/integration/src/integration-test/data/vanilla/build.gradle
+++ b/integration/src/integration-test/data/vanilla/build.gradle
@@ -77,13 +77,15 @@ if (System.getProperty('hive.version')) {
     asakusafwOrganizer {
         hive.enabled true
     }
-    if (System.getProperty('hive.version') != '*') {
+    if (System.getProperty('hive.version') != 'default') {
         asakusafwOrganizer {
             hive.libraries = ["org.apache.hive:hive-exec:${System.getProperty('hive.version')}"]
         }
-        configurations.all {
-            resolutionStrategy {
-                force "org.apache.hive:hive-exec:${System.getProperty('hive.version')}"
+        if (System.getProperty('hive.followSdkVersion', 'false') != 'false') {
+            configurations.all {
+                resolutionStrategy {
+                    force "org.apache.hive:hive-exec:${System.getProperty('hive.version')}"
+                }
             }
         }
     }

--- a/integration/src/integration-test/data/vanilla/build.gradle
+++ b/integration/src/integration-test/data/vanilla/build.gradle
@@ -77,16 +77,14 @@ if (System.getProperty('hive.version')) {
     asakusafwOrganizer {
         hive.enabled true
     }
-    if (System.getProperty('hive.version') != 'default') {
+    if (System.getProperty('hive.version', 'default') != 'default') {
         asakusafwOrganizer {
             hive.libraries = ["org.apache.hive:hive-exec:${System.getProperty('hive.version')}"]
         }
-        if (System.getProperty('hive.followSdkVersion', 'false') != 'false') {
-            configurations.all {
-                resolutionStrategy {
-                    force "org.apache.hive:hive-exec:${System.getProperty('hive.version')}"
-                }
-            }
+    }
+    if (System.getProperty('sdk.hive.version', 'default') != 'default') {
+        asakusafw {
+            sdk.hive = ["org.apache.hive:hive-exec:${System.getProperty('sdk.hive.version')}"]
         }
     }
 }

--- a/integration/src/integration-test/java/com/asakusafw/integration/lang/HiveTest.java
+++ b/integration/src/integration-test/java/com/asakusafw/integration/lang/HiveTest.java
@@ -50,15 +50,18 @@ public class HiveTest {
      * Return the test parameters.
      * @return the test parameters
      */
-    @Parameters(name = "version:{0}")
+    @Parameters(name = "sdk:{0},assembly:{1}")
     public static Object[][] getTestParameters() {
         return new Object[][] {
-            { "default", },
-            {   "1.1.1", },
-            {   "1.2.1", },
-            {   "1.2.2", },
-            {   "2.3.4", },
-//            {   "3.1.1", },
+            { "default", "default", },
+            { "default",   "1.1.1", },
+            { "default",   "1.2.1", },
+            { "default",   "1.2.2", },
+            { "default",   "2.3.4", },
+            {   "1.2.2",   "1.2.2", },
+            {   "2.3.4",   "1.2.2", },
+            {   "1.2.2",   "2.3.4", },
+            {   "2.3.4",   "2.3.4", },
         };
     }
 
@@ -75,10 +78,12 @@ public class HiveTest {
 
     /**
      * creates a new instance.
-     * @param hiveVersion the hive-exec version
+     * @param sdkHiveVersion  the hive-exec version for SDK
+     * @param assemblyHiveVersion the hive-exec version for assemblies
      */
-    public HiveTest(String hiveVersion) {
-        provider.withProject(PropertyConfigurator.of("hive.version", String.valueOf(hiveVersion)));
+    public HiveTest(String sdkHiveVersion, String assemblyHiveVersion) {
+        provider.withProject(PropertyConfigurator.of("sdk.hive.version", String.valueOf(sdkHiveVersion)));
+        provider.withProject(PropertyConfigurator.of("hive.version", String.valueOf(assemblyHiveVersion)));
     }
 
     /**

--- a/integration/src/integration-test/java/com/asakusafw/integration/lang/PortalTest.java
+++ b/integration/src/integration-test/java/com/asakusafw/integration/lang/PortalTest.java
@@ -43,7 +43,7 @@ public class PortalTest {
             .withProject(ContentsConfigurator.copy(data("logback-test")))
             .withProject(AsakusaConfigurator.projectHome())
             .withProject(AsakusaConfigurator.hadoop(AsakusaConfigurator.Action.UNSET_ALWAYS))
-            .withProject(PropertyConfigurator.of("hive.version", "*"))
+            .withProject(PropertyConfigurator.of("hive.version", "default"))
             .withProvider(provider -> {
                 // install framework only once
                 framework = provider.newInstance("inf")


### PR DESCRIPTION
## Summary

This PR introduces more integration test cases about asakusafw/asakusafw#834, which enables to use `hive-exec:2.3.4`.

## Background, Problem or Goal of the patch

N/A.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw#834
