### PR TITLE
mark deprecated to framework API classes in bridge.

### DIFF
--- a/bridge-project/runtime-directio/src/main/java/com/asakusafw/bridge/directio/api/DirectIo.java
+++ b/bridge-project/runtime-directio/src/main/java/com/asakusafw/bridge/directio/api/DirectIo.java
@@ -38,7 +38,10 @@ import com.asakusafw.runtime.io.ModelInput;
  * This API requires that either {@link Configuration a Hadoop configuration} object or
  * {@link ResourceConfiguration Asakusa configuration} object has been registered to {@link ResourceBroker}.
  * </p>
+ * @deprecated this API is not for application developers,
+ *      please use {@link com.asakusafw.runtime.directio.api.DirectIo} instead
  */
+@Deprecated
 public final class DirectIo {
 
     private DirectIo() {

--- a/bridge-project/runtime-directio/src/main/java/com/asakusafw/bridge/directio/api/activate/DirectIoApiActivator.java
+++ b/bridge-project/runtime-directio/src/main/java/com/asakusafw/bridge/directio/api/activate/DirectIoApiActivator.java
@@ -31,6 +31,7 @@ import com.asakusafw.runtime.io.ModelInput;
  * Activates {@link DirectIo}.
  * @since 0.4.0
  */
+@SuppressWarnings("deprecation")
 public class DirectIoApiActivator implements ApiActivator {
 
     static final Logger LOG = LoggerFactory.getLogger(DirectIoApiActivator.class);

--- a/bridge-project/runtime/src/main/java/com/asakusafw/bridge/api/BatchContext.java
+++ b/bridge-project/runtime/src/main/java/com/asakusafw/bridge/api/BatchContext.java
@@ -36,7 +36,10 @@ import com.asakusafw.runtime.stage.StageConstants;
  * @see com.asakusafw.runtime.core.BatchContext
  * @since 0.1.0
  * @version 0.3.1
+ * @deprecated this API is not for application developers,
+ *      please use {@link com.asakusafw.runtime.core.BatchContext} instead
  */
+@Deprecated
 public final class BatchContext {
 
     private static final ResourceCacheStorage<StageInfo> CACHE = new ResourceCacheStorage<>();

--- a/bridge-project/runtime/src/main/java/com/asakusafw/bridge/api/Report.java
+++ b/bridge-project/runtime/src/main/java/com/asakusafw/bridge/api/Report.java
@@ -35,7 +35,10 @@ import com.asakusafw.runtime.core.ResourceConfiguration;
  * </p>
  * @since 0.1.0
  * @version 0.1.1
+ * @deprecated this API is not for application developers,
+ *      please use {@link com.asakusafw.runtime.core.Report} instead
  */
+@Deprecated
 public final class Report {
 
     private Report() {

--- a/bridge-project/runtime/src/main/java/com/asakusafw/bridge/api/activate/BatchContextApiActivator.java
+++ b/bridge-project/runtime/src/main/java/com/asakusafw/bridge/api/activate/BatchContextApiActivator.java
@@ -23,6 +23,7 @@ import com.asakusafw.runtime.core.api.BatchContextApi;
  * Activates {@link BatchContext}.
  * @since 0.4.0
  */
+@SuppressWarnings("deprecation")
 public class BatchContextApiActivator implements ApiActivator {
 
     private static final BatchContextApi API = new BatchContextApi() {

--- a/bridge-project/runtime/src/main/java/com/asakusafw/bridge/api/activate/ReportApiActivator.java
+++ b/bridge-project/runtime/src/main/java/com/asakusafw/bridge/api/activate/ReportApiActivator.java
@@ -23,6 +23,7 @@ import com.asakusafw.runtime.core.api.ReportApi;
  * Activates {@link Report}.
  * @since 0.4.0
  */
+@SuppressWarnings("deprecation")
 public class ReportApiActivator implements ApiActivator {
 
     private static final ReportApi API = new ReportApi() {


### PR DESCRIPTION
## Summary

This PR marks framework API classes in `asakusafw-bridge-runtime` as deprecated.

## Background, Problem or Goal of the patch

Framework API classes in `asakusafw-bridge-runtime` are same name in `asakusa-runtime`. It sometimes confuses when using Eclipse.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.
