### PR TITLE
DSL compiler supports `Class-Path` entries in each JAR manifest.

### DIFF
--- a/compiler-project/api/src/main/java/com/asakusafw/lang/compiler/api/CompilerOptions.java
+++ b/compiler-project/api/src/main/java/com/asakusafw/lang/compiler/api/CompilerOptions.java
@@ -24,8 +24,17 @@ import com.asakusafw.lang.compiler.common.util.StringUtil;
 
 /**
  * Represents a set of Asakusa DSL compiler options.
+ * @since 0.1.0
+ * @version 0.5.4
  */
 public class CompilerOptions {
+
+    /**
+     * the system property key prefix of each compiler options.
+     * each property is only available if the target option was absent.
+     * @since 0.5.4
+     */
+    public static final String PREFIX_SYSTEM_PROPERTY = "asakusafw.lang."; //$NON-NLS-1$
 
     /**
      * Represents a path of the default file system root.
@@ -121,6 +130,19 @@ public class CompilerOptions {
      */
     public Map<String, String> getProperties(String propertyKeyPrefix) {
         Map<String, String> results = new LinkedHashMap<>();
+        String systemPropertyPrefix = PREFIX_SYSTEM_PROPERTY + propertyKeyPrefix;
+        for (Map.Entry<Object, Object> entry : System.getProperties().entrySet()) {
+            if (!(entry.getKey() instanceof String) || !(entry.getValue() instanceof String)) {
+                continue;
+            }
+            String rawKey = (String) entry.getKey();
+            if (!rawKey.startsWith(systemPropertyPrefix)) {
+                continue;
+            }
+            String key = rawKey.substring(PREFIX_SYSTEM_PROPERTY.length());
+            String value = (String) entry.getValue();
+            results.put(key, value);
+        }
         for (Map.Entry<String, String> entry : properties.entrySet()) {
             String key = entry.getKey();
             if (key.startsWith(propertyKeyPrefix)) {
@@ -139,7 +161,7 @@ public class CompilerOptions {
     public String get(String propertyKey, String defaultValue) {
         String value = properties.get(propertyKey);
         if (value == null) {
-            return defaultValue;
+            return System.getProperty(PREFIX_SYSTEM_PROPERTY + propertyKey, defaultValue);
         }
         return value;
     }

--- a/compiler-project/core/src/main/java/com/asakusafw/lang/compiler/core/participant/JavaSourceExtensionParticipant.java
+++ b/compiler-project/core/src/main/java/com/asakusafw/lang/compiler/core/participant/JavaSourceExtensionParticipant.java
@@ -55,6 +55,8 @@ import com.asakusafw.lang.compiler.packaging.ResourceUtil;
  *   </ul>
  * </li>
  * </ul>
+ * @since 0.1.0
+ * @version 0.5.4
  */
 public class JavaSourceExtensionParticipant extends AbstractCompilerParticipant {
 
@@ -72,10 +74,42 @@ public class JavaSourceExtensionParticipant extends AbstractCompilerParticipant 
      */
     public static final String KEY_BOOT_CLASSPATH = KEY_PREFIX + "bootclasspath"; //$NON-NLS-1$
 
+    /**
+     * The compiler option key of whether or not treat
+     * resolves {@code Class-Path} entries in {@code MANIFEST.MF}.
+     * @since 0.5.4
+     */
+    public static final String KEY_INCLUDE_MANIFEST_CLASSPATH = KEY_PREFIX + "classpath.manifest"; //$NON-NLS-1$
+
+    /**
+     * The compiler option key of whether or not include
+     * Java extension libraries to compiler classpath.
+     * @since 0.5.4
+     */
+    public static final String KEY_INCLUDE_EXTENSION_LIBRARIES = KEY_PREFIX + "classpath.extension"; //$NON-NLS-1$
+
+    /**
+     * the default value of {@link #KEY_INCLUDE_MANIFEST_CLASSPATH}.
+     * @since 0.5.4
+     */
+    public static final boolean DEFAULT_INCLUDE_MANIFEST_CLASSPATH = false;
+
+    /**
+     * the default value of {@link #KEY_INCLUDE_EXTENSION_LIBRARIES}.
+     * @since 0.5.4
+     */
+    public static final boolean DEFAULT_INCLUDE_EXTENSION_LIBRARIES = false;
+
     @Override
     public void beforeJobflow(Context context, BatchInfo batch, Jobflow jobflow) {
         LOG.debug("enabling {}", JavaSourceExtension.class.getName()); //$NON-NLS-1$
-        List<File> classPath = JavaCompilerUtil.getLibraries(context.getProject().getClassLoader());
+        boolean extensionClasspath = context.getOptions()
+                .get(KEY_INCLUDE_EXTENSION_LIBRARIES, DEFAULT_INCLUDE_EXTENSION_LIBRARIES);
+        boolean manifestClasspath = context.getOptions()
+                .get(KEY_INCLUDE_MANIFEST_CLASSPATH, DEFAULT_INCLUDE_MANIFEST_CLASSPATH);
+        List<File> classPath = JavaCompilerUtil.getLibraries(
+                context.getProject().getClassLoader(),
+                extensionClasspath, manifestClasspath);
         File sourcePath = createTemporaryOutput(context, jobflow);
         BasicJavaCompilerSupport extension = new BasicJavaCompilerSupport(
                 sourcePath,

--- a/compiler-project/javac/src/main/java/com/asakusafw/lang/compiler/javac/JavaCompilerUtil.java
+++ b/compiler-project/javac/src/main/java/com/asakusafw/lang/compiler/javac/JavaCompilerUtil.java
@@ -16,26 +16,40 @@
 package com.asakusafw.lang.compiler.javac;
 
 import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.text.MessageFormat;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
 import java.util.List;
-import java.util.regex.Pattern;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Utilities for {@link JavaCompilerSupport}.
+ * @since 0.1.0
+ * @version 0.5.4
  */
 public final class JavaCompilerUtil {
 
     static final Logger LOG = LoggerFactory.getLogger(JavaCompilerUtil.class);
 
-    static final Pattern PATTERN_ARCHIVE = Pattern.compile(".+\\.(zip|jar)"); //$NON-NLS-1$
+    static final String EXTENSION_ZIP = ".zip"; //$NON-NLS-1$
+
+    static final String EXTENSION_JAR = ".jar"; //$NON-NLS-1$
 
     private JavaCompilerUtil() {
         return;
@@ -58,28 +72,52 @@ public final class JavaCompilerUtil {
      * @return the related library files
      */
     public static List<File> getLibraries(ClassLoader classLoader, boolean includeExtensionLibraries) {
+        return getLibraries(classLoader, includeExtensionLibraries, false);
+    }
+
+    /**
+     * Returns library files from the target class loader.
+     * @param classLoader the target class loader
+     * @param includeExtensionLibraries {@code true} to include extension libraries, otherwise {@code false}
+     * @param resolveManifestClasspath resolves {@code Class-Path} entries in {@code MANIFEST.MF}
+     * @return the related library files
+     */
+    public static List<File> getLibraries(
+            ClassLoader classLoader,
+            boolean includeExtensionLibraries,
+            boolean resolveManifestClasspath) {
         List<File> results = new ArrayList<>();
         List<URLClassLoader> loaders = getClassLoaders(classLoader, includeExtensionLibraries);
         for (int i = loaders.size() - 1; i >= 0; i--) {
             URLClassLoader current = loaders.get(i);
             LOG.trace("analyzing class loader: {}", current); //$NON-NLS-1$
-            for (URL url : current.getURLs()) {
+            URL[] urls = current.getURLs();
+            for (URL url : urls) {
                 LOG.trace("  analyzing class library: {}", url); //$NON-NLS-1$
                 File file = toFile(url);
                 if (file == null) {
                     LOG.trace("  class library does not have valid file location: {}", url); //$NON-NLS-1$
                     continue;
                 }
-                if (file.isFile() && PATTERN_ARCHIVE.matcher(file.getName()).matches() == false) {
+                if (file.isFile() && !isArchiveName(file.getName())) {
                     LOG.trace("  class library is not valid archive: {}", file); //$NON-NLS-1$
                     continue;
                 }
-                results.add(file);
+                if (resolveManifestClasspath) {
+                    // collect all Class-Path entries
+                    results.addAll(collectClassPath(file));
+                } else {
+                    results.add(file);
+                }
             }
         }
         return results;
     }
 
+    private static boolean isArchiveName(String name) {
+        String s = name.toLowerCase();
+        return s.endsWith(EXTENSION_JAR) || s.endsWith(EXTENSION_ZIP);
+    }
 
     private static List<URLClassLoader> getClassLoaders(ClassLoader classLoader, boolean includeExtensionLibraries) {
         List<URLClassLoader> results = new ArrayList<>();
@@ -97,6 +135,77 @@ public final class JavaCompilerUtil {
         return results;
     }
 
+    private static List<File> collectClassPath(File path) {
+        List<File> results = new ArrayList<>();
+        Deque<File> work = new ArrayDeque<>();
+        work.addFirst(path);
+        while (!work.isEmpty()) {
+            File entry = work.removeFirst();
+            results.add(entry);
+            // find "Class-Path" entries from MANIFEST.MF by DFS
+            if (entry.isFile() && isArchiveName(entry.getName())) {
+                List<File> classpath = extractClassPathAttribute(entry);
+                for (int i = classpath.size() - 1; i >= 0; --i) {
+                    work.addFirst(classpath.get(i));
+                }
+            }
+        }
+        return results;
+    }
+
+    private static List<File> extractClassPathAttribute(File file) {
+        try (JarFile jar = new JarFile(file)) {
+            Manifest manifest = jar.getManifest();
+            if (manifest != null) {
+                Attributes attrs = manifest.getMainAttributes();
+                String classpath = (String) attrs.get(Attributes.Name.CLASS_PATH);
+                if (classpath != null) {
+                    LOG.debug("extracting Class-Path entries: {}", file);
+                    File base = file.getParentFile();
+                    return extractClassPathAttributeValue(base, classpath);
+                }
+            }
+        } catch (IOException e) {
+            LOG.warn(MessageFormat.format(
+                    "failed to extract Class-Path entry: {0}",
+                    file), e);
+        }
+        return Collections.emptyList();
+    }
+
+    private static List<File> extractClassPathAttributeValue(File base, String entries) {
+        URL baseUrl;
+        try {
+            baseUrl = new URL(base.toURI().toASCIIString());
+        } catch (MalformedURLException e) {
+            LOG.warn(MessageFormat.format(
+                    "invalid library URL: {0}",
+                    base), e);
+            return Collections.emptyList();
+        }
+        return Arrays.stream(entries.split("\\s+")) //$NON-NLS-1$
+                .map(String::trim)
+                .filter(it -> !it.isEmpty())
+                .flatMap(it -> {
+                    LOG.trace("resolving Class-Path entry: {}", it);
+                    URL url;
+                    try {
+                        url = new URL(baseUrl, it);
+                    } catch (MalformedURLException e) {
+                        LOG.warn(MessageFormat.format(
+                                "invalid library URL: {0}",
+                                it), e);
+                        return Stream.empty();
+                    }
+                    File file = toFile(url);
+                    if (file != null) {
+                        return Stream.of(file);
+                    }
+                    return Stream.empty();
+                })
+                .collect(Collectors.toList());
+    }
+
     private static File toFile(URL url) {
         String protocol = url.getProtocol();
         if (protocol == null || protocol.equals("file") == false) { //$NON-NLS-1$
@@ -107,7 +216,7 @@ public final class JavaCompilerUtil {
             URI uri = url.toURI();
             File file = new File(uri);
             return file;
-        } catch (URISyntaxException e) {
+        } catch (URISyntaxException | IllegalArgumentException e) {
             LOG.warn(MessageFormat.format(
                     "invalid library URL: {0}",
                     url), e);


### PR DESCRIPTION
## Summary

This PR enables DSL compiler to extract `Class-Path` entries in each JAR manifest.

## Background, Problem or Goal of the patch

This feature is mainly to support running tests with Eclipse Buildship environment.
Additionally, this PR introduces a way to inject DSL compiler options via system properties.

The introduced feature is currently **DISABLED** by default, please add compiler option `javac.classpath.manifest=true` to enable it, or specify `-Dasakusafw.lang.javac.classpath.manifest=true` to launching JVM arguments.

## Design of the fix, or a new feature

This introduces the following compiler option:

* `javac.classpath.manifest`
  * whether or not jobflow compiler treat `Class-Path` entry in manifest file of each class library on compiling generated source files
  * default: `false` (disabled)
* `javac.classpath.extension`
  * whether or not jobflow compiler treat Java extension libraries on compiling generated source files
  * default: `false` (disabled)

Additionally, each compiler options are now configurable via system properties. To set compiler options using system properties, please add `-Dasakusafw.lang.<option-name>=<option-value>` to your JVM startup parameter.

## Related Issue, Pull Request or Code

N/A.