### PR TITLE
Change maven repository URL to use https in build configurations

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Bug reports, Patch contribution
 * Please report any issues to [repository for issue tracking](https://github.com/asakusafw/asakusafw-issues/issues)
-* Please contribute with patches according to our [contribution guide (Japanese only, English version to be added)](http://docs.asakusafw.com/latest/release/ja/html/contribution.html)
+* Please contribute with patches according to our [contribution guide (Japanese only, English version to be added)](https://docs.asakusafw.com/latest/release/ja/html/contribution.html)
 
 ## Template of Issues or Pull Requests
 

--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -45,8 +45,8 @@ repositories {
         mavenLocal()
     }
     mavenCentral()
-    maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-    maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+    maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+    maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
 }
 
 dependencies {

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -48,8 +48,8 @@ repositories {
         mavenLocal()
     }
     mavenCentral()
-    maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-    maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+    maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+    maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
     maven { url 'https://repo.gradle.org/gradle/libs-releases' }
 }
 

--- a/integration/src/integration-test/data/vanilla/build.gradle
+++ b/integration/src/integration-test/data/vanilla/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         if (System.getProperty("maven.local", "true") == "true") {
             mavenLocal()
         }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
         classpath group: 'com.asakusafw.vanilla', 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <version>0.5.4-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <url>http://asakusafw.com</url>
+  <url>https://asakusafw.com</url>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -19,7 +19,7 @@
   <inceptionYear>2011</inceptionYear>
   <organization>
     <name>Asakusa Framework Team</name>
-    <url>http://asakusafw.com</url>
+    <url>https://asakusafw.com</url>
   </organization>
 
   <scm>
@@ -94,7 +94,7 @@
     <repository>
       <id>central</id>
       <name>Maven Central repository</name>
-      <url>http://repo1.maven.org/maven2/</url>
+      <url>https://repo.maven.apache.org/maven2/</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -102,7 +102,7 @@
     <repository>
       <id>com.asakusafw.releases</id>
       <name>Asakusa Framework Repository</name>
-      <url>http://asakusafw.s3.amazonaws.com/maven/releases</url>
+      <url>https://asakusafw.s3.amazonaws.com/maven/releases</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -110,7 +110,7 @@
     <repository>
       <id>com.asakusafw.snapshots</id>
       <name>Asakusa Framework Snapshot Repository</name>
-      <url>http://asakusafw.s3.amazonaws.com/maven/snapshots</url>
+      <url>https://asakusafw.s3.amazonaws.com/maven/snapshots</url>
       <releases>
         <enabled>false</enabled>
       </releases>
@@ -137,7 +137,7 @@
     <pluginRepository>
       <id>central</id>
       <name>Central Repository</name>
-      <url>http://repo.maven.apache.org/maven2</url>
+      <url>https://repo.maven.apache.org/maven2</url>
       <layout>default</layout>
       <snapshots>
         <enabled>false</enabled>
@@ -149,7 +149,7 @@
     <pluginRepository>
       <id>com.asakusafw.releases</id>
       <name>Asakusa Framework Repository</name>
-      <url>http://asakusafw.s3.amazonaws.com/maven/releases</url>
+      <url>https://asakusafw.s3.amazonaws.com/maven/releases</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -157,7 +157,7 @@
     <pluginRepository>
       <id>com.asakusafw.snapshots</id>
       <name>Asakusa Framework Snapshot Repository</name>
-      <url>http://asakusafw.s3.amazonaws.com/maven/snapshots</url>
+      <url>https://asakusafw.s3.amazonaws.com/maven/snapshots</url>
       <releases>
         <enabled>false</enabled>
       </releases>

--- a/vanilla/gradle/build.gradle
+++ b/vanilla/gradle/build.gradle
@@ -45,8 +45,8 @@ repositories {
         mavenLocal()
     }
     mavenCentral()
-    maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-    maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+    maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+    maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
This PR changes maven repository URL protocol from http to https in `pom.xml` and `build.gradle` for framework build configurations.
This also changes link URL to https in documentation files.

## Background, Problem or Goal of the patch
Follow-up asakusafw/asakusafw#845

## Design of the fix, or a new feature
The same as asakusafw/asakusafw#845

## Related Issue, Pull Request or Code
N/A.
